### PR TITLE
deps: declare shiv:shell dependency

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,9 +2,13 @@
 quiet = true
 task_output = "interleave"
 
+[plugins]
+shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
+
 [tools]
 usage = "latest"
 uv = "latest"
 bats = "1.13.0"
+"shiv:shell" = "0.1.0"                     # Persistent terminal sessions (used by wake)
 erlang = "28.4.1"
 elixir = "1.19.5-otp-27"


### PR DESCRIPTION
Sessions wake calls shell run. Declaring the dependency in mise.toml so `shiv install sessions` transitively installs shell.

Part of the effort to make each tool declare its exact dependencies — see also KnickKnackLabs/shimmer#705, KnickKnackLabs/notes#23.