### PR TITLE
refactor(harness): step 1 — extract pi into lib/harness/pi.{sh,py,ex}

### DIFF
--- a/.mise/tasks/new
+++ b/.mise/tasks/new
@@ -39,21 +39,14 @@ fi
 command -v jq >/dev/null 2>&1 || { echo "Error: jq is required" >&2; exit 1; }
 command -v uuidgen >/dev/null 2>&1 || { echo "Error: uuidgen is required" >&2; exit 1; }
 
-PI_DIR="${PI_DIR:-$HOME/.pi}"
-SESSIONS_DIR="$PI_DIR/agent/sessions"
-
-# --- Encode cwd as pi directory name ---
-# Pi uses double-dash bookends: /Users/foo/bar -> --Users-foo-bar--
-ENCODED=$(echo "$CWD_ABS" | sed 's|/|-|g')
-PROJECT_DIR="$SESSIONS_DIR/-${ENCODED}-/"
-mkdir -p "$PROJECT_DIR"
+# shellcheck source=/dev/null
+source "$MISE_CONFIG_ROOT/lib/harness/pi.sh"
 
 # --- Generate session ---
 
 SESSION_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
 NOW_ISO=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
-NOW_FILE=$(echo "$NOW_ISO" | sed 's/:/-/g')
-SESSION_FILE="${PROJECT_DIR}${NOW_FILE}_${SESSION_ID}.jsonl"
+SESSION_FILE=$(harness_pi_session_file_path "$CWD_ABS" "$SESSION_ID" "$NOW_ISO")
 
 # --- Build meta object from --meta flags ---
 #
@@ -90,60 +83,17 @@ if [ -n "$META_RAW" ]; then
 fi
 
 # --- Session header ---
-# Build with jq, conditionally including name and meta fields.
 
-HEADER_ARGS=(
-  --arg id "$SESSION_ID"
-  --arg ts "$NOW_ISO"
-  --arg cwd "$CWD_ABS"
-)
-HEADER_EXPR='{type: "session", version: 3, id: $id, timestamp: $ts, cwd: $cwd}'
-
-if [ -n "$NAME" ]; then
-  HEADER_ARGS+=(--arg name "$NAME")
-  HEADER_EXPR="$HEADER_EXPR + {name: \$name}"
-fi
-
-if [ "$META_JSON" != "{}" ]; then
-  HEADER_ARGS+=(--argjson meta "$META_JSON")
-  HEADER_EXPR="$HEADER_EXPR + {meta: \$meta}"
-fi
-
-jq -nc "${HEADER_ARGS[@]}" "$HEADER_EXPR" > "$SESSION_FILE"
+harness_pi_header_entry "$SESSION_ID" "$NOW_ISO" "$CWD_ABS" "$NAME" "$META_JSON" > "$SESSION_FILE"
 
 # Model change entry
 MC_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
-jq -nc \
-  --arg id "$MC_ID" \
-  --arg ts "$NOW_ISO" \
-  --arg model "$MODEL" \
-  '{
-    type: "model_change",
-    id: $id,
-    parentId: null,
-    timestamp: $ts,
-    provider: "anthropic",
-    modelId: $model
-  }' >> "$SESSION_FILE"
+harness_pi_model_change_entry "$MC_ID" "$NOW_ISO" "$MODEL" >> "$SESSION_FILE"
 
 # Inject context as a user message if provided
 if [ -n "$CONTEXT" ]; then
   MSG_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
-  jq -nc \
-    --arg id "$MSG_ID" \
-    --arg parent_id "$MC_ID" \
-    --arg ts "$NOW_ISO" \
-    --arg content "$CONTEXT" \
-    '{
-      type: "message",
-      id: $id,
-      parentId: $parent_id,
-      timestamp: $ts,
-      message: {
-        role: "user",
-        content: [{ type: "text", text: $content }]
-      }
-    }' >> "$SESSION_FILE"
+  harness_pi_user_message_entry "$MSG_ID" "$MC_ID" "$NOW_ISO" "$CONTEXT" >> "$SESSION_FILE"
 fi
 
 # --- Output ---

--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -42,6 +42,8 @@ fi
 
 # --- Find session file ---
 
+# shellcheck source=/dev/null
+source "$MISE_CONFIG_ROOT/lib/harness/pi.sh"
 source "$MISE_CONFIG_ROOT/lib/find.sh"
 source "$MISE_CONFIG_ROOT/lib/shell.sh"
 SESSION_FILE=$(find_session_file "$SESSION_ID") || exit 1
@@ -97,43 +99,14 @@ fi
 HARNESS_CMD="sessions run"
 [ "$HEADLESS" = "true" ] && HARNESS_CMD="sessions run --headless"
 
-if [ "$WAKE_META" = "{}" ]; then
-  jq -nc \
-    --arg id "$WAKE_ID" \
-    --arg parent_id "$LAST_ID" \
-    --arg ts "$NOW_ISO" \
-    --arg shell_name "$SHELL_NAME" \
-    --arg agent "${GIT_AUTHOR_NAME:-unknown}" \
-    --arg harness "$HARNESS_CMD" \
-    '{
-      type: "wake",
-      id: $id,
-      parentId: $parent_id,
-      timestamp: $ts,
-      shell: $shell_name,
-      agent: $agent,
-      harness: $harness
-    }' >> "$SESSION_FILE"
-else
-  jq -nc \
-    --arg id "$WAKE_ID" \
-    --arg parent_id "$LAST_ID" \
-    --arg ts "$NOW_ISO" \
-    --arg shell_name "$SHELL_NAME" \
-    --arg agent "${GIT_AUTHOR_NAME:-unknown}" \
-    --arg harness "$HARNESS_CMD" \
-    --argjson meta "$WAKE_META" \
-    '{
-      type: "wake",
-      id: $id,
-      parentId: $parent_id,
-      timestamp: $ts,
-      shell: $shell_name,
-      agent: $agent,
-      harness: $harness,
-      meta: $meta
-    }' >> "$SESSION_FILE"
-fi
+harness_pi_wake_entry \
+  "$WAKE_ID" \
+  "$LAST_ID" \
+  "$NOW_ISO" \
+  "$SHELL_NAME" \
+  "${GIT_AUTHOR_NAME:-unknown}" \
+  "$HARNESS_CMD" \
+  "$WAKE_META" >> "$SESSION_FILE"
 
 # --- Inject context into session file if provided ---
 
@@ -141,21 +114,7 @@ if [ -n "$CONTEXT" ]; then
   LAST_ID="$WAKE_ID"
   MSG_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
 
-  jq -nc \
-    --arg id "$MSG_ID" \
-    --arg parent_id "$LAST_ID" \
-    --arg ts "$NOW_ISO" \
-    --arg content "$CONTEXT" \
-    '{
-      type: "message",
-      id: $id,
-      parentId: $parent_id,
-      timestamp: $ts,
-      message: {
-        role: "user",
-        content: [{ type: "text", text: $content }]
-      }
-    }' >> "$SESSION_FILE"
+  harness_pi_user_message_entry "$MSG_ID" "$LAST_ID" "$NOW_ISO" "$CONTEXT" >> "$SESSION_FILE"
 fi
 
 # --- Resolve working directory from session ---

--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -43,7 +43,6 @@ fi
 # --- Find session file ---
 
 # shellcheck source=/dev/null
-source "$MISE_CONFIG_ROOT/lib/harness/pi.sh"
 source "$MISE_CONFIG_ROOT/lib/find.sh"
 source "$MISE_CONFIG_ROOT/lib/shell.sh"
 SESSION_FILE=$(find_session_file "$SESSION_ID") || exit 1

--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -225,7 +225,7 @@ defmodule Cli do
 
           partial ->
             extracted = extract_partial_text(partial)
-            new_text = text_beyond_flushed(extracted, state.flushed_chars)
+            new_text = Cli.Text.text_beyond_flushed(extracted, state.flushed_chars)
             if new_text != "", do: IO.write(new_text)
             stream_output(port, %{state | flushed_chars: String.length(extracted)})
         end
@@ -241,10 +241,10 @@ defmodule Cli do
 
       {:error, _} ->
         extracted = extract_partial_text(buffer)
-        new_text = text_beyond_flushed(extracted, state.flushed_chars)
+        new_text = Cli.Text.text_beyond_flushed(extracted, state.flushed_chars)
         if new_text != "", do: IO.write(new_text)
 
