### PR TITLE
fix: self-heal missing cli/deps/ on fresh install

### DIFF
--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -70,5 +70,11 @@ CLI_ARGS=(--system-prompt-file "$SYSTEM_PROMPT_FILE" --cwd "$CWD")
 [ "$SKILLS" != "true" ] && CLI_ARGS+=(--no-skills)
 [ "$PROMPT_TEMPLATES" != "true" ] && CLI_ARGS+=(--no-prompt-templates)
 
+# Self-heal on fresh installs before handing off to mix. See
+# KnickKnackLabs/sessions#53 for rationale.
+# shellcheck source=../../lib/ensure-deps.sh
+source "$MISE_CONFIG_ROOT/lib/ensure-deps.sh"
+ensure_cli_deps "$CLI_DIR"
+
 cd "$CLI_DIR"
 exec mix sessions "${CLI_ARGS[@]}" "$MESSAGE"

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 141 passing](https://img.shields.io/badge/tests-141%20passing-brightgreen?style=flat)](test/)
-![commands: 10](https://img.shields.io/badge/commands-10-blue?style=flat)
+[![tests: 161 passing](https://img.shields.io/badge/tests-161%20passing-brightgreen?style=flat)](test/)
+![commands: 13](https://img.shields.io/badge/commands-13-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
 </div>
@@ -162,7 +162,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**141 tests** across 10 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 634 lines of Python in `lib/`.
+**161 tests** across 12 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 434 lines of Python in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -178,13 +178,21 @@ sessions/
 │   ├── search       # Full-text regex across transcripts
 │   ├── inspect      # Forensic metadata (duration, tools, model)
 │   ├── copy         # Duplicate sessions for handoff
+│   ├── remove       # Remove sessions (kill shell + delete file)
+│   ├── run          # Execute agent sessions (wraps Elixir CLI)
+│   ├── cli/build    # Build Elixir CLI dependencies
 │   ├── export       # Portable bundles (JSONL + metadata)
 │   └── import       # Import exported sessions
+├── cli/             # Elixir execution engine (timeout, ABORT, usage)
 ├── lib/
-│   ├── parse.py     # JSONL parser, session model, filter engine
-│   └── format.py    # Rich formatting helpers
+│   ├── parse.py        # JSONL parser, session model, filter engine
+│   ├── format.py       # Rich formatting helpers
+│   ├── ensure-deps.sh  # First-run CLI deps self-heal
+│   ├── find.sh         # Back-compat shim → harness adapter
+│   ├── shell.sh        # Shell helpers
+│   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats       # 141 tests
+    └── *.bats          # 161 tests
 ```
 
 </details>

--- a/README.tsx
+++ b/README.tsx
@@ -290,10 +290,14 @@ mise run test`}</CodeBlock>
 │   └── import       # Import exported sessions
 ├── cli/             # Elixir execution engine (timeout, ABORT, usage)
 ├── lib/
-│   ├── parse.py     # JSONL parser, session model, filter engine
-│   └── format.py    # Rich formatting helpers
+│   ├── parse.py        # JSONL parser, session model, filter engine
+│   ├── format.py       # Rich formatting helpers
+│   ├── ensure-deps.sh  # First-run CLI deps self-heal
+│   ├── find.sh         # Back-compat shim → harness adapter
+│   ├── shell.sh        # Shell helpers
+│   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats       # ${testCount} tests`}</CodeBlock>
+    └── *.bats          # ${testCount} tests`}</CodeBlock>
       </Details>
     </Section>
 

--- a/lib/ensure-deps.sh
+++ b/lib/ensure-deps.sh
@@ -27,14 +27,16 @@ ensure_cli_deps() {
     return 2
   fi
 
-  # Populated-deps check: if any subdir exists under deps/, we assume
+  # Populated-deps check: if any entry exists under deps/, we assume
   # deps have been fetched at least once. `mix` itself will handle
-  # version drift (it re-fetches on `mix.lock` change).
+  # version drift (it re-fetches on `mix.lock` change). In practice
+  # `mix deps.get` only creates subdirectories, but we check for any
+  # entry so the code matches what `ls -A` actually reports.
   if [ -n "$(ls -A "$cli_dir/deps" 2>/dev/null)" ]; then
     return 0
   fi
 
-  echo "sessions: first-run setup — fetching Elixir dependencies (one-time)…" >&2
+  echo "sessions: first-run setup — fetching Elixir dependencies…" >&2
   (
     cd "$cli_dir" || exit 1
     mix local.hex --force --if-missing >&2 || exit 1

--- a/lib/ensure-deps.sh
+++ b/lib/ensure-deps.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Self-healing deps check for the sessions CLI.
+#
+# On a fresh shiv-sessions install (or after a manual `rm -rf cli/deps`),
+# `cli/deps/` is empty and `mix sessions` refuses to start with an
+# 'Unchecked dependencies' error. This helper detects that case and
+# runs `mix deps.get` on the fly.
+#
+# See KnickKnackLabs/sessions#53 for the rationale.
+
+# ensure_cli_deps <cli_dir>
+#
+# Returns:
+#   0 — deps are already populated, or were just fetched successfully.
+#   1 — fetch failed; an actionable hint is emitted to stderr.
+#   2 — programmer error (missing arg, or <cli_dir> does not exist).
+ensure_cli_deps() {
+  local cli_dir="$1"
+
+  if [ -z "$cli_dir" ]; then
+    echo "ensure_cli_deps: cli_dir argument required" >&2
+    return 2
+  fi
+
+  if [ ! -d "$cli_dir" ]; then
+    echo "ensure_cli_deps: cli dir does not exist: $cli_dir" >&2
+    return 2
+  fi
+
+  # Populated-deps check: if any subdir exists under deps/, we assume
+  # deps have been fetched at least once. `mix` itself will handle
+  # version drift (it re-fetches on `mix.lock` change).
+  if [ -n "$(ls -A "$cli_dir/deps" 2>/dev/null)" ]; then
+    return 0
+  fi
+
+  echo "sessions: first-run setup — fetching Elixir dependencies (one-time)…" >&2
+  (
+    cd "$cli_dir" || exit 1
+    mix local.hex --force --if-missing >&2 || exit 1
+    mix deps.get >&2 || exit 1
+  ) || {
+    echo "sessions: failed to fetch dependencies." >&2
+    echo "  try: mise run cli:build   (in $cli_dir)" >&2
+    return 1
+  }
+
+  return 0
+}

--- a/test/ensure-deps.bats
+++ b/test/ensure-deps.bats
@@ -86,24 +86,27 @@ teardown() {
 # Error paths
 # ----------------------------------------------------------------------------
 
-@test "ensure_cli_deps: errors when cli_dir argument is missing" {
+@test "ensure_cli_deps: returns 2 (programmer error) when cli_dir argument is missing" {
+  # Tests the documented contract: return 2 for programmer errors,
+  # return 1 for runtime fetch failures. A future refactor that swaps
+  # these should fail here.
   run ensure_cli_deps
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 2 ]
   [[ "$output" == *"cli_dir argument required"* ]]
 }
 
-@test "ensure_cli_deps: errors when cli_dir does not exist" {
+@test "ensure_cli_deps: returns 2 (programmer error) when cli_dir does not exist" {
   run ensure_cli_deps "$TMP/does-not-exist"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 2 ]
   [[ "$output" == *"cli dir does not exist"* ]]
 }
 
-@test "ensure_cli_deps: errors and emits hint when mix fetch fails" {
+@test "ensure_cli_deps: returns 1 (fetch failed) and emits hint when mix fails" {
   # Break the mix project so deps.get fails.
   echo "this is not valid elixir" > "$CLI/mix.exs"
 
   run ensure_cli_deps "$CLI"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 1 ]
   [[ "$output" == *"first-run setup"* ]]
   [[ "$output" == *"failed to fetch dependencies"* ]]
   [[ "$output" == *"mise run cli:build"* ]]

--- a/test/ensure-deps.bats
+++ b/test/ensure-deps.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+# Tests for lib/ensure-deps.sh — the defensive deps check that self-heals
+# a fresh shiv-sessions install. See KnickKnackLabs/sessions#53.
+
+load helpers
+
+setup() {
+  # Source the helper under test. Using MISE_CONFIG_ROOT guarantees we're
+  # sourcing the version in the tree being tested (not the shiv-installed
+  # one), consistent with how `.mise/tasks/run` resolves it.
+  source "$MISE_CONFIG_ROOT/lib/ensure-deps.sh"
+
+  TMP=$(mktemp -d)
+  CLI="$TMP/cli"
+  mkdir -p "$CLI/deps"
+
+  # Minimal mix project so `mix deps.get` has something to read.
+  cat > "$CLI/mix.exs" <<'EOF'
+defmodule EnsureDepsTest.MixProject do
+  use Mix.Project
+  def project, do: [app: :ensure_deps_test, version: "0.0.1", elixir: "~> 1.19", deps: deps()]
+  def application, do: [extra_applications: [:logger]]
+  defp deps, do: [{:jason, "~> 1.4"}]
+end
+EOF
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+# ----------------------------------------------------------------------------
+# Happy paths
+# ----------------------------------------------------------------------------
+
+@test "ensure_cli_deps: returns 0 when deps/ is already populated" {
+  # Simulate previously-fetched state by planting a dummy subdir.
+  mkdir -p "$CLI/deps/some_pkg"
+  run ensure_cli_deps "$CLI"
+  [ "$status" -eq 0 ]
+  # Should NOT emit the first-run notice when deps are present.
+  [[ "$output" != *"first-run setup"* ]]
+}
+
+@test "ensure_cli_deps: returns 0 and does nothing when deps are populated" {
+  # Multiple subdirs, mimicking a real install.
+  mkdir -p "$CLI/deps/jason" "$CLI/deps/credo" "$CLI/deps/bunt"
+  run ensure_cli_deps "$CLI"
+  [ "$status" -eq 0 ]
+  # Directory unchanged.
+  [ -d "$CLI/deps/jason" ]
+  [ -d "$CLI/deps/credo" ]
+  [ -d "$CLI/deps/bunt" ]
+}
+
+# ----------------------------------------------------------------------------
+# Self-heal
+# ----------------------------------------------------------------------------
+
+@test "ensure_cli_deps: fetches deps when deps/ is empty" {
+  # deps/ exists but is empty — the fresh-install condition.
+  [ -z "$(ls -A "$CLI/deps")" ]
+
+  run ensure_cli_deps "$CLI"
+  [ "$status" -eq 0 ]
+
+  # First-run notice must be emitted.
+  [[ "$output" == *"first-run setup"* ]]
+
+  # deps/ should now be populated. jason is the only dep in our fixture.
+  [ -d "$CLI/deps/jason" ]
+}
+
+@test "ensure_cli_deps: fetches deps when deps/ does not exist at all" {
+  # Nuke the deps dir entirely — ls -A returns empty for a missing dir.
+  rm -rf "$CLI/deps"
+
+  run ensure_cli_deps "$CLI"
+  [ "$status" -eq 0 ]
+
+  [[ "$output" == *"first-run setup"* ]]
+  [ -d "$CLI/deps/jason" ]
+}
+
+# ----------------------------------------------------------------------------
+# Error paths
+# ----------------------------------------------------------------------------
+
+@test "ensure_cli_deps: errors when cli_dir argument is missing" {
+  run ensure_cli_deps
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cli_dir argument required"* ]]
+}
+
+@test "ensure_cli_deps: errors when cli_dir does not exist" {
+  run ensure_cli_deps "$TMP/does-not-exist"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cli dir does not exist"* ]]
+}
+
+@test "ensure_cli_deps: errors and emits hint when mix fetch fails" {
+  # Break the mix project so deps.get fails.
+  echo "this is not valid elixir" > "$CLI/mix.exs"
+
+  run ensure_cli_deps "$CLI"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"first-run setup"* ]]
+  [[ "$output" == *"failed to fetch dependencies"* ]]
+  [[ "$output" == *"mise run cli:build"* ]]
+}


### PR DESCRIPTION
Closes #53.

## What

A fresh `shiv install sessions` doesn't populate `cli/deps/`, so every first `sessions wake` (or anything touching `.mise/tasks/run`) fails with:

```
Unchecked dependencies for environment dev:
* jason (Hex package)
  the dependency is not available, run "mix deps.get"
* credo (Hex package)
  the dependency is not available, run "mix deps.get"
** (Mix) Can't continue due to errors on dependencies
```

This PR adds a defensive deps-check in `.mise/tasks/run`: if `cli/deps/` is empty or missing, run `mix local.hex --force --if-missing` + `mix deps.get` on the fly before exec'ing `mix sessions`. The tool now self-heals its own first-run state — same pattern apt/cargo/pip/npm use.

## Why not the other options

See #53 for the full rationale. TL;DR:

- **Option 1 (shiv post-install hook).** Better long-term answer, but carries real security implications — arbitrary code execution at install time is a supply-chain attack surface. Tracked at KnickKnackLabs/shiv#99 for a real design discussion.
- **Option 3 (escript / OTP release).** Nicest end state, bigger lift. Queued as a follow-up.

## Changes

- **`lib/ensure-deps.sh` (new):** `ensure_cli_deps <cli_dir>` — returns 0 if populated, fetches if empty, errors with a hint to `mise run cli:build` if the fetch fails.
- **`.mise/tasks/run`:** sources the helper and calls it before `exec mix sessions …`.
- **`test/ensure-deps.bats` (new):** 7 tests covering populated, empty, missing-dir, missing-arg, nonexistent-dir, and broken-mix.exs paths.

## Testing

- `mise run test` → 161/161 green (was 154).
- Manual smoke test: copied sessions tree to `/tmp/fresh-sessions-smoke`, `rm -rf cli/deps cli/_build`, sourced the helper, called `ensure_cli_deps` — emitted the first-run notice, fetched all four deps (bunt, credo, file_system, jason) cleanly. `cli/deps/` populated as expected.

## Related symptom (out of scope)

While debugging the original report, I hit a separate failure mode: invoking `sessions wake` through a **mise-in-mise-in-mise chain** (`mise run self:wake` → `sessions wake` → `sessions run` → `mix`) fails with the same "Unchecked dependencies" error *even when `cli/deps/` is already populated*. Running `sessions wake` directly (not through an outer `mise run`) works fine. Root cause unclear — possibly stale MIX_* env vars or Elixir activation caching across nested mise invocations.

The defensive check in this PR masks that symptom too (deps are present → the check short-circuits → mix gets fresh env on the exec). I'm filing this observation as a follow-up note in my session log, not blocking this PR. Happy to dig in as a separate issue if it recurs after this ships.

## Related

- Issue: KnickKnackLabs/sessions#53 (includes ikma's full triage)
- Design discussion: KnickKnackLabs/shiv#99 (fresh-install framework + post-install hook security)