-        {abort_seen, recent_text, had_newline} = check_abort_signal(extracted, state)
+        {abort_seen, recent_text, had_newline} = Cli.Text.check_abort_signal(extracted, state)
 
         %{
           state
@@ -291,82 +291,7 @@ defmodule Cli do
 
   @doc false
   @spec process_line(String.t(), map()) :: map()
-  def process_line(line, state) do
-    Cli.Harness.Pi.process_line(line, state,
-      check_abort: &__MODULE__.check_abort_signal/2,
-      text_beyond_flushed: &__MODULE__.text_beyond_flushed/2
-    )
-  end
-
-  # --- Harness-agnostic helpers ---
-
-  @doc """
-  Returns the portion of `text` beyond already-flushed characters.
-
-  ## Examples
-
-      iex> Cli.text_beyond_flushed("hello world", 5)
-      " world"
-
-      iex> Cli.text_beyond_flushed("hello", 5)
-      ""
-
-      iex> Cli.text_beyond_flushed("hello", 0)
-      "hello"
-
-      iex> Cli.text_beyond_flushed("hi", 10)
-      ""
-
-  """
-  @spec text_beyond_flushed(String.t(), non_neg_integer()) :: String.t()
-  def text_beyond_flushed(text, 0), do: text
-
-  def text_beyond_flushed(text, flushed_chars) when is_integer(flushed_chars) do
-    if String.length(text) > flushed_chars do
-      String.slice(text, flushed_chars..-1//1)
-    else
-      ""
-    end
-  end
-
-  @typep abort_state :: %{
-           optional(:abort_seen) => boolean(),
-           optional(:recent_text) => String.t(),
-           optional(:had_newline_before_window) => boolean()
-         }
-
-  @doc """
-  Detect [[ABORT]] signal on its own line, handling chunk boundaries.
-  Returns {abort_seen, recent_text, had_newline_before_window}.
-
-  Harness-agnostic — operates on raw text, not on any specific event
-  schema.
-  """
-  @spec check_abort_signal(String.t(), abort_state()) ::
-          {boolean(), String.t(), boolean()}
-  def check_abort_signal(text, state) do
-    combined = state.recent_text <> text
-    combined_len = String.length(combined)
-
-    trimmed_len = max(0, combined_len - 20)
-    trimmed_portion = String.slice(combined, 0, trimmed_len)
-
-    had_newline_before_window =
-      if String.contains?(trimmed_portion, "\n"),
-        do: true,
-        else: state.had_newline_before_window
-
-    text_to_check =
-      if had_newline_before_window, do: "\n" <> combined, else: combined
-
-    abort_seen =
-      state.abort_seen ||
-        Regex.match?(~r/(?:^|\n)\[\[ABORT\]\](?:\n|$)/, text_to_check)
-
-    recent_text = String.slice(combined, -20, 20)
-
-    {abort_seen, recent_text, had_newline_before_window}
-  end
+  defdelegate process_line(line, state), to: Cli.Harness.Pi
 
   defp print_usage_summary(%{usage: nil}), do: :ok
 

--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -1,16 +1,18 @@
 defmodule Cli do
   @moduledoc """
-  Session execution engine — runs pi with streaming output, timeout,
-  ABORT detection, and usage reporting.
+  Session execution engine — runs an agent harness with streaming output,
+  timeout, ABORT detection, and usage reporting.
 
   Identity-agnostic: receives a system prompt file, doesn't know or care
   what's in it. Prompt composition (identity, passphrase, context) is the
   caller's responsibility.
+
+  Today this engine only knows pi. All pi-specific logic lives in
+  `Cli.Harness.Pi`; this module keeps the CLI surface, port spawning,
+  stream loop, and harness-agnostic helpers (abort detection, usage
+  summary). See sessions#50 for the multi-harness plan.
   """
 
-  @default_model "claude-opus-4-6"
-  @truncate_edit_limit 60
-  @truncate_prompt_limit 100
   @buffer_flush_timeout_ms 100
   @timeout_exit_code 124
 
@@ -34,7 +36,7 @@ defmodule Cli do
   defp run_with_opts(opts, rest) do
     message = Enum.join(rest, " ")
     timeout = opts[:timeout]
-    model = opts[:model] || @default_model
+    model = opts[:model] || Cli.Harness.Pi.default_model()
     cwd = opts[:cwd]
     session = opts[:session]
 
@@ -120,6 +122,8 @@ defmodule Cli do
   end
 
   defp print_help do
+    default_model = Cli.Harness.Pi.default_model()
+
     IO.puts("""
     Usage: sessions run --system-prompt-file <path> [options] <message>
 
@@ -130,7 +134,7 @@ defmodule Cli do
 
     Options:
       --timeout <seconds>          Maximum runtime in seconds (default: no timeout)
-      --model <model>              Model to use (default: #{@default_model})
+      --model <model>              Model to use (default: #{default_model})
       --cwd <path>                 Working directory for pi
       --session <path>             Session file for conversation continuity
       --no-extensions              Disable pi extensions
@@ -146,40 +150,19 @@ defmodule Cli do
   end
 
   defp run_agent(message, system_prompt_file, timeout, model, cwd, session, pi_opts) do
-    # Ensure model includes a provider prefix (e.g. "anthropic/claude-opus-4-6").
-    qualified_model =
-      if String.contains?(model, "/"), do: model, else: "anthropic/#{model}"
+    {shell_script, positional_args} =
+      Cli.Harness.Pi.build_command(
+        message,
+        model,
+        system_prompt_file,
+        session,
+        timeout,
+        pi_opts[:extensions],
+        pi_opts[:skills],
+        pi_opts[:prompt_templates]
+      )
 
-    # Build pi flags. User-controlled strings use positional args to avoid shell injection.
-    # $1=message, $2=model, $3=system_prompt_file, $4=session (if provided)
-    session_flag =
-      if session, do: ~s( --session "$4"), else: " --no-session"
-
-    pi_flags =
-      [
-        ~s( --append-system-prompt "$3"),
-        ~s( --model "$2"),
-        " --mode json",
-        session_flag,
-        if(pi_opts[:extensions], do: "", else: " --no-extensions"),
-        if(pi_opts[:skills], do: "", else: " --no-skills"),
-        if(pi_opts[:prompt_templates], do: "", else: " --no-prompt-templates")
-      ]
-      |> Enum.join("")
-
-    pi_cmd = ~s(pi -p "$1"#{pi_flags})
-
-    # echo | pipes empty stdin so pi doesn't block waiting for terminal input.
-    # pi -p (print mode) reads stdin before processing the message.
-    shell_script =
-      if timeout do
-        "echo | timeout #{timeout} #{pi_cmd}"
-      else
-        "echo | #{pi_cmd}"
-      end
-
-    args = ["-c", shell_script, "--", message, qualified_model, system_prompt_file]
-    args = if session, do: args ++ [session], else: args
+    args = ["-c", shell_script, "--"] ++ positional_args
 
     port_opts = [:binary, :exit_status, :stderr_to_stdout, {:args, args}]
     port_opts = if cwd, do: [{:cd, cwd} | port_opts], else: port_opts
@@ -272,23 +255,21 @@ defmodule Cli do
     end
   end
 
+  # --- Delegating wrappers ---
+  #
+  # These exist so existing callers, tests, and doctests don't break
+  # during the multi-harness refactor. Step 2 will make `process_line`
+  # (and friends) dispatch on a harness resolved from session context.
+
   @doc """
   Extract text from incomplete JSON lines in the buffer.
   Returns the unescaped text, or empty string if none found.
+
+  Delegates to the pi harness adapter today; will dispatch on harness
+  in step 2.
   """
   @spec extract_partial_text(String.t()) :: String.t()
-  def extract_partial_text(partial) do
-    case Regex.run(~r/"(?:text|delta)"\s*:\s*"((?:[^"\\]|\\.)*)$/, partial) do
-      [_, text] ->
-        case Jason.decode("\"#{text}\"") do
-          {:ok, unescaped} -> unescaped
-          {:error, _} -> ""
-        end
-
-      nil ->
-        ""
-    end
-  end
+  defdelegate extract_partial_text(partial), to: Cli.Harness.Pi
 
   @doc """
   Flush incomplete JSON lines from the buffer to stdout.
@@ -301,168 +282,23 @@ defmodule Cli do
     end
   end
 
-  @typep stream_state :: %{
-           tool_input: String.t(),
-           buffer: String.t(),
-           usage: map() | nil,
-           abort_seen: boolean(),
-           recent_text: String.t(),
-           flushed_chars: non_neg_integer(),
-           had_newline_before_window: boolean()
-         }
-
   @doc """
-  Detect [[ABORT]] signal on its own line, handling chunk boundaries.
-  Returns {abort_seen, recent_text, had_newline_before_window}.
+  Format tool input map into a human-readable string for display.
+  Returns nil for unrecognized input formats.
   """
-  @spec check_abort_signal(String.t(), stream_state()) ::
-          {boolean(), String.t(), boolean()}
-  def check_abort_signal(text, state) do
-    combined = state.recent_text <> text
-    combined_len = String.length(combined)
-
-    trimmed_len = max(0, combined_len - 20)
-    trimmed_portion = String.slice(combined, 0, trimmed_len)
-
-    had_newline_before_window =
-      if String.contains?(trimmed_portion, "\n"),
-        do: true,
-        else: state.had_newline_before_window
-
-    text_to_check =
-      if had_newline_before_window, do: "\n" <> combined, else: combined
-
-    abort_seen =
-      state.abort_seen ||
-        Regex.match?(~r/(?:^|\n)\[\[ABORT\]\](?:\n|$)/, text_to_check)
-
-    recent_text = String.slice(combined, -20, 20)
-
-    {abort_seen, recent_text, had_newline_before_window}
-  end
+  @spec format_tool_input(map()) :: String.t() | nil
+  defdelegate format_tool_input(input), to: Cli.Harness.Pi
 
   @doc false
-  @spec process_line(String.t(), stream_state()) :: stream_state()
+  @spec process_line(String.t(), map()) :: map()
   def process_line(line, state) do
-    case Jason.decode(line) do
-      {:ok,
-       %{
-         "type" => "message_update",
-         "assistantMessageEvent" => %{"type" => "text_delta", "delta" => text}
-       }} ->
-        handle_text_delta(text, state)
-
-      {:ok,
-       %{
-         "type" => "message_update",
-         "assistantMessageEvent" => %{"type" => "toolcall_start"} = event
-       }} ->
-        name = extract_tool_name_from_event(event)
-        IO.puts("\n[TOOL] #{name}")
-        %{state | tool_input: ""}
-
-      {:ok,
-       %{
-         "type" => "message_update",
-         "assistantMessageEvent" => %{"type" => "toolcall_delta", "delta" => json}
-       }}
-      when json != "" ->
-        %{state | tool_input: state.tool_input <> json}
-
-      {:ok,
-       %{
-         "type" => "message_update",
-         "assistantMessageEvent" => %{"type" => "toolcall_end", "toolCall" => tool_call}
-       }} ->
-        handle_tool_call_end(tool_call, state)
-
-      {:ok, %{"type" => "agent_end", "messages" => messages}} ->
-        handle_agent_end(messages, state)
-
-      _ ->
-        state
-    end
+    Cli.Harness.Pi.process_line(line, state,
+      check_abort: &__MODULE__.check_abort_signal/2,
+      text_beyond_flushed: &__MODULE__.text_beyond_flushed/2
+    )
   end
 
-  defp extract_tool_name_from_event(%{
-         "contentIndex" => idx,
-         "partial" => %{"content" => content}
-       }) do
-    case Enum.at(content, idx) do
-      %{"name" => name} -> name
-      _ -> "unknown"
-    end
-  end
-
-  defp extract_tool_name_from_event(_), do: "unknown"
-
-  defp handle_text_delta(text, state) do
-    text_to_write = text_beyond_flushed(text, state.flushed_chars)
-    maybe_write_text(text_to_write)
-
-    {abort_seen, recent_text, had_newline} = check_abort_signal(text, state)
-
-    %{
-      state
-      | abort_seen: abort_seen,
-        recent_text: recent_text,
-        flushed_chars: 0,
-        had_newline_before_window: had_newline
-    }
-  end
-
-  defp maybe_write_text(""), do: :ok
-  defp maybe_write_text(text), do: IO.write(text)
-
-  defp handle_tool_call_end(tool_call, state) do
-    case Map.get(tool_call, "arguments") do
-      nil -> :ok
-      args -> print_tool_input(args)
-    end
-
-    %{state | tool_input: ""}
-  end
-
-  defp handle_agent_end(messages, state) do
-    assistant_msgs =
-      Enum.filter(messages, fn msg ->
-        msg["role"] == "assistant" && msg["usage"] != nil
-      end)
-
-    totals =
-      Enum.reduce(
-        assistant_msgs,
-        %{input: 0, output: 0, cache_read: 0, cache_write: 0, cost: 0.0},
-        fn msg, acc ->
-          u = msg["usage"]
-          cost = get_in(u, ["cost", "total"]) || 0.0
-
-          %{
-            input: acc.input + (u["input"] || 0),
-            output: acc.output + (u["output"] || 0),
-            cache_read: acc.cache_read + (u["cacheRead"] || 0),
-            cache_write: acc.cache_write + (u["cacheWrite"] || 0),
-            cost: acc.cost + cost
-          }
-        end
-      )
-
-    %{
-      state
-      | usage: %{
-          cost_usd: totals.cost,
-          duration_ms: nil,
-          num_turns: length(assistant_msgs),
-          usage: %{
-            "input_tokens" => totals.input,
-            "output_tokens" => totals.output,
-            "cache_read_input_tokens" => totals.cache_read,
-            "cache_creation_input_tokens" => totals.cache_write
-          },
-          model_usage: nil
-        }
-    }
-  end
+  # --- Harness-agnostic helpers ---
 
   @doc """
   Returns the portion of `text` beyond already-flushed characters.
@@ -491,6 +327,45 @@ defmodule Cli do
     else
       ""
     end
+  end
+
+  @typep abort_state :: %{
+           optional(:abort_seen) => boolean(),
+           optional(:recent_text) => String.t(),
+           optional(:had_newline_before_window) => boolean()
+         }
+
+  @doc """
+  Detect [[ABORT]] signal on its own line, handling chunk boundaries.
+  Returns {abort_seen, recent_text, had_newline_before_window}.
+
+  Harness-agnostic — operates on raw text, not on any specific event
+  schema.
+  """
+  @spec check_abort_signal(String.t(), abort_state()) ::
+          {boolean(), String.t(), boolean()}
+  def check_abort_signal(text, state) do
+    combined = state.recent_text <> text
+    combined_len = String.length(combined)
+
+    trimmed_len = max(0, combined_len - 20)
+    trimmed_portion = String.slice(combined, 0, trimmed_len)
+
+    had_newline_before_window =
+      if String.contains?(trimmed_portion, "\n"),
+        do: true,
+        else: state.had_newline_before_window
+
+    text_to_check =
+      if had_newline_before_window, do: "\n" <> combined, else: combined
+
+    abort_seen =
+      state.abort_seen ||
+        Regex.match?(~r/(?:^|\n)\[\[ABORT\]\](?:\n|$)/, text_to_check)
+
+    recent_text = String.slice(combined, -20, 20)
+
+    {abort_seen, recent_text, had_newline_before_window}
   end
 
   defp print_usage_summary(%{usage: nil}), do: :ok
@@ -522,111 +397,6 @@ defmodule Cli do
       if cache_read > 0 or cache_create > 0 do
         IO.puts("  Cache: #{cache_read} read, #{cache_create} created")
       end
-    end
-  end
-
-  defp print_tool_input(input) do
-    case format_tool_input(input) do
-      nil -> :ok
-      output -> IO.puts(output)
-    end
-  end
-
-  @doc """
-  Formats tool input map into a human-readable string for display.
-  Returns nil for unrecognized input formats.
-  """
-  @spec format_tool_input(map()) :: String.t() | nil
-  def format_tool_input(%{"command" => cmd}) do
-    "  $ #{cmd}"
-  end
-
-  def format_tool_input(%{"path" => path, "edits" => [first | _]}) when is_map(first) do
-    old =
-      first
-      |> Map.get("oldText", "")
-      |> truncate(@truncate_edit_limit)
-      |> String.replace("\n", "\\n")
-
-    new =
-      first
-      |> Map.get("newText", "")
-      |> truncate(@truncate_edit_limit)
-      |> String.replace("\n", "\\n")
-
-    "  #{path}\n  - #{old}\n  + #{new}"
-  end
-
-  def format_tool_input(%{"pattern" => pattern} = input) do
-    case Map.get(input, "path") do
-      nil -> "  pattern: #{pattern}"
-      path -> "  #{path}\n  pattern: #{pattern}"
-    end
-  end
-
-  def format_tool_input(%{"path" => path}) do
-    "  -> #{path}"
-  end
-
-  def format_tool_input(%{"url" => url, "prompt" => prompt} = input) do
-    prompt_preview = truncate(prompt, @truncate_prompt_limit)
-
-    case Map.get(input, "description") do
-      desc when desc in [nil, ""] -> "  url: #{url}\n  prompt: #{prompt_preview}"
-      desc -> "  #{desc}\n  url: #{url}\n  prompt: #{prompt_preview}"
-    end
-  end
-
-  def format_tool_input(%{"prompt" => prompt} = input) do
-    prompt_preview = truncate(prompt, @truncate_prompt_limit)
-
-    case Map.get(input, "description") do
-      desc when desc in [nil, ""] -> "  prompt: #{prompt_preview}"
-      desc -> "  #{desc}\n  prompt: #{prompt_preview}"
-    end
-  end
-
-  def format_tool_input(%{"todos" => todos}) when is_list(todos) do
-    count = length(todos)
-    first = List.first(todos)
-
-    preview =
-      case first do
-        %{"content" => content} when is_binary(content) -> ": #{truncate(content, 50)}"
-        _ -> ""
-      end
-
-    "  #{count} todo(s)#{preview}"
-  end
-
-  def format_tool_input(%{"query" => query}) do
-    "  search: #{truncate(query, 80)}"
-  end
-
-  def format_tool_input(%{"operation" => op, "filePath" => path, "line" => line}) do
-    "  #{op} at #{path}:#{line}"
-  end
-
-  def format_tool_input(%{"skill" => skill} = input) do
-    case Map.get(input, "args") do
-      nil -> "  skill: #{skill}"
-      args -> "  skill: #{skill} #{truncate(args, 50)}"
-    end
-  end
-
-  def format_tool_input(%{"shell_id" => id}) do
-    "  shell: #{id}"
-  end
-
-  def format_tool_input(_), do: nil
-
-  defp truncate(nil, _limit), do: ""
-
-  defp truncate(string, limit) do
-    if String.length(string) > limit do
-      String.slice(string, 0, limit) <> "..."
-    else
-      string
     end
   end
 end

--- a/cli/lib/harness/pi.ex
+++ b/cli/lib/harness/pi.ex
@@ -1,0 +1,376 @@
+defmodule Cli.Harness.Pi do
+  @moduledoc """
+  Pi harness adapter (Elixir).
+
+  Authoritative home for pi-specific knowledge used by `sessions run`:
+
+    * How to invoke the pi CLI (command + flags)
+    * Pi's streaming JSON protocol (`message_update` events with
+      `assistantMessageEvent` sub-types, `agent_end`, `toolcall_*`, etc.)
+    * Pi's tool-input argument shapes
+    * Pi's `usage` shape in `agent_end`
+
+  Step 1c of multi-harness support (sessions#50): pure extraction from
+  `Cli`. `Cli` keeps orchestration (arg parsing, port spawning, stream
+  loop, abort detection) and delegates harness-specific work here.
+  Other harnesses (claude, ...) will live in sibling modules
+  (`Cli.Harness.Claude`, etc.); step 2 adds a dispatcher.
+
+  Functions exposed here as `@doc` are part of the shared contract every
+  harness will implement once the dispatcher lands.
+  """
+
+  @default_model "claude-opus-4-6"
+  @truncate_edit_limit 60
+  @truncate_prompt_limit 100
+
+  @doc "Default model when the caller doesn't pass --model."
+  @spec default_model() :: String.t()
+  def default_model, do: @default_model
+
+  # --- Command construction ---
+
+  @doc """
+  Build the args list passed to `/bin/sh -c <script> -- $1 $2 ...` when
+  launching pi under a port.
+
+  Returns `{shell_script, positional_args}`. Positional args use
+  `$1`/`$2`/... so user-controlled strings (message, model,
+  system_prompt_file, session) are shell-safe.
+  """
+  @spec build_command(
+          message :: String.t(),
+          model :: String.t(),
+          system_prompt_file :: String.t(),
+          session :: String.t() | nil,
+          timeout :: non_neg_integer() | nil,
+          extensions :: boolean(),
+          skills :: boolean(),
+          prompt_templates :: boolean()
+        ) :: {String.t(), [String.t()]}
+  def build_command(
+        message,
+        model,
+        system_prompt_file,
+        session,
+        timeout,
+        extensions,
+        skills,
+        prompt_templates
+      ) do
+    qualified_model =
+      if String.contains?(model, "/"), do: model, else: "anthropic/#{model}"
+
+    session_flag =
+      if session, do: ~s( --session "$4"), else: " --no-session"
+
+    pi_flags =
+      [
+        ~s( --append-system-prompt "$3"),
+        ~s( --model "$2"),
+        " --mode json",
+        session_flag,
+        if(extensions, do: "", else: " --no-extensions"),
+        if(skills, do: "", else: " --no-skills"),
+        if(prompt_templates, do: "", else: " --no-prompt-templates")
+      ]
+      |> Enum.join("")
+
+    pi_cmd = ~s(pi -p "$1"#{pi_flags})
+
+    # `echo |` pipes empty stdin so pi doesn't block waiting for a TTY.
+    shell_script =
+      if timeout do
+        "echo | timeout #{timeout} #{pi_cmd}"
+      else
+        "echo | #{pi_cmd}"
+      end
+
+    positional = [message, qualified_model, system_prompt_file]
+    positional = if session, do: positional ++ [session], else: positional
+
+    {shell_script, positional}
+  end
+
+  # --- Streaming protocol ---
+
+  @typep stream_state :: %{
+           optional(:tool_input) => String.t(),
+           optional(:usage) => map() | nil,
+           optional(:abort_seen) => boolean(),
+           optional(:recent_text) => String.t(),
+           optional(:flushed_chars) => non_neg_integer(),
+           optional(:had_newline_before_window) => boolean(),
+           optional(:buffer) => String.t()
+         }
+
+  @doc """
+  Consume one line of pi's JSON stream and return the updated state.
+
+  Text deltas are written to stdout as they arrive and fed into the
+  abort detector (handled by the caller via a harness-agnostic
+  function). Tool events print tool names and formatted arguments.
+  `agent_end` events capture usage totals.
+
+  Unknown / malformed / unrelated events pass through untouched.
+
+  The caller is responsible for providing `check_abort_signal/2` and
+  `text_beyond_flushed/2` callbacks. To keep the refactor minimal
+  we accept them as functions on the caller module via optional
+  keyword args — see `Cli.process_line/2`.
+  """
+  @spec process_line(String.t(), stream_state(), keyword()) :: stream_state()
+  def process_line(line, state, callbacks) do
+    check_abort_fn = Keyword.fetch!(callbacks, :check_abort)
+    text_beyond_fn = Keyword.fetch!(callbacks, :text_beyond_flushed)
+
+    case Jason.decode(line) do
+      {:ok,
+       %{
+         "type" => "message_update",
+         "assistantMessageEvent" => %{"type" => "text_delta", "delta" => text}
+       }} ->
+        handle_text_delta(text, state, check_abort_fn, text_beyond_fn)
+
+      {:ok,
+       %{
+         "type" => "message_update",
+         "assistantMessageEvent" => %{"type" => "toolcall_start"} = event
+       }} ->
+        name = extract_tool_name_from_event(event)
+        IO.puts("\n[TOOL] #{name}")
+        %{state | tool_input: ""}
+
+      {:ok,
+       %{
+         "type" => "message_update",
+         "assistantMessageEvent" => %{"type" => "toolcall_delta", "delta" => json}
+       }}
+      when json != "" ->
+        %{state | tool_input: state.tool_input <> json}
+
+      {:ok,
+       %{
+         "type" => "message_update",
+         "assistantMessageEvent" => %{"type" => "toolcall_end", "toolCall" => tool_call}
+       }} ->
+        handle_tool_call_end(tool_call, state)
+
+      {:ok, %{"type" => "agent_end", "messages" => messages}} ->
+        handle_agent_end(messages, state)
+
+      _ ->
+        state
+    end
+  end
+
+  @doc """
+  Extract partial text from an incomplete JSON line buffered mid-stream.
+
+  Pi's text-carrying events emit `"delta":"..."` (or `"text":"..."` in
+  some paths); we look for the trailing unclosed string and unescape it.
+  Returns empty string if no partial text can be recovered.
+  """
+  @spec extract_partial_text(String.t()) :: String.t()
+  def extract_partial_text(partial) do
+    case Regex.run(~r/"(?:text|delta)"\s*:\s*"((?:[^"\\]|\\.)*)$/, partial) do
+      [_, text] ->
+        case Jason.decode("\"#{text}\"") do
+          {:ok, unescaped} -> unescaped
+          {:error, _} -> ""
+        end
+
+      nil ->
+        ""
+    end
+  end
+
+  # --- Tool input formatting ---
+
+  @doc """
+  Format a pi tool-call's `arguments` map into a human-readable summary.
+  Returns `nil` for unrecognized shapes so callers can skip output.
+  """
+  @spec format_tool_input(map()) :: String.t() | nil
+  def format_tool_input(%{"command" => cmd}) do
+    "  $ #{cmd}"
+  end
+
+  def format_tool_input(%{"path" => path, "edits" => [first | _]}) when is_map(first) do
+    old =
+      first
+      |> Map.get("oldText", "")
+      |> truncate(@truncate_edit_limit)
+      |> String.replace("\n", "\\n")
+
+    new =
+      first
+      |> Map.get("newText", "")
+      |> truncate(@truncate_edit_limit)
+      |> String.replace("\n", "\\n")
+
+    "  #{path}\n  - #{old}\n  + #{new}"
+  end
+
+  def format_tool_input(%{"pattern" => pattern} = input) do
+    case Map.get(input, "path") do
+      nil -> "  pattern: #{pattern}"
+      path -> "  #{path}\n  pattern: #{pattern}"
+    end
+  end
+
+  def format_tool_input(%{"path" => path}) do
+    "  -> #{path}"
+  end
+
+  def format_tool_input(%{"url" => url, "prompt" => prompt} = input) do
+    prompt_preview = truncate(prompt, @truncate_prompt_limit)
+
+    case Map.get(input, "description") do
+      desc when desc in [nil, ""] -> "  url: #{url}\n  prompt: #{prompt_preview}"
+      desc -> "  #{desc}\n  url: #{url}\n  prompt: #{prompt_preview}"
+    end
+  end
+
+  def format_tool_input(%{"prompt" => prompt} = input) do
+    prompt_preview = truncate(prompt, @truncate_prompt_limit)
+
+    case Map.get(input, "description") do
+      desc when desc in [nil, ""] -> "  prompt: #{prompt_preview}"
+      desc -> "  #{desc}\n  prompt: #{prompt_preview}"
+    end
+  end
+
+  def format_tool_input(%{"todos" => todos}) when is_list(todos) do
+    count = length(todos)
+    first = List.first(todos)
+
+    preview =
+      case first do
+        %{"content" => content} when is_binary(content) -> ": #{truncate(content, 50)}"
+        _ -> ""
+      end
+
+    "  #{count} todo(s)#{preview}"
+  end
+
+  def format_tool_input(%{"query" => query}) do
+    "  search: #{truncate(query, 80)}"
+  end
+
+  def format_tool_input(%{"operation" => op, "filePath" => path, "line" => line}) do
+    "  #{op} at #{path}:#{line}"
+  end
+
+  def format_tool_input(%{"skill" => skill} = input) do
+    case Map.get(input, "args") do
+      nil -> "  skill: #{skill}"
+      args -> "  skill: #{skill} #{truncate(args, 50)}"
+    end
+  end
+
+  def format_tool_input(%{"shell_id" => id}) do
+    "  shell: #{id}"
+  end
+
+  def format_tool_input(_), do: nil
+
+  # --- Internal helpers ---
+
+  defp handle_text_delta(text, state, check_abort_fn, text_beyond_fn) do
+    text_to_write = text_beyond_fn.(text, state.flushed_chars)
+    maybe_write_text(text_to_write)
+
+    {abort_seen, recent_text, had_newline} = check_abort_fn.(text, state)
+
+    %{
+      state
+      | abort_seen: abort_seen,
+        recent_text: recent_text,
+        flushed_chars: 0,
+        had_newline_before_window: had_newline
+    }
+  end
+
+  defp maybe_write_text(""), do: :ok
+  defp maybe_write_text(text), do: IO.write(text)
+
+  defp handle_tool_call_end(tool_call, state) do
+    case Map.get(tool_call, "arguments") do
+      nil -> :ok
+      args -> print_tool_input(args)
+    end
+
+    %{state | tool_input: ""}
+  end
+
+  defp handle_agent_end(messages, state) do
+    assistant_msgs =
+      Enum.filter(messages, fn msg ->
+        msg["role"] == "assistant" && msg["usage"] != nil
+      end)
+
+    totals =
+      Enum.reduce(
+        assistant_msgs,
+        %{input: 0, output: 0, cache_read: 0, cache_write: 0, cost: 0.0},
+        fn msg, acc ->
+          u = msg["usage"]
+          cost = get_in(u, ["cost", "total"]) || 0.0
+
+          %{
+            input: acc.input + (u["input"] || 0),
+            output: acc.output + (u["output"] || 0),
+            cache_read: acc.cache_read + (u["cacheRead"] || 0),
+            cache_write: acc.cache_write + (u["cacheWrite"] || 0),
+            cost: acc.cost + cost
+          }
+        end
+      )
+
+    %{
+      state
+      | usage: %{
+          cost_usd: totals.cost,
+          duration_ms: nil,
+          num_turns: length(assistant_msgs),
+          usage: %{
+            "input_tokens" => totals.input,
+            "output_tokens" => totals.output,
+            "cache_read_input_tokens" => totals.cache_read,
+            "cache_creation_input_tokens" => totals.cache_write
+          },
+          model_usage: nil
+        }
+    }
+  end
+
+  defp extract_tool_name_from_event(%{
+         "contentIndex" => idx,
+         "partial" => %{"content" => content}
+       }) do
+    case Enum.at(content, idx) do
+      %{"name" => name} -> name
+      _ -> "unknown"
+    end
+  end
+
+  defp extract_tool_name_from_event(_), do: "unknown"
+
+  defp print_tool_input(input) do
+    case format_tool_input(input) do
+      nil -> :ok
+      output -> IO.puts(output)
+    end
+  end
+
+  defp truncate(nil, _limit), do: ""
+
+  defp truncate(string, limit) do
+    if String.length(string) > limit do
+      String.slice(string, 0, limit) <> "..."
+    else
+      string
+    end
+  end
+end

--- a/cli/lib/harness/pi.ex
+++ b/cli/lib/harness/pi.ex
@@ -108,29 +108,19 @@ defmodule Cli.Harness.Pi do
   Consume one line of pi's JSON stream and return the updated state.
 
   Text deltas are written to stdout as they arrive and fed into the
-  abort detector (handled by the caller via a harness-agnostic
-  function). Tool events print tool names and formatted arguments.
-  `agent_end` events capture usage totals.
-
-  Unknown / malformed / unrelated events pass through untouched.
-
-  The caller is responsible for providing `check_abort_signal/2` and
-  `text_beyond_flushed/2` callbacks. To keep the refactor minimal
-  we accept them as functions on the caller module via optional
-  keyword args — see `Cli.process_line/2`.
+  (harness-agnostic) abort detector in `Cli.Text`. Tool events print
+  tool names and formatted arguments. `agent_end` events capture usage
+  totals. Unknown / malformed / unrelated events pass through untouched.
   """
-  @spec process_line(String.t(), stream_state(), keyword()) :: stream_state()
-  def process_line(line, state, callbacks) do
-    check_abort_fn = Keyword.fetch!(callbacks, :check_abort)
-    text_beyond_fn = Keyword.fetch!(callbacks, :text_beyond_flushed)
-
+  @spec process_line(String.t(), stream_state()) :: stream_state()
+  def process_line(line, state) do
     case Jason.decode(line) do
       {:ok,
        %{
          "type" => "message_update",
          "assistantMessageEvent" => %{"type" => "text_delta", "delta" => text}
        }} ->
-        handle_text_delta(text, state, check_abort_fn, text_beyond_fn)
+        handle_text_delta(text, state)
 
       {:ok,
        %{
@@ -277,11 +267,11 @@ defmodule Cli.Harness.Pi do
 
   # --- Internal helpers ---
 
-  defp handle_text_delta(text, state, check_abort_fn, text_beyond_fn) do
-    text_to_write = text_beyond_fn.(text, state.flushed_chars)
+  defp handle_text_delta(text, state) do
+    text_to_write = Cli.Text.text_beyond_flushed(text, state.flushed_chars)
     maybe_write_text(text_to_write)
 
-    {abort_seen, recent_text, had_newline} = check_abort_fn.(text, state)
+    {abort_seen, recent_text, had_newline} = Cli.Text.check_abort_signal(text, state)
 
     %{
       state

--- a/cli/lib/text.ex
+++ b/cli/lib/text.ex
@@ -1,0 +1,83 @@
+defmodule Cli.Text do
+  @moduledoc """
+  Harness-agnostic text-stream helpers used by the `sessions run` engine.
+
+  These operate purely on strings — no knowledge of any specific harness
+  schema — so every harness adapter can call them directly instead of
+  receiving them as callbacks. Moving them here breaks the circular
+  dependency that would otherwise exist between `Cli` and
+  `Cli.Harness.Pi` (and any future harness adapter).
+  """
+
+  @doc """
+  Return the portion of `text` beyond already-flushed characters.
+
+  ## Examples
+
+      iex> Cli.Text.text_beyond_flushed("hello world", 5)
+      " world"
+
+      iex> Cli.Text.text_beyond_flushed("hello", 5)
+      ""
+
+      iex> Cli.Text.text_beyond_flushed("hello", 0)
+      "hello"
+
+      iex> Cli.Text.text_beyond_flushed("hi", 10)
+      ""
+
+  """
+  @spec text_beyond_flushed(String.t(), non_neg_integer()) :: String.t()
+  def text_beyond_flushed(text, 0), do: text
+
+  def text_beyond_flushed(text, flushed_chars) when is_integer(flushed_chars) do
+    if String.length(text) > flushed_chars do
+      String.slice(text, flushed_chars..-1//1)
+    else
+      ""
+    end
+  end
+
+  @typep abort_state :: %{
+           optional(:abort_seen) => boolean(),
+           optional(:recent_text) => String.t(),
+           optional(:had_newline_before_window) => boolean()
+         }
+
+  @doc """
+  Detect `[[ABORT]]` on its own line across streaming chunks.
+
+  Returns `{abort_seen, recent_text, had_newline_before_window}`:
+
+    * `abort_seen` stays `true` once set.
+    * `recent_text` is the last 20 characters of combined input, kept
+      for boundary-spanning detection.
+    * `had_newline_before_window` remembers whether a newline has
+      already been observed outside the current 20-char lookback window.
+  """
+  @spec check_abort_signal(String.t(), abort_state()) ::
+          {boolean(), String.t(), boolean()}
+  def check_abort_signal(text, state) do
+    combined = state.recent_text <> text
+    combined_len = String.length(combined)
+
+    trimmed_len = max(0, combined_len - 20)
+    trimmed_portion = String.slice(combined, 0, trimmed_len)
+
+    had_newline_before_window =
+      if String.contains?(trimmed_portion, "\n"),
+        do: true,
+        else: state.had_newline_before_window
+
+    text_to_check =
+      if had_newline_before_window, do: "\n" <> combined, else: combined
+
+    abort_seen =
+      state.abort_seen ||
+        Regex.match?(~r/(?:^|\n)\[\[ABORT\]\](?:\n|$)/, text_to_check)
+
+    recent_text = String.slice(combined, -20, 20)
+
+    {abort_seen, recent_text, had_newline_before_window}
+  end
+end

--- a/cli/test/cli_test.exs
+++ b/cli/test/cli_test.exs
@@ -1,6 +1,7 @@
 defmodule CliTest do
   use ExUnit.Case
   doctest Cli
+  doctest Cli.Text
   import ExUnit.CaptureIO
 
   # Helper to capture both IO output and return value from Cli.run
@@ -761,32 +762,32 @@ defmodule CliTest do
     end
   end
 
-  describe "check_abort_signal/2" do
+  describe "Cli.Text.check_abort_signal/2" do
     test "detects abort on its own line" do
       state = %{abort_seen: false, recent_text: "", had_newline_before_window: true}
-      {abort_seen, _, _} = Cli.check_abort_signal("[[ABORT]]\n", state)
+      {abort_seen, _, _} = Cli.Text.check_abort_signal("[[ABORT]]\n", state)
       assert abort_seen
     end
 
     test "does not detect abort embedded in text" do
       state = %{abort_seen: false, recent_text: "", had_newline_before_window: true}
-      {abort_seen, _, _} = Cli.check_abort_signal("some [[ABORT]] text", state)
+      {abort_seen, _, _} = Cli.Text.check_abort_signal("some [[ABORT]] text", state)
       refute abort_seen
     end
 
     test "detects abort split across calls" do
       state = %{abort_seen: false, recent_text: "", had_newline_before_window: true}
-      {abort_seen1, recent1, had_nl1} = Cli.check_abort_signal("[[ABO", state)
+      {abort_seen1, recent1, had_nl1} = Cli.Text.check_abort_signal("[[ABO", state)
       refute abort_seen1
 
       state2 = %{abort_seen: false, recent_text: recent1, had_newline_before_window: had_nl1}
-      {abort_seen2, _, _} = Cli.check_abort_signal("RT]]\n", state2)
+      {abort_seen2, _, _} = Cli.Text.check_abort_signal("RT]]\n", state2)
       assert abort_seen2
     end
 
     test "preserves abort_seen once set" do
       state = %{abort_seen: true, recent_text: "", had_newline_before_window: true}
-      {abort_seen, _, _} = Cli.check_abort_signal("more text", state)
+      {abort_seen, _, _} = Cli.Text.check_abort_signal("more text", state)
       assert abort_seen
     end
 
@@ -795,7 +796,7 @@ defmodule CliTest do
       # Newline at position 5, then 30+ more chars. The 20-char window keeps the
       # last 20 chars, so the newline falls in the trimmed portion (positions 0-15+).
       long_text = String.duplicate("a", 5) <> "\n" <> String.duplicate("b", 30)
-      {_, _, had_newline} = Cli.check_abort_signal(long_text, state)
+      {_, _, had_newline} = Cli.Text.check_abort_signal(long_text, state)
       assert had_newline
     end
   end
@@ -867,31 +868,31 @@ defmodule CliTest do
     end
   end
 
-  describe "text_beyond_flushed/2" do
+  describe "Cli.Text.text_beyond_flushed/2" do
     test "returns remainder after flushed chars" do
-      assert Cli.text_beyond_flushed("hello world", 5) == " world"
+      assert Cli.Text.text_beyond_flushed("hello world", 5) == " world"
     end
 
     test "returns empty string when fully flushed" do
-      assert Cli.text_beyond_flushed("hello", 5) == ""
+      assert Cli.Text.text_beyond_flushed("hello", 5) == ""
     end
 
     test "returns full text when flushed_chars is zero" do
-      assert Cli.text_beyond_flushed("hello", 0) == "hello"
+      assert Cli.Text.text_beyond_flushed("hello", 0) == "hello"
     end
 
     test "returns empty string when flushed_chars exceeds text length" do
-      assert Cli.text_beyond_flushed("different", 10) == ""
+      assert Cli.Text.text_beyond_flushed("different", 10) == ""
     end
 
     test "handles empty text" do
-      assert Cli.text_beyond_flushed("", 0) == ""
-      assert Cli.text_beyond_flushed("", 5) == ""
+      assert Cli.Text.text_beyond_flushed("", 0) == ""
+      assert Cli.Text.text_beyond_flushed("", 5) == ""
     end
 
     test "raises on nil flushed_chars (type safety)" do
       assert_raise FunctionClauseError, fn ->
-        Cli.text_beyond_flushed("hello world", nil)
+        Cli.Text.text_beyond_flushed("hello world", nil)
       end
     end
   end

--- a/lib/find.sh
+++ b/lib/find.sh
@@ -6,6 +6,10 @@
 # (tests, ad-hoc scripts) that sources `lib/find.sh` keeps working while
 # we migrate to the adapter-aware `lib/harness/*.sh` layout.
 #
+# Used by: .mise/tasks/wake (and anything else that sources this file
+# transitively picks up `lib/harness/pi.sh`). Do not drop until the
+# step 2 dispatcher replaces it.
+#
 # Step 2 (sessions#50) will replace this with a dispatcher that picks
 # the right harness adapter at call time.
 

--- a/lib/find.sh
+++ b/lib/find.sh
@@ -1,75 +1,17 @@
 #!/usr/bin/env bash
-# Shared session-finding logic for bash tasks.
+# Back-compat shim for session lookup.
 #
-# Usage:
-#   source "$MISE_CONFIG_ROOT/lib/find.sh"
-#   SESSION_FILE=$(find_session_file "$query")
+# Pre-multi-harness, this file owned the find_session_file function.
+# It now delegates to the pi harness adapter. Left in place so anything
+# (tests, ad-hoc scripts) that sources `lib/find.sh` keeps working while
+# we migrate to the adapter-aware `lib/harness/*.sh` layout.
 #
-# Matches by UUID prefix first, then by session name in the JSONL header.
-# Exits with error if no match or ambiguous.
+# Step 2 (sessions#50) will replace this with a dispatcher that picks
+# the right harness adapter at call time.
+
+# shellcheck source=/dev/null
+source "$MISE_CONFIG_ROOT/lib/harness/pi.sh"
 
 find_session_file() {
-  local query="$1"
-  local sessions_dir
-  local pi_dir="${PI_DIR:-$HOME/.pi}"
-  sessions_dir="$pi_dir/agent/sessions"
-
-  if [ ! -d "$sessions_dir" ]; then
-    echo "Error: No sessions directory at $sessions_dir" >&2
-    return 1
-  fi
-
-  local id_matches=()
-  local name_matches=()
-
-  for project_dir in "$sessions_dir"/*/; do
-    for jsonl in "$project_dir"*.jsonl; do
-      [ -f "$jsonl" ] || continue
-      local basename
-      basename=$(basename "$jsonl" .jsonl)
-
-      # Match against UUID part of filename
-      local uuid_part
-      if [[ "$basename" == *_* ]]; then
-        uuid_part="${basename##*_}"
-      else
-        uuid_part="$basename"
-      fi
-      if [[ "$uuid_part" == "$query"* ]]; then
-        id_matches+=("$jsonl")
-        continue
-      fi
-
-      # Match against session name in header
-      local name
-      name=$(head -1 "$jsonl" | jq -r '.name // empty' 2>/dev/null)
-      if [ -n "$name" ] && [ "$name" = "$query" ]; then
-        name_matches+=("$jsonl")
-      fi
-    done
-  done
-
-  # ID matches take priority; fall back to name matches
-  local matches=()
-  if [ ${#id_matches[@]} -gt 0 ]; then
-    matches=("${id_matches[@]}")
-  elif [ ${#name_matches[@]} -gt 0 ]; then
-    matches=("${name_matches[@]}")
-  fi
-
-  case ${#matches[@]} in
-    0)
-      echo "Error: No session matching '$query'" >&2
-      return 1
-      ;;
-    1)
-      echo "${matches[0]}"
-      return 0
-      ;;
-    *)
-      echo "Error: Ambiguous query '$query', matches:" >&2
-      printf '  %s\n' "${matches[@]}" >&2
-      return 1
-      ;;
-  esac
+  harness_pi_find_session "$@"
 }

--- a/lib/harness/pi.py
+++ b/lib/harness/pi.py
@@ -1,0 +1,307 @@
+"""
+Pi harness adapter (Python).
+
+Authoritative home for pi-specific knowledge used by the read/search/
+list/inspect tasks:
+  - Where pi stores sessions on disk
+  - How pi encodes paths into project directory names
+  - Pi's JSONL entry schema (session header, model_change, message,
+    toolResult, wake, etc.)
+  - Tool-call argument shapes in pi's content blocks
+
+Step 1b of multi-harness support (sessions#50): pure extraction from
+parse.py. Other harnesses will live in sibling modules
+(lib/harness/claude.py, etc.); step 2 will add a dispatcher.
+
+All functions are pure — they take raw entry lists and filepaths,
+return the derived value. No I/O except in the discover/find helpers
+at the bottom.
+"""
+
+import json
+import os
+import sys
+
+
+# --- Entry-level schema ---
+
+def is_message_entry(entry: dict) -> bool:
+    """True if `entry` is a pi user/assistant message."""
+    return (
+        entry.get("type") == "message"
+        and entry.get("message", {}).get("role") in ("user", "assistant")
+    )
+
+
+def messages(entries: list) -> list:
+    """Return all user/assistant message entries."""
+    return [e for e in entries if is_message_entry(e)]
+
+
+def session_id(entries: list, filepath: str) -> str:
+    """Session ID from the pi session header, falling back to filename UUID."""
+    for e in entries:
+        if e.get("type") == "session":
+            return e.get("id", "")
+    basename = os.path.basename(filepath).replace(".jsonl", "")
+    parts = basename.rsplit("_", 1)
+    return parts[-1] if len(parts) == 2 else basename
+
+
+def name(entries: list) -> str:
+    """Session name from the pi session header, or empty string."""
+    for e in entries:
+        if e.get("type") == "session":
+            return e.get("name", "")
+    return ""
+
+
+def meta(entries: list) -> dict:
+    """Meta dict from the pi session header, or empty dict."""
+    for e in entries:
+        if e.get("type") == "session":
+            return e.get("meta", {})
+    return {}
+
+
+def slug(entries: list) -> str:  # noqa: ARG001 (kept for parity with claude, which may have one)
+    """Pi sessions don't have slugs."""
+    return ""
+
+
+def model(entries: list) -> str:
+    """Model from the first pi model_change entry, falling back to assistant message."""
+    for e in entries:
+        if e.get("type") == "model_change":
+            m = e.get("modelId", "")
+            if m:
+                return m
+    for e in entries:
+        if e.get("type") == "message":
+            msg = e.get("message", {})
+            if msg.get("role") == "assistant":
+                m = msg.get("model", "")
+                if m:
+                    return m
+    return "unknown"
+
+
+def project(filepath: str) -> str:
+    """Decode pi's project directory name into a readable owner/repo path.
+
+    Pi encodes paths with double-dash bookends: --Users-foo-bar--
+    """
+    dirname = os.path.basename(os.path.dirname(filepath))
+    if dirname.startswith("--") and dirname.endswith("--"):
+        dirname = dirname[2:-2]
+    readable = dirname.replace("-", "/")
+    if readable.startswith("/"):
+        readable = readable[1:]
+    parts = readable.split("/")
+    if len(parts) >= 2:
+        return "/".join(parts[-2:])
+    return readable
+
+
+def first_timestamp(entries: list) -> str:
+    for e in entries:
+        ts = e.get("timestamp", "")
+        if ts:
+            return ts
+    return ""
+
+
+def last_timestamp(entries: list) -> str:
+    for e in reversed(entries):
+        ts = e.get("timestamp", "")
+        if ts:
+            return ts
+    return ""
+
+
+def message_counts(entries: list) -> tuple[int, int]:
+    """Return (user_count, assistant_count) for pi message entries."""
+    user_count = 0
+    assistant_count = 0
+    for e in entries:
+        if e.get("type") != "message":
+            continue
+        role = e.get("message", {}).get("role", "")
+        if role == "user":
+            user_count += 1
+        elif role == "assistant":
+            assistant_count += 1
+    return user_count, assistant_count
+
+
+# --- Text rendering ---
+
+def text_messages(entries: list) -> list:
+    """
+    Render pi's JSONL entries into (index, role, timestamp, text) tuples.
+
+    Tool calls become `[tool_use: name ...]`, tool results become
+    `[tool_result: name: preview]`, thinking blocks are skipped.
+    """
+    results = []
+    for i, entry in enumerate(entries):
+        if entry.get("type") != "message":
+            continue
+
+        msg = entry.get("message", {})
+        role = msg.get("role", "")
+        ts = entry.get("timestamp", "")
+
+        if role == "user":
+            parts = _extract_text_content(msg)
+            text = "\n".join(parts) if parts else "(empty)"
+            results.append((i, "user", ts, text))
+
+        elif role == "assistant":
+            parts = _extract_assistant_content(msg)
+            text = "\n".join(parts) if parts else "(empty)"
+            results.append((i, "assistant", ts, text))
+
+        elif role == "toolResult":
+            tool_name = msg.get("toolName", "?")
+            content = msg.get("content", [])
+            preview = _extract_tool_result_preview(content)
+            text = (
+                f"[tool_result: {tool_name}: {preview}]"
+                if preview else f"[tool_result: {tool_name}]"
+            )
+            results.append((i, "user", ts, text))
+
+    return results
+
+
+def _extract_text_content(msg: dict) -> list:
+    content = msg.get("content", "")
+    parts = []
+    if isinstance(content, str):
+        parts.append(content)
+    elif isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "text":
+                parts.append(block.get("text", ""))
+    return parts
+
+
+def _extract_assistant_content(msg: dict) -> list:
+    content = msg.get("content", [])
+    parts = []
+    if isinstance(content, str):
+        parts.append(content)
+        return parts
+    if not isinstance(content, list):
+        return parts
+
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type", "")
+
+        if btype == "text":
+            parts.append(block.get("text", ""))
+
+        elif btype == "toolCall":
+            tool_name = block.get("name", "?")
+            args = block.get("arguments", {})
+            detail = _format_tool_detail(tool_name, args)
+            parts.append(f"[tool_use: {tool_name}{detail}]")
+
+        elif btype == "thinking":
+            # Internal reasoning — skip in rendered output.
+            pass
+
+    return parts
+
+
+def _format_tool_detail(tool_name: str, args: dict) -> str:  # noqa: ARG001
+    if "command" in args:
+        cmd = args["command"]
+        return f" $ {cmd[:80]}" if len(cmd) <= 80 else f" $ {cmd[:77]}..."
+    elif "path" in args:
+        return f" {args['path']}"
+    elif "file_path" in args:
+        return f" {args['file_path']}"
+    elif "pattern" in args:
+        return f" /{args['pattern']}/"
+    return ""
+
+
+def _extract_tool_result_preview(content) -> str:
+    if isinstance(content, str):
+        return content[:100].replace("\n", " ")
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                return block.get("text", "")[:100].replace("\n", " ")
+    return ""
+
+
+# --- Location / lookup ---
+
+def sessions_dir() -> str:
+    """Pi sessions root. Honours $PI_DIR for tests; defaults to ~/.pi."""
+    pi_dir = os.environ.get("PI_DIR", os.path.expanduser("~/.pi"))
+    return os.path.join(pi_dir, "agent", "sessions")
+
+
+def find_session(query: str) -> str:
+    """Find a pi session JSONL by UUID prefix or session name.
+
+    Prints errors to stderr and calls sys.exit(1) on no-match or ambiguous
+    match — matching the legacy `parse.find_session` contract.
+    """
+    root = sessions_dir()
+    if not os.path.isdir(root):
+        print(f"Error: No sessions directory at {root}", file=sys.stderr)
+        sys.exit(1)
+
+    id_matches = []
+    name_matches = []
+
+    for project_dir in os.listdir(root):
+        project_path = os.path.join(root, project_dir)
+        if not os.path.isdir(project_path):
+            continue
+        for fname in os.listdir(project_path):
+            if not fname.endswith(".jsonl"):
+                continue
+            filepath = os.path.join(project_path, fname)
+
+            uuid_part = (
+                fname.rsplit("_", 1)[-1].replace(".jsonl", "")
+                if "_" in fname
+                else fname.replace(".jsonl", "")
+            )
+            if uuid_part.startswith(query) or fname.startswith(query):
+                id_matches.append(filepath)
+                continue
+
+            try:
+                with open(filepath) as f:
+                    first_line = f.readline().strip()
+                    if first_line:
+                        header = json.loads(first_line)
+                        hname = header.get("name", "")
+                        if hname and hname == query:
+                            name_matches.append(filepath)
+            except (json.JSONDecodeError, OSError):
+                continue
+
+    matches = id_matches if id_matches else name_matches
+
+    if not matches:
+        print(f"Error: No session matching '{query}'", file=sys.stderr)
+        sys.exit(1)
+    if len(matches) > 1:
+        print(f"Error: Ambiguous query '{query}', matches:", file=sys.stderr)
+        for m in matches:
+            print(f"  {os.path.basename(m)}", file=sys.stderr)
+        sys.exit(1)
+
+    return matches[0]

--- a/lib/harness/pi.py
+++ b/lib/harness/pi.py
@@ -64,8 +64,13 @@ def meta(entries: list) -> dict:
     return {}
 
 
-def slug(entries: list) -> str:  # noqa: ARG001 (kept for parity with claude, which may have one)
-    """Pi sessions don't have slugs."""
+def slug() -> str:
+    """Pi sessions don't have slugs.
+
+    Kept as a no-arg function so the dispatcher in step 2 can route to
+    per-harness implementations uniformly. Harnesses that derive slugs
+    from entries (if any emerge) will introduce their own signature.
+    """
     return ""
 
 

--- a/lib/harness/pi.sh
+++ b/lib/harness/pi.sh
@@ -250,14 +250,3 @@ harness_pi_wake_entry() {
   fi
 }
 
-# --- Launch ---
-
-# Print the args pi's headless harness expects to continue an existing
-# session. Today that's `--session <file>`. Callers append these after
-# the harness command (e.g. `shimmer agent --headless`).
-#
-# Printed one arg per line so callers can read into an array safely.
-harness_pi_launch_session_args() {
-  local session_file="$1"
-  printf '%s\n' "--session" "$session_file"
-}

--- a/lib/harness/pi.sh
+++ b/lib/harness/pi.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# Pi harness adapter for sessions.
+#
+# This file is the authoritative home for pi-specific knowledge:
+#   - Where pi stores sessions on disk
+#   - How pi encodes paths into directory names
+#   - Pi's JSONL entry schema (session header, model_change, message, wake)
+#
+# Step 1 of multi-harness support (sessions#50): pure extraction, no
+# behavior change. Other harnesses will live in sibling files
+# (lib/harness/claude.sh, etc.) and a dispatcher (step 2) will route
+# commands based on session metadata.
+#
+# All functions are prefixed `harness_pi_` to keep the namespace clean
+# when dispatched from a generic harness loader.
+#
+# Usage:
+#   source "$MISE_CONFIG_ROOT/lib/harness/pi.sh"
+
+# --- Location ---
+
+# Print the absolute path of pi's sessions root.
+# Honours $PI_DIR for test isolation; defaults to ~/.pi.
+harness_pi_sessions_dir() {
+  local pi_dir="${PI_DIR:-$HOME/.pi}"
+  echo "$pi_dir/agent/sessions"
+}
+
+# Encode an absolute cwd into pi's project directory name.
+# Pi uses double-dash bookends: /Users/foo/bar -> --Users-foo-bar--
+harness_pi_encode_cwd() {
+  local cwd_abs="$1"
+  local encoded
+  encoded=$(echo "$cwd_abs" | sed 's|/|-|g')
+  echo "-${encoded}-"
+}
+
+# Print the full path for a new pi session file, creating the project dir.
+# Filename format: <timestamp-with-colons-as-dashes>_<session-uuid>.jsonl
+harness_pi_session_file_path() {
+  local cwd_abs="$1"
+  local session_id="$2"
+  local now_iso="$3"
+
+  local sessions_dir project_dir now_file
+  sessions_dir=$(harness_pi_sessions_dir)
+  project_dir="$sessions_dir/$(harness_pi_encode_cwd "$cwd_abs")/"
+  mkdir -p "$project_dir"
+
+  now_file=$(echo "$now_iso" | sed 's/:/-/g')
+  echo "${project_dir}${now_file}_${session_id}.jsonl"
+}
+
+# --- Lookup ---
+
+# Find a pi session file by UUID prefix or session name.
+# Prints the path on success; prints error and returns non-zero otherwise.
+harness_pi_find_session() {
+  local query="$1"
+  local sessions_dir
+  sessions_dir=$(harness_pi_sessions_dir)
+
+  if [ ! -d "$sessions_dir" ]; then
+    echo "Error: No sessions directory at $sessions_dir" >&2
+    return 1
+  fi
+
+  local id_matches=()
+  local name_matches=()
+
+  for project_dir in "$sessions_dir"/*/; do
+    for jsonl in "$project_dir"*.jsonl; do
+      [ -f "$jsonl" ] || continue
+      local basename
+      basename=$(basename "$jsonl" .jsonl)
+
+      local uuid_part
+      if [[ "$basename" == *_* ]]; then
+        uuid_part="${basename##*_}"
+      else
+        uuid_part="$basename"
+      fi
+      if [[ "$uuid_part" == "$query"* ]]; then
+        id_matches+=("$jsonl")
+        continue
+      fi
+
+      local name
+      name=$(head -1 "$jsonl" | jq -r '.name // empty' 2>/dev/null)
+      if [ -n "$name" ] && [ "$name" = "$query" ]; then
+        name_matches+=("$jsonl")
+      fi
+    done
+  done
+
+  local matches=()
+  if [ ${#id_matches[@]} -gt 0 ]; then
+    matches=("${id_matches[@]}")
+  elif [ ${#name_matches[@]} -gt 0 ]; then
+    matches=("${name_matches[@]}")
+  fi
+
+  case ${#matches[@]} in
+    0)
+      echo "Error: No session matching '$query'" >&2
+      return 1
+      ;;
+    1)
+      echo "${matches[0]}"
+      return 0
+      ;;
+    *)
+      echo "Error: Ambiguous query '$query', matches:" >&2
+      printf '  %s\n' "${matches[@]}" >&2
+      return 1
+      ;;
+  esac
+}
+
+# --- Entry builders ---
+#
+# Each function prints a single JSONL entry to stdout. Callers append
+# to the session file. Entries match pi's on-disk schema; any changes
+# here must stay synchronised with pi itself.
+
+# Session header entry (first line of every session file).
+#   $1 session_id, $2 timestamp_iso, $3 cwd_abs, $4 name (optional),
+#   $5 meta_json (optional, "{}" or "" for none)
+harness_pi_header_entry() {
+  local session_id="$1"
+  local ts="$2"
+  local cwd_abs="$3"
+  local name="${4:-}"
+  local meta_json="${5:-}"
+
+  local args=(
+    --arg id "$session_id"
+    --arg ts "$ts"
+    --arg cwd "$cwd_abs"
+  )
+  local expr='{type: "session", version: 3, id: $id, timestamp: $ts, cwd: $cwd}'
+
+  if [ -n "$name" ]; then
+    args+=(--arg name "$name")
+    expr="$expr + {name: \$name}"
+  fi
+
+  if [ -n "$meta_json" ] && [ "$meta_json" != "{}" ]; then
+    args+=(--argjson meta "$meta_json")
+    expr="$expr + {meta: \$meta}"
+  fi
+
+  jq -nc "${args[@]}" "$expr"
+}
+
+# Model change entry.
+#   $1 entry_id, $2 timestamp_iso, $3 model_id
+harness_pi_model_change_entry() {
+  local entry_id="$1"
+  local ts="$2"
+  local model="$3"
+
+  jq -nc \
+    --arg id "$entry_id" \
+    --arg ts "$ts" \
+    --arg model "$model" \
+    '{
+      type: "model_change",
+      id: $id,
+      parentId: null,
+      timestamp: $ts,
+      provider: "anthropic",
+      modelId: $model
+    }'
+}
+
+# User message entry (used for context injection at new/wake time).
+#   $1 entry_id, $2 parent_id, $3 timestamp_iso, $4 text
+harness_pi_user_message_entry() {
+  local entry_id="$1"
+  local parent_id="$2"
+  local ts="$3"
+  local text="$4"
+
+  jq -nc \
+    --arg id "$entry_id" \
+    --arg parent_id "$parent_id" \
+    --arg ts "$ts" \
+    --arg content "$text" \
+    '{
+      type: "message",
+      id: $id,
+      parentId: $parent_id,
+      timestamp: $ts,
+      message: {
+        role: "user",
+        content: [{ type: "text", text: $content }]
+      }
+    }'
+}
+
+# Wake event entry.
+#   $1 entry_id, $2 parent_id, $3 timestamp_iso, $4 shell_name,
+#   $5 agent, $6 harness_cmd, $7 meta_json (optional, "{}" or "" for none)
+harness_pi_wake_entry() {
+  local entry_id="$1"
+  local parent_id="$2"
+  local ts="$3"
+  local shell_name="$4"
+  local agent="$5"
+  local harness_cmd="$6"
+  local meta_json="${7:-}"
+
+  if [ -z "$meta_json" ] || [ "$meta_json" = "{}" ]; then
+    jq -nc \
+      --arg id "$entry_id" \
+      --arg parent_id "$parent_id" \
+      --arg ts "$ts" \
+      --arg shell_name "$shell_name" \
+      --arg agent "$agent" \
+      --arg harness "$harness_cmd" \
+      '{
+        type: "wake",
+        id: $id,
+        parentId: $parent_id,
+        timestamp: $ts,
+        shell: $shell_name,
+        agent: $agent,
+        harness: $harness
+      }'
+  else
+    jq -nc \
+      --arg id "$entry_id" \
+      --arg parent_id "$parent_id" \
+      --arg ts "$ts" \
+      --arg shell_name "$shell_name" \
+      --arg agent "$agent" \
+      --arg harness "$harness_cmd" \
+      --argjson meta "$meta_json" \
+      '{
+        type: "wake",
+        id: $id,
+        parentId: $parent_id,
+        timestamp: $ts,
+        shell: $shell_name,
+        agent: $agent,
+        harness: $harness,
+        meta: $meta
+      }'
+  fi
+}
+
+# --- Launch ---
+
+# Print the args pi's headless harness expects to continue an existing
+# session. Today that's `--session <file>`. Callers append these after
+# the harness command (e.g. `shimmer agent --headless`).
+#
+# Printed one arg per line so callers can read into an array safely.
+harness_pi_launch_session_args() {
+  local session_file="$1"
+  printf '%s\n' "--session" "$session_file"
+}

--- a/lib/parse.py
+++ b/lib/parse.py
@@ -1,22 +1,28 @@
 """
 Shared JSONL session parser for the sessions tooling.
 
-Parses pi's session log format (~/.pi/agent/sessions/).
+This module is deliberately harness-agnostic: it loads JSONL files,
+exposes a `Session` container, and implements filter parsing that
+works against any dotted-path + value expression.
+
+All pi-specific schema knowledge lives in `lib/harness/pi.py`. Step 1b
+of multi-harness support (sessions#50) extracted it there; step 2 will
+add a dispatcher so `Session` methods pick the right harness adapter.
 
 Usage:
     import parse
     session = parse.load(filepath)
     # session.entries       — all raw JSONL dicts
-    # session.messages      — user/assistant message entries only
+    # session.messages      — user/assistant message entries (pi-shaped today)
     # session.metadata()    — dict with id, project, model, timestamps, counts, etc.
     # session.text_messages() — list of (index, role, timestamp, text) tuples
 """
 
 import json
-import os
-import re
 import sys
 from dataclasses import dataclass, field
+
+from harness import pi as _pi
 
 
 @dataclass
@@ -26,109 +32,42 @@ class Session:
 
     @property
     def messages(self) -> list:
-        """Return message entries with user or assistant role."""
-        return [
-            e for e in self.entries
-            if e.get("type") == "message"
-            and e.get("message", {}).get("role") in ("user", "assistant")
-        ]
+        return _pi.messages(self.entries)
 
     @property
     def session_id(self) -> str:
-        """Get session ID from the session header entry, or derive from filename."""
-        for e in self.entries:
-            if e.get("type") == "session":
-                return e.get("id", "")
-        # Fallback: extract UUID from pi filename (timestamp_uuid.jsonl)
-        basename = os.path.basename(self.filepath).replace(".jsonl", "")
-        parts = basename.rsplit("_", 1)
-        return parts[-1] if len(parts) == 2 else basename
+        return _pi.session_id(self.entries, self.filepath)
 
     @property
     def name(self) -> str:
-        """Get session name from the session header, or empty string."""
-        for e in self.entries:
-            if e.get("type") == "session":
-                return e.get("name", "")
-        return ""
+        return _pi.name(self.entries)
 
     @property
     def slug(self) -> str:
-        """Pi sessions don't have slugs."""
-        return ""
+        return _pi.slug(self.entries)
 
     @property
     def meta(self) -> dict:
-        """Get meta field from the session header, or empty dict."""
-        for e in self.entries:
-            if e.get("type") == "session":
-                return e.get("meta", {})
-        return {}
+        return _pi.meta(self.entries)
 
     @property
     def project(self) -> str:
-        """Decode the project directory name into a readable path.
-
-        Pi encodes paths with double-dash bookends: --Users-foo-bar--
-        """
-        dirname = os.path.basename(os.path.dirname(self.filepath))
-        # Strip double-dash bookends
-        if dirname.startswith("--") and dirname.endswith("--"):
-            dirname = dirname[2:-2]
-        readable = dirname.replace("-", "/")
-        if readable.startswith("/"):
-            readable = readable[1:]
-        # Trim to last two components (owner/repo style)
-        parts = readable.split("/")
-        if len(parts) >= 2:
-            return "/".join(parts[-2:])
-        return readable
+        return _pi.project(self.filepath)
 
     @property
     def model(self) -> str:
-        """Get model from first model_change entry or first assistant message."""
-        for e in self.entries:
-            if e.get("type") == "model_change":
-                m = e.get("modelId", "")
-                if m:
-                    return m
-        # Fallback: check assistant messages
-        for e in self.entries:
-            if e.get("type") == "message":
-                msg = e.get("message", {})
-                if msg.get("role") == "assistant":
-                    m = msg.get("model", "")
-                    if m:
-                        return m
-        return "unknown"
+        return _pi.model(self.entries)
 
     @property
     def first_timestamp(self) -> str:
-        for e in self.entries:
-            ts = e.get("timestamp", "")
-            if ts:
-                return ts
-        return ""
+        return _pi.first_timestamp(self.entries)
 
     @property
     def last_timestamp(self) -> str:
-        for e in reversed(self.entries):
-            ts = e.get("timestamp", "")
-            if ts:
-                return ts
-        return ""
+        return _pi.last_timestamp(self.entries)
 
     def metadata(self) -> dict:
-        user_count = 0
-        assistant_count = 0
-        for e in self.entries:
-            if e.get("type") != "message":
-                continue
-            role = e.get("message", {}).get("role", "")
-            if role == "user":
-                user_count += 1
-            elif role == "assistant":
-                assistant_count += 1
+        user_count, assistant_count = _pi.message_counts(self.entries)
         result = {
             "session_id": self.session_id,
             "name": self.name,
@@ -147,106 +86,10 @@ class Session:
         return result
 
     def text_messages(self) -> list:
-        """
-        Extract human-readable messages as (index, role, timestamp, text) tuples.
-        Tool calls are rendered as [tool_use: name], tool results as [tool_result].
-        """
-        results = []
-        for i, entry in enumerate(self.entries):
-            if entry.get("type") != "message":
-                continue
+        return _pi.text_messages(self.entries)
 
-            msg = entry.get("message", {})
-            role = msg.get("role", "")
-            ts = entry.get("timestamp", "")
 
-            if role == "user":
-                parts = self._extract_text_content(msg)
-                text = "\n".join(parts) if parts else "(empty)"
-                results.append((i, "user", ts, text))
-
-            elif role == "assistant":
-                parts = self._extract_assistant_content(msg)
-                text = "\n".join(parts) if parts else "(empty)"
-                results.append((i, "assistant", ts, text))
-
-            elif role == "toolResult":
-                # Tool results are separate entries in pi format
-                tool_name = msg.get("toolName", "?")
-                content = msg.get("content", [])
-                preview = self._extract_tool_result_preview(content)
-                text = f"[tool_result: {tool_name}: {preview}]" if preview else f"[tool_result: {tool_name}]"
-                results.append((i, "user", ts, text))
-
-        return results
-
-    def _extract_text_content(self, msg: dict) -> list:
-        """Extract text from a user message's content."""
-        content = msg.get("content", "")
-        parts = []
-        if isinstance(content, str):
-            parts.append(content)
-        elif isinstance(content, list):
-            for block in content:
-                if not isinstance(block, dict):
-                    continue
-                if block.get("type") == "text":
-                    parts.append(block.get("text", ""))
-        return parts
-
-    def _extract_assistant_content(self, msg: dict) -> list:
-        """Extract text and tool call summaries from an assistant message."""
-        content = msg.get("content", [])
-        parts = []
-        if isinstance(content, str):
-            parts.append(content)
-            return parts
-        if not isinstance(content, list):
-            return parts
-
-        for block in content:
-            if not isinstance(block, dict):
-                continue
-            btype = block.get("type", "")
-
-            if btype == "text":
-                parts.append(block.get("text", ""))
-
-            elif btype == "toolCall":
-                name = block.get("name", "?")
-                args = block.get("arguments", {})
-                detail = self._format_tool_detail(name, args)
-                parts.append(f"[tool_use: {name}{detail}]")
-
-            elif btype == "thinking":
-                # Skip thinking blocks in output — they're internal reasoning
-                pass
-
-        return parts
-
-    def _format_tool_detail(self, name: str, args: dict) -> str:
-        """Format tool call arguments into a brief summary."""
-        if "command" in args:
-            cmd = args["command"]
-            return f" $ {cmd[:80]}" if len(cmd) <= 80 else f" $ {cmd[:77]}..."
-        elif "path" in args:
-            return f" {args['path']}"
-        elif "file_path" in args:
-            return f" {args['file_path']}"
-        elif "pattern" in args:
-            return f" /{args['pattern']}/"
-        return ""
-
-    def _extract_tool_result_preview(self, content) -> str:
-        """Extract a short preview from tool result content."""
-        if isinstance(content, str):
-            return content[:100].replace("\n", " ")
-        elif isinstance(content, list):
-            for block in content:
-                if isinstance(block, dict) and block.get("type") == "text":
-                    return block.get("text", "")[:100].replace("\n", " ")
-        return ""
-
+# --- Generic helpers (harness-agnostic) ---
 
 def dict_contains(haystack: dict, needle: dict) -> bool:
     """Check if haystack contains all keys/values from needle (recursive)."""
@@ -397,11 +240,9 @@ def _entry_matches_filter(entry: dict, f: Filter) -> bool:
 def session_matches_filters(session: 'Session', filters: list) -> bool:
     """Check if a session matches ALL filters."""
     for f in filters:
-        # Collect entries of the specified type
         typed_entries = [e for e in session.entries if e.get("type") == f.entry_type]
 
         if f.index is not None:
-            # Index-specific: check one entry
             try:
                 entry = typed_entries[f.index]
             except IndexError:
@@ -409,7 +250,6 @@ def session_matches_filters(session: 'Session', filters: list) -> bool:
             if not _entry_matches_filter(entry, f):
                 return False
         else:
-            # Any-match: at least one entry of this type must match
             if not any(_entry_matches_filter(e, f) for e in typed_entries):
                 return False
 
@@ -431,59 +271,14 @@ def load(filepath: str) -> Session:
     return Session(filepath=filepath, entries=entries)
 
 
+# --- Back-compat shims ---
+#
+# These delegate to the pi harness adapter. Step 2 will turn them into
+# dispatchers that pick an adapter based on context.
+
 def discover_sessions_dir() -> str:
-    """Find the pi sessions directory. Respects PI_DIR env var for testing."""
-    pi_dir = os.environ.get("PI_DIR", os.path.expanduser("~/.pi"))
-    return os.path.join(pi_dir, "agent", "sessions")
+    return _pi.sessions_dir()
 
 
 def find_session(query: str) -> str:
-    """Find a session JSONL file by ID prefix or name. Returns filepath or exits."""
-    sessions_dir = discover_sessions_dir()
-    if not os.path.isdir(sessions_dir):
-        print(f"Error: No sessions directory at {sessions_dir}", file=sys.stderr)
-        sys.exit(1)
-
-    id_matches = []
-    name_matches = []
-
-    for project_dir in os.listdir(sessions_dir):
-        project_path = os.path.join(sessions_dir, project_dir)
-        if not os.path.isdir(project_path):
-            continue
-        for fname in os.listdir(project_path):
-            if not fname.endswith(".jsonl"):
-                continue
-            filepath = os.path.join(project_path, fname)
-
-            # Match against UUID part of filename
-            uuid_part = fname.rsplit("_", 1)[-1].replace(".jsonl", "") if "_" in fname else fname.replace(".jsonl", "")
-            if uuid_part.startswith(query) or fname.startswith(query):
-                id_matches.append(filepath)
-                continue
-
-            # Match against session name in header
-            try:
-                with open(filepath) as f:
-                    first_line = f.readline().strip()
-                    if first_line:
-                        header = json.loads(first_line)
-                        name = header.get("name", "")
-                        if name and name == query:
-                            name_matches.append(filepath)
-            except (json.JSONDecodeError, OSError):
-                continue
-
-    # ID matches take priority; fall back to name matches
-    matches = id_matches if id_matches else name_matches
-
-    if not matches:
-        print(f"Error: No session matching '{query}'", file=sys.stderr)
-        sys.exit(1)
-    if len(matches) > 1:
-        print(f"Error: Ambiguous query '{query}', matches:", file=sys.stderr)
-        for m in matches:
-            print(f"  {os.path.basename(m)}", file=sys.stderr)
-        sys.exit(1)
-
-    return matches[0]
+    return _pi.find_session(query)

--- a/lib/parse.py
+++ b/lib/parse.py
@@ -44,7 +44,7 @@ class Session:
 
     @property
     def slug(self) -> str:
-        return _pi.slug(self.entries)
+        return _pi.slug()
 
     @property
     def meta(self) -> dict:
@@ -275,6 +275,11 @@ def load(filepath: str) -> Session:
 #
 # These delegate to the pi harness adapter. Step 2 will turn them into
 # dispatchers that pick an adapter based on context.
+#
+# Used by: .mise/tasks/{export,import,list} (via `parse.find_session` and
+# `parse.discover_sessions_dir`). Do not drop without updating those
+# callers — the shims exist so tasks don't yet need to know about the
+# harness layer.
 
 def discover_sessions_dir() -> str:
     return _pi.sessions_dir()


### PR DESCRIPTION
Step 1 of sessions#50 (multi-harness support). Pure extraction — **no behavior change**, all tests still green:

- **154/154** bats tests
- **4 doctests + 73 elixir tests, 0 failures**

## What moved where

| From | To | Why |
|---|---|---|
| `.mise/tasks/new`, `.mise/tasks/wake`, `lib/find.sh` | `lib/harness/pi.sh` | All pi schema + location knowledge in one file |
| `lib/parse.py` (Session pi properties, find_session, discover_sessions_dir) | `lib/harness/pi.py` | All pi read-path schema knowledge in one file |
| `cli/lib/cli.ex` (command build, stream parser, tool formatting) | `cli/lib/harness/pi.ex` | All pi run-path knowledge in one file |

## What stayed

- `.mise/tasks/*` — orchestration only, sources pi adapter
- `lib/parse.py` — `Session` container, JSONL loader, filter parsing, `session_matches_filters`
- `cli/lib/cli.ex` — arg parsing, port spawning, stream loop, `check_abort_signal`, `text_beyond_flushed`, usage summary

## Back-compat shims

Anything that imported the old interfaces keeps working:
- `lib/find.sh` — still sourceable, `find_session_file` delegates to `harness_pi_find_session`
- `parse.discover_sessions_dir()` + `parse.find_session()` — delegate to `harness.pi`
- `Cli.process_line/2`, `Cli.format_tool_input/1`, `Cli.extract_partial_text/1`, `Cli.flush_partial_buffer/1` — delegate to `Cli.Harness.Pi`

Step 2 will replace these shims with dispatchers that select an adapter based on session context.

## Commits

1. `refactor(harness): extract pi bash adapter to lib/harness/pi.sh`
2. `refactor(harness): extract pi Python adapter to lib/harness/pi.py`
3. `refactor(harness): extract pi Elixir adapter to Cli.Harness.Pi`

Each commit leaves the full test suite green.

## Self-worries for review

1. **Naming.** `harness_pi_*` is verbose but keeps the bash namespace clean once we add `harness_claude_*` in step 3. Open to shorter prefix if anyone has preferences.
2. **`Cli.process_line/2` wrapper.** Passes `check_abort_signal` and `text_beyond_flushed` as callbacks into `Cli.Harness.Pi.process_line/3` to avoid a circular module dep. Ugly but explicit — step 2's dispatcher will make this cleaner.
3. **Test coverage didn't change.** Intentional for a refactor. Step 3 adds `test/harness_dispatch.bats`.
