### PR TITLE
Multi-harness step 3: claude adapter skeleton + UNSUPPORTED contract + task/lib hygiene

### DIFF
--- a/.mise/tasks/export
+++ b/.mise/tasks/export
@@ -1,8 +1,11 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 #MISE description="Export a session as a portable bundle (JSONL + metadata)"
 #USAGE arg "<session_id>" help="Session ID (prefix match supported)"
 #USAGE flag "--output <path>" help="Output directory (default: ./exports/)"
 #USAGE flag "--format <fmt>" default="bundle" help="Export format: bundle (JSONL+meta), markdown, jsonl"
+# /// script
+# requires-python = ">=3.10"
+# ///
 
 import json
 import os

--- a/.mise/tasks/import
+++ b/.mise/tasks/import
@@ -1,7 +1,10 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 #MISE description="Import a previously exported session bundle"
 #USAGE arg "<path>" help="Path to exported bundle directory or JSONL file"
 #USAGE flag "--project <project>" help="Target project directory name (required for JSONL imports)"
+# /// script
+# requires-python = ">=3.10"
+# ///
 
 import json
 import os

--- a/.mise/tasks/new
+++ b/.mise/tasks/new
@@ -55,7 +55,7 @@ source "$MISE_CONFIG_ROOT/lib/harness/$HARNESS_NAME.sh"
 
 SESSION_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
 NOW_ISO=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
-SESSION_FILE=$("harness_${HARNESS_NAME}_session_file_path" "$CWD_ABS" "$SESSION_ID" "$NOW_ISO")
+SESSION_FILE=$(harness_call "$HARNESS_NAME" session_file_path "$CWD_ABS" "$SESSION_ID" "$NOW_ISO")
 
 # --- Build meta object from --meta flags ---
 #
@@ -93,7 +93,7 @@ fi
 
 # --- Session header ---
 
-"harness_${HARNESS_NAME}_header_entry" "$SESSION_ID" "$NOW_ISO" "$CWD_ABS" "$NAME" "$META_JSON" > "$SESSION_FILE"
+harness_call "$HARNESS_NAME" header_entry "$SESSION_ID" "$NOW_ISO" "$CWD_ABS" "$NAME" "$META_JSON" > "$SESSION_FILE"
 
 # Harness declaration entry — records the active harness. Subsequent
 # readers (wake, run, read) use `harness_resolve` over this file to
@@ -103,12 +103,12 @@ harness_entry "$HARNESS_ENTRY_ID" "$SESSION_ID" "$NOW_ISO" "$HARNESS_NAME" >> "$
 
 # Model change entry
 MC_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
-"harness_${HARNESS_NAME}_model_change_entry" "$MC_ID" "$NOW_ISO" "$MODEL" >> "$SESSION_FILE"
+harness_call "$HARNESS_NAME" model_change_entry "$MC_ID" "$NOW_ISO" "$MODEL" >> "$SESSION_FILE"
 
 # Inject context as a user message if provided
 if [ -n "$CONTEXT" ]; then
   MSG_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
-  "harness_${HARNESS_NAME}_user_message_entry" "$MSG_ID" "$MC_ID" "$NOW_ISO" "$CONTEXT" >> "$SESSION_FILE"
+  harness_call "$HARNESS_NAME" user_message_entry "$MSG_ID" "$MC_ID" "$NOW_ISO" "$CONTEXT" >> "$SESSION_FILE"
 fi
 
 # --- Output ---

--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -12,7 +12,7 @@
 #USAGE flag "--skills" help="Enable pi skills (default: disabled)"
 #USAGE flag "--prompt-templates" help="Enable pi prompt templates (default: disabled)"
 
-set -e
+set -euo pipefail
 
 MESSAGE="${usage_message:-}"
 SYSTEM_PROMPT_FILE="${usage_system_prompt_file:-}"
@@ -33,7 +33,7 @@ if [ -z "$MESSAGE" ]; then
 fi
 
 # If no system prompt file provided but AGENT_IDENTITY is in env, write it to a temp file
-if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "$AGENT_IDENTITY" ]; then
+if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "${AGENT_IDENTITY:-}" ]; then
   SYSTEM_PROMPT_FILE=$(mktemp)
   echo "$AGENT_IDENTITY" > "$SYSTEM_PROMPT_FILE"
 
@@ -41,7 +41,7 @@ if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "$AGENT_IDENTITY" ]; then
 fi
 
 # Append dispatch context (outside the conditional — applies to any prompt file)
-if [ -n "$DISPATCH_CONTEXT" ] && [ -n "$SYSTEM_PROMPT_FILE" ]; then
+if [ -n "${DISPATCH_CONTEXT:-}" ] && [ -n "$SYSTEM_PROMPT_FILE" ]; then
   echo "" >> "$SYSTEM_PROMPT_FILE"
   echo "## Dispatch Context" >> "$SYSTEM_PROMPT_FILE"
   echo "This session was triggered by: $DISPATCH_CONTEXT" >> "$SYSTEM_PROMPT_FILE"

--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -35,10 +35,13 @@ fi
 
 command -v jq >/dev/null 2>&1 || { echo "Error: jq is required" >&2; exit 1; }
 
-if ! command -v sessions >/dev/null 2>&1; then
-  echo "Error: sessions not found on PATH" >&2
-  exit 1
-fi
+# Sibling-task dispatcher. Always call from the codebase that defined
+# *this* task (`$MISE_CONFIG_ROOT`) so we don't end up calling a stale
+# PATH-resolved `sessions` binary from a shiv install of a different
+# revision. The `-C` argument is required because wake later runs
+# `cd "$SESSION_CWD"` before the final exec — without `-C`, `mise run`
+# would look for tasks in the session cwd.
+mise_run=(mise -C "$MISE_CONFIG_ROOT" run -q)
 
 # --- Find session file ---
 
@@ -122,7 +125,7 @@ fi
 
 # --- Resolve working directory from session ---
 
-SESSION_CWD=$(sessions meta "${FULL_SESSION_ID:0:8}" --field .cwd 2>/dev/null) || true
+SESSION_CWD=$("${mise_run[@]}" meta "${FULL_SESSION_ID:0:8}" --field .cwd 2>/dev/null) || true
 if [ -z "$SESSION_CWD" ] || [ ! -d "$SESSION_CWD" ]; then
   echo "Warning: session cwd '$SESSION_CWD' not found, using current directory" >&2
   SESSION_CWD="."
@@ -130,7 +133,7 @@ fi
 
 # --- Launch ---
 
-RUN_CMD=(sessions run --session "$SESSION_FILE")
+RUN_CMD=("${mise_run[@]}" run --session "$SESSION_FILE")
 [ "$HEADLESS" = "true" ] && RUN_CMD+=(--headless)
 if [ -n "$MESSAGE" ]; then
   RUN_CMD+=("$MESSAGE")
@@ -148,7 +151,7 @@ if [ "$BACKGROUND" = "true" ]; then
   fi
   echo "Monitor: sessions read ${FULL_SESSION_ID:0:8} --last 10" >&2
 else
-  # Foreground: call sessions run directly (blocks until done)
+  # Foreground: call our own `run` task directly (blocks until done)
   echo "$FULL_SESSION_ID"
   if [ -n "$SESSION_NAME" ]; then
     echo "Woke session '$SESSION_NAME'" >&2

--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -117,7 +117,7 @@ if [ -n "$CONTEXT" ]; then
   LAST_ID="$WAKE_ID"
   MSG_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
 
-  "harness_${HARNESS_NAME}_user_message_entry" "$MSG_ID" "$LAST_ID" "$NOW_ISO" "$CONTEXT" >> "$SESSION_FILE"
+  harness_call "$HARNESS_NAME" user_message_entry "$MSG_ID" "$LAST_ID" "$NOW_ISO" "$CONTEXT" >> "$SESSION_FILE"
 fi
 
 # --- Resolve working directory from session ---

--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -25,7 +25,17 @@ defmodule Cli do
       print_help()
       0
     else
-      run_with_opts(opts, rest)
+      try do
+        run_with_opts(opts, rest)
+      rescue
+        e in Cli.Harness.UnsupportedError ->
+          # Clean UNSUPPORTED path: short message to stderr, reserved
+          # exit code so wrapping shells can branch. No stacktrace —
+          # this is an expected "not yet implemented for this adapter"
+          # signal, not a bug.
+          IO.puts(:stderr, "sessions: #{Exception.message(e)}")
+          Cli.Harness.UnsupportedError.exit_code()
+      end
     end
   end
 

--- a/cli/lib/harness.ex
+++ b/cli/lib/harness.ex
@@ -1,3 +1,30 @@
+defmodule Cli.Harness.UnsupportedError do
+  @moduledoc """
+  Raised by adapter functions that don't implement a given operation
+  for this harness.
+
+  Mirrors `harness_unsupported` (bash, exit 10) and `harness.Unsupported`
+  (Python). The CLI boundary rescues this, prints a clean message, and
+  halts with exit code 10 so wrapping shells can branch.
+  """
+
+  # Reserved exit code — stay in sync with `HARNESS_UNSUPPORTED_EXIT` in
+  # `lib/harness/dispatch.sh` and `UNSUPPORTED_EXIT` in
+  # `lib/harness/__init__.py`.
+  @exit_code 10
+  def exit_code, do: @exit_code
+
+  defexception [:harness, :op, :message]
+
+  @impl true
+  def exception(opts) do
+    harness = Keyword.fetch!(opts, :harness)
+    op = Keyword.fetch!(opts, :op)
+    msg = "'#{harness}' harness does not support '#{op}' yet"
+    %__MODULE__{harness: harness, op: op, message: msg}
+  end
+end
+
 defmodule Cli.Harness do
   @moduledoc """
   Harness dispatch layer (Elixir). Mirrors `lib/harness/dispatch.sh` and

--- a/cli/lib/harness.ex
+++ b/cli/lib/harness.ex
@@ -46,7 +46,7 @@ defmodule Cli.Harness do
   """
 
   @default :pi
-  @adapters %{pi: Cli.Harness.Pi}
+  @adapters %{pi: Cli.Harness.Pi, claude: Cli.Harness.Claude}
 
   @spec available() :: [atom()]
   def available, do: @adapters |> Map.keys() |> Enum.sort()
@@ -133,36 +133,44 @@ defmodule Cli.Harness do
   # three together when editing.
   #
   # Each prefix candidate ends with a `/` so `~/.pi-alt/...` does not
-  # get claimed by the pi adapter. Both `$PI_DIR` and the literal
-  # `$HOME/.pi` path are checked, because the environment override and
-  # the default location can coexist (e.g. a user with a custom PI_DIR
-  # who still has legacy sessions under ~/.pi).
+  # get claimed by the pi adapter. Both the env override (`$PI_DIR` /
+  # `$CLAUDE_DIR`) and the literal `$HOME/.<name>` path are checked, so
+  # a user with a custom override and legacy sessions under the default
+  # location both resolve.
   def from_path(path) when is_binary(path) do
+    rules = [
+      {:pi, "PI_DIR", "/.pi/"},
+      {:claude, "CLAUDE_DIR", "/.claude/"}
+    ]
+
+    Enum.find_value(rules, fn {name, env_var, home_suffix} ->
+      if path_matches?(path, env_var, home_suffix), do: name, else: nil
+    end)
+  end
+
+  defp path_matches?(path, env_var, home_suffix) do
     home = System.get_env("HOME")
 
     # Bypass Path.join here — `Path.join(home, ".pi/")` strips the
     # trailing separator, which would re-introduce the `~/.pi-alt/...`
     # false-positive we added the trailing slash to prevent.
-    home_pi = if home && home != "", do: home <> "/.pi/", else: nil
+    home_prefix = if home && home != "", do: home <> home_suffix, else: nil
 
-    env_pi = System.get_env("PI_DIR")
+    env_override = System.get_env(env_var)
 
-    env_pi_slash =
-      if env_pi && env_pi != "" do
-        String.trim_trailing(env_pi, "/") <> "/"
+    env_prefix =
+      if env_override && env_override != "" do
+        String.trim_trailing(env_override, "/") <> "/"
       else
         nil
       end
 
     candidates =
-      [env_pi_slash, home_pi]
+      [env_prefix, home_prefix]
       |> Enum.reject(&is_nil/1)
       |> Enum.uniq()
 
-    cond do
-      Enum.any?(candidates, &String.starts_with?(path, &1)) -> :pi
-      true -> nil
-    end
+    Enum.any?(candidates, &String.starts_with?(path, &1))
   end
 
   @doc false

--- a/cli/lib/harness/claude.ex
+++ b/cli/lib/harness/claude.ex
@@ -1,0 +1,28 @@
+defmodule Cli.Harness.Claude do
+  @moduledoc """
+  Claude harness adapter — step 3 skeleton.
+
+  Every function raises `Cli.Harness.UnsupportedError`. The CLI
+  boundary (`Cli.run/1`) rescues it and exits with the reserved
+  UNSUPPORTED exit code. Step 5 will fill in a real command builder
+  and stream parser for `claude -p --output-format stream-json`.
+  """
+
+  alias Cli.Harness.UnsupportedError
+
+  def build_command(_message, _model, _system_prompt_file, _session, _timeout, _opts) do
+    raise UnsupportedError, harness: :claude, op: :build_command
+  end
+
+  def default_model do
+    raise UnsupportedError, harness: :claude, op: :default_model
+  end
+
+  def process_line(_line, _state) do
+    raise UnsupportedError, harness: :claude, op: :process_line
+  end
+
+  def extract_partial_text(_partial) do
+    raise UnsupportedError, harness: :claude, op: :extract_partial_text
+  end
+end

--- a/cli/test/harness_test.exs
+++ b/cli/test/harness_test.exs
@@ -3,6 +3,22 @@ defmodule Cli.HarnessTest do
   # async: false — we mutate process environment variables.
 
   alias Cli.Harness
+  alias Cli.Harness.UnsupportedError
+
+  # --- UNSUPPORTED exception ---
+
+  describe "UnsupportedError" do
+    test "exit_code/0 matches the bash/python contract (10)" do
+      assert UnsupportedError.exit_code() == 10
+    end
+
+    test "exception carries harness, op, and a readable message" do
+      e = UnsupportedError.exception(harness: :claude, op: :build_command)
+      assert e.harness == :claude
+      assert e.op == :build_command
+      assert Exception.message(e) =~ "'claude' harness does not support 'build_command' yet"
+    end
+  end
 
   # --- Registry ---
 

--- a/cli/test/harness_test.exs
+++ b/cli/test/harness_test.exs
@@ -23,8 +23,8 @@ defmodule Cli.HarnessTest do
   # --- Registry ---
 
   describe "available/0" do
-    test "returns :pi today, sorted" do
-      assert Harness.available() == [:pi]
+    test "returns registered adapters, sorted" do
+      assert Harness.available() == [:claude, :pi]
     end
   end
 
@@ -33,9 +33,13 @@ defmodule Cli.HarnessTest do
       assert Harness.adapter(:pi) == Cli.Harness.Pi
     end
 
+    test "returns the claude adapter module" do
+      assert Harness.adapter(:claude) == Cli.Harness.Claude
+    end
+
     test "raises on unknown name" do
       assert_raise ArgumentError, ~r/Unknown harness/, fn ->
-        Harness.adapter(:claude)
+        Harness.adapter(:xyz)
       end
     end
   end
@@ -55,9 +59,10 @@ defmodule Cli.HarnessTest do
 
     test "explicit :name as string is validated against the adapter list" do
       assert Harness.resolve(name: "pi") == Cli.Harness.Pi
+      assert Harness.resolve(name: "claude") == Cli.Harness.Claude
 
-      assert_raise ArgumentError, ~r/Unknown harness "claude" from name: option/, fn ->
-        Harness.resolve(name: "claude")
+      assert_raise ArgumentError, ~r/Unknown harness "xyz" from name: option/, fn ->
+        Harness.resolve(name: "xyz")
       end
     end
 

--- a/cli/test/harness_test.exs
+++ b/cli/test/harness_test.exs
@@ -107,10 +107,12 @@ defmodule Cli.HarnessTest do
     end
 
     test "path-based detection requires a `/` separator after the prefix" do
-      # TODO(step 3): when a second adapter exists, strengthen this test
-      # so the resolver returning :pi via the *path rule* is distinguishable
-      # from it returning :pi via the compile-time default. Today both
-      # produce the same answer.
+      # With two adapters registered, this test now bites: a path
+      # under `$CLAUDE_DIR-alt/` must NOT resolve to :claude. If the
+      # rule were loose (prefix match without the separator), it
+      # would; if the rule is right, resolve/1 falls through past the
+      # path rule and lands on the compile-time default (:pi). That's
+      # a distinguishable outcome.
       base = System.tmp_dir!() |> Path.join("harness-test-base-#{System.unique_integer([:positive])}")
       alt = base <> "-alt"
       File.mkdir_p!(base)
@@ -121,7 +123,10 @@ defmodule Cli.HarnessTest do
       """)
 
       try do
-        with_env(%{"PI_DIR" => base, "SESSIONS_DEFAULT_HARNESS" => nil}, fn ->
+        with_env(%{"CLAUDE_DIR" => base, "SESSIONS_DEFAULT_HARNESS" => nil}, fn ->
+          # If the path rule incorrectly claimed the -alt directory,
+          # this would resolve to Cli.Harness.Claude. It doesn't —
+          # proving the rule correctly requires the trailing separator.
           assert Harness.resolve(session: legacy_under_alt) == Cli.Harness.Pi
         end)
       after
@@ -139,6 +144,39 @@ defmodule Cli.HarnessTest do
     test "from_path matches under $PI_DIR with a separator" do
       with_env(%{"PI_DIR" => "/custom/pi"}, fn ->
         assert Harness.from_path("/custom/pi/agent/sessions/foo.jsonl") == :pi
+      end)
+    end
+
+    # --- Claude path rules (mirror the pi coverage above) ---
+
+    test "from_path matches under $CLAUDE_DIR with a separator" do
+      with_env(%{"CLAUDE_DIR" => "/custom/claude"}, fn ->
+        assert Harness.from_path("/custom/claude/projects/foo.jsonl") == :claude
+      end)
+    end
+
+    test "from_path rejects sibling of $CLAUDE_DIR (no trailing-slash false positive)" do
+      with_env(%{"CLAUDE_DIR" => "/custom/claude", "HOME" => "/nonexistent"}, fn ->
+        assert Harness.from_path("/custom/claude-alt/projects/foo.jsonl") == nil
+      end)
+    end
+
+    test "from_path matches under $HOME/.claude when CLAUDE_DIR is unset" do
+      with_env(%{"CLAUDE_DIR" => nil, "HOME" => "/fake/home"}, fn ->
+        assert Harness.from_path("/fake/home/.claude/projects/foo.jsonl") == :claude
+      end)
+    end
+
+    test "from_path rejects $HOME/.claude-alt even when CLAUDE_DIR is unset" do
+      with_env(%{"CLAUDE_DIR" => nil, "HOME" => "/fake/home"}, fn ->
+        assert Harness.from_path("/fake/home/.claude-alt/projects/foo.jsonl") == nil
+      end)
+    end
+
+    test "from_path treats CLAUDE_DIR=\"\" the same as unset" do
+      with_env(%{"CLAUDE_DIR" => "", "HOME" => "/fake/home"}, fn ->
+        assert Harness.from_path("/etc/passwd") == nil
+        assert Harness.from_path("/fake/home/.claude/foo.jsonl") == :claude
       end)
     end
 

--- a/lib/find.sh
+++ b/lib/find.sh
@@ -26,6 +26,14 @@
 # Self-locate relative to this file. Don't reach for $MISE_CONFIG_ROOT:
 # that's a task-execution variable and callers from a test context may
 # have a polluted value (see KnickKnackLabs/codebase#16).
+#
+# Caveat: bash `cd` is logical by default, so if this file is accessed
+# via a symlink the result is the symlink's parent, not the target's.
+# Sessions is installed via shiv, which uses file-level regular files
+# under a versioned package dir; the only symlinks are at the
+# package-version level (`latest -> 0.3.0`) which doesn't affect
+# sibling sourcing. If we ever ship configurations where lib/*.sh is
+# individually symlinked, switch to `realpath` or `readlink -f`.
 _FIND_SH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # shellcheck source=/dev/null

--- a/lib/find.sh
+++ b/lib/find.sh
@@ -23,8 +23,13 @@
 #
 # Used by: .mise/tasks/wake (and anything else that sources this file).
 
+# Self-locate relative to this file. Don't reach for $MISE_CONFIG_ROOT:
+# that's a task-execution variable and callers from a test context may
+# have a polluted value (see KnickKnackLabs/codebase#16).
+_FIND_SH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # shellcheck source=/dev/null
-source "$MISE_CONFIG_ROOT/lib/harness/dispatch.sh"
+source "$_FIND_SH_DIR/harness/dispatch.sh"
 
 find_session_file() {
   local query="$1"

--- a/lib/harness/__init__.py
+++ b/lib/harness/__init__.py
@@ -17,8 +17,39 @@ same surface — see `pi.py` for the reference.
 
 import importlib
 import os
+import sys
 
 DEFAULT = "pi"
+
+# Reserved exit code for UNSUPPORTED operations. Mirrored in
+# `lib/harness/dispatch.sh` (HARNESS_UNSUPPORTED_EXIT=10) and
+# `Cli.Harness.UnsupportedError` (Elixir).
+UNSUPPORTED_EXIT = 10
+
+
+class Unsupported(Exception):
+    """Raised by adapter functions that don't implement a given operation.
+
+    Adapters raise this with a short, user-facing message; the CLI
+    entry point catches it, prints the message, and exits with
+    `UNSUPPORTED_EXIT`. Aggregator code (e.g. `parse.find_session`) may
+    catch it earlier to skip adapters that can't contribute to the
+    aggregate — see call sites for which semantics apply.
+    """
+
+
+def exit_unsupported(harness: str, op: str) -> None:
+    """Print the clean UNSUPPORTED message and exit the process.
+
+    Call from CLI entry points after catching an `Unsupported` raised
+    deep in an adapter. Kept here (not duplicated across .mise/tasks)
+    so the wording is uniform.
+    """
+    print(
+        f"sessions: '{harness}' harness does not support '{op}' yet",
+        file=sys.stderr,
+    )
+    sys.exit(UNSUPPORTED_EXIT)
 
 
 # --- Registry ---

--- a/lib/harness/__init__.py
+++ b/lib/harness/__init__.py
@@ -30,12 +30,26 @@ UNSUPPORTED_EXIT = 10
 class Unsupported(Exception):
     """Raised by adapter functions that don't implement a given operation.
 
-    Adapters raise this with a short, user-facing message; the CLI
-    entry point catches it, prints the message, and exits with
-    `UNSUPPORTED_EXIT`. Aggregator code (e.g. `parse.find_session`) may
-    catch it earlier to skip adapters that can't contribute to the
-    aggregate — see call sites for which semantics apply.
+    Carries structured fields (`op` and optionally `harness`) so catch
+    sites can inspect them — mirrors `Cli.Harness.UnsupportedError` in
+    Elixir. Back-compat: `raise Unsupported("op_name")` still works;
+    `raise Unsupported("op_name", harness="claude")` adds the harness
+    for structured access and produces a richer message.
+
+    Adapters raise this with a short, user-facing identifier; the CLI
+    entry point (or `exit_unsupported` below) owns the final wording
+    and exit.
     """
+
+    def __init__(self, op: str, harness: str = ""):
+        self.op = op
+        self.harness = harness
+        message = (
+            f"'{harness}' harness does not support '{op}' yet"
+            if harness
+            else op
+        )
+        super().__init__(message)
 
 
 def exit_unsupported(harness: str, op: str) -> None:

--- a/lib/harness/__init__.py
+++ b/lib/harness/__init__.py
@@ -89,25 +89,30 @@ def _from_entries(entries: list):
 def _from_path(filepath: str):
     """Infer harness from a path prefix. Returns None if no rule matches.
 
-    Requires a trailing `/` after the prefix so `~/.pi-alt/...` does not
-    get claimed by the pi adapter. Kept in sync with `lib/harness/dispatch.sh`
-    and `cli/lib/harness.ex` — review all three together when editing.
+    Each prefix candidate ends with a `/` so `~/.pi-alt/...` does not
+    get claimed by the pi adapter. Kept in sync with
+    `lib/harness/dispatch.sh` and `cli/lib/harness.ex` — review all
+    three together when editing.
+
+    `PI_DIR=""` / `CLAUDE_DIR=""` are treated as unset, not as `"/"`
+    (which would match every absolute path).
     """
     if not filepath:
         return None
-    # `os.environ.get(..., default)` returns the default only for *missing*
-    # keys; an empty-string value still wins. Guard explicitly so
-    # `PI_DIR=""` doesn't collapse the prefix to `"/"` (which would
-    # match every absolute path).
-    env_pi = os.environ.get("PI_DIR") or None
-    home_pi = os.path.expanduser("~/.pi")
-    candidates = set()
-    if env_pi:
-        candidates.add(env_pi.rstrip("/") + "/")
-    candidates.add(home_pi.rstrip("/") + "/")
-    if any(filepath.startswith(p) for p in candidates):
-        return "pi"
-    # Future: ~/.claude/... → claude
+
+    for harness_name, env_var, default_home in (
+        ("pi", "PI_DIR", "~/.pi"),
+        ("claude", "CLAUDE_DIR", "~/.claude"),
+    ):
+        env_override = os.environ.get(env_var) or None
+        home_default = os.path.expanduser(default_home)
+        candidates = set()
+        if env_override:
+            candidates.add(env_override.rstrip("/") + "/")
+        candidates.add(home_default.rstrip("/") + "/")
+        if any(filepath.startswith(p) for p in candidates):
+            return harness_name
+
     return None
 
 

--- a/lib/harness/claude.py
+++ b/lib/harness/claude.py
@@ -1,0 +1,79 @@
+"""
+Claude harness adapter (Python) — step 3 skeleton.
+
+Every function raises `Unsupported`. The structural behaviour that
+allows the cross-adapter aggregator (`parse.find_session`) to keep
+working is provided by `find_session` returning `None` instead of
+raising.
+
+Step 4 (claude new + wake) will fill in the real behaviour.
+"""
+
+from harness import Unsupported
+
+
+# --- Entry-level schema ---
+
+def is_message_entry(entry: dict) -> bool:
+    raise Unsupported("is_message_entry")
+
+
+def messages(entries: list) -> list:
+    raise Unsupported("messages")
+
+
+def session_id(entries: list, filepath: str) -> str:
+    raise Unsupported("session_id")
+
+
+def name(entries: list) -> str:
+    raise Unsupported("name")
+
+
+def meta(entries: list) -> dict:
+    raise Unsupported("meta")
+
+
+def slug() -> str:
+    raise Unsupported("slug")
+
+
+def model(entries: list) -> str:
+    raise Unsupported("model")
+
+
+def project(filepath: str) -> str:
+    raise Unsupported("project")
+
+
+def first_timestamp(entries: list) -> str:
+    raise Unsupported("first_timestamp")
+
+
+def last_timestamp(entries: list) -> str:
+    raise Unsupported("last_timestamp")
+
+
+def message_counts(entries: list) -> tuple:
+    raise Unsupported("message_counts")
+
+
+def text_messages(entries: list) -> list:
+    raise Unsupported("text_messages")
+
+
+# --- Location / lookup ---
+
+def sessions_dir() -> str:
+    raise Unsupported("sessions_dir")
+
+
+def find_session(query: str):
+    """Structural stub: no claude sessions exist yet.
+
+    Unlike the other functions, this returns a sane "no match" sentinel
+    rather than raising — `parse.find_session` iterates every registered
+    adapter and would break lookup for pi sessions if claude raised.
+    Step 4 will implement the real scan against claude's on-disk layout.
+    """
+    return None

--- a/lib/harness/claude.py
+++ b/lib/harness/claude.py
@@ -15,57 +15,57 @@ from harness import Unsupported
 # --- Entry-level schema ---
 
 def is_message_entry(entry: dict) -> bool:
-    raise Unsupported("is_message_entry")
+    raise Unsupported("is_message_entry", harness="claude")
 
 
 def messages(entries: list) -> list:
-    raise Unsupported("messages")
+    raise Unsupported("messages", harness="claude")
 
 
 def session_id(entries: list, filepath: str) -> str:
-    raise Unsupported("session_id")
+    raise Unsupported("session_id", harness="claude")
 
 
 def name(entries: list) -> str:
-    raise Unsupported("name")
+    raise Unsupported("name", harness="claude")
 
 
 def meta(entries: list) -> dict:
-    raise Unsupported("meta")
+    raise Unsupported("meta", harness="claude")
 
 
 def slug() -> str:
-    raise Unsupported("slug")
+    raise Unsupported("slug", harness="claude")
 
 
 def model(entries: list) -> str:
-    raise Unsupported("model")
+    raise Unsupported("model", harness="claude")
 
 
 def project(filepath: str) -> str:
-    raise Unsupported("project")
+    raise Unsupported("project", harness="claude")
 
 
 def first_timestamp(entries: list) -> str:
-    raise Unsupported("first_timestamp")
+    raise Unsupported("first_timestamp", harness="claude")
 
 
 def last_timestamp(entries: list) -> str:
-    raise Unsupported("last_timestamp")
+    raise Unsupported("last_timestamp", harness="claude")
 
 
 def message_counts(entries: list) -> tuple:
-    raise Unsupported("message_counts")
+    raise Unsupported("message_counts", harness="claude")
 
 
 def text_messages(entries: list) -> list:
-    raise Unsupported("text_messages")
+    raise Unsupported("text_messages", harness="claude")
 
 
 # --- Location / lookup ---
 
 def sessions_dir() -> str:
-    raise Unsupported("sessions_dir")
+    raise Unsupported("sessions_dir", harness="claude")
 
 
 def find_session(query: str):

--- a/lib/harness/claude.sh
+++ b/lib/harness/claude.sh
@@ -17,7 +17,7 @@
 # claude` therefore fails fast at session_file_path — before any
 # directory creation or file write — with a clean UNSUPPORTED message.
 #
-# Usage:
+# Usage (from task scripts, where $MISE_CONFIG_ROOT is set by mise):
 #   source "$MISE_CONFIG_ROOT/lib/harness/claude.sh"
 
 # --- Location ---

--- a/lib/harness/claude.sh
+++ b/lib/harness/claude.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Claude harness adapter for sessions (step 3 skeleton).
+#
+# This file is the authoritative home for claude-specific knowledge.
+# At step 3 it's a skeleton: every function that depends on claude's
+# on-disk layout or JSONL schema returns UNSUPPORTED. Step 4 (claude
+# new + wake) will fill in the real behaviour.
+#
+# What's structural (not UNSUPPORTED) at step 3:
+#   - harness_claude_find_session — the cross-adapter find aggregator
+#     walks every registered adapter; UNSUPPORTED here would break
+#     lookup for pi sessions. Returns "no match" unconditionally until
+#     step 4 knows what to look at.
+#
+# Everything else (sessions_dir, encode_cwd, session_file_path, and
+# the native entry builders) is UNSUPPORTED. `sessions new --harness
+# claude` therefore fails fast at session_file_path — before any
+# directory creation or file write — with a clean UNSUPPORTED message.
+#
+# Usage:
+#   source "$MISE_CONFIG_ROOT/lib/harness/claude.sh"
+
+# --- Location ---
+
+harness_claude_sessions_dir() {
+  harness_unsupported
+}
+
+harness_claude_encode_cwd() {
+  harness_unsupported
+}
+
+harness_claude_session_file_path() {
+  harness_unsupported
+}
+
+# --- Lookup ---
+
+# Contract matches pi's: stdout = match path, exit 0 = unique match,
+# exit 1 = no match, exit 2 = within-adapter ambiguity. Step 3 always
+# returns "no match" — no claude sessions exist yet.
+harness_claude_find_session() {
+  return 1
+}
+
+# --- Entry builders ---
+
+harness_claude_header_entry() {
+  harness_unsupported
+}
+
+harness_claude_model_change_entry() {
+  harness_unsupported
+}
+
+harness_claude_user_message_entry() {
+  harness_unsupported
+}

--- a/lib/harness/dispatch.sh
+++ b/lib/harness/dispatch.sh
@@ -29,10 +29,17 @@
 #   4. $SESSIONS_DEFAULT_HARNESS environment variable
 #   5. Compile-time default: "pi"
 #
-# Usage:
+# Usage (from task scripts, where $MISE_CONFIG_ROOT is set by mise):
 #   source "$MISE_CONFIG_ROOT/lib/harness/dispatch.sh"
 #   name=$(harness_resolve --session "$SESSION_FILE" --flag "$HARNESS_FLAG")
 #   source "$MISE_CONFIG_ROOT/lib/harness/$name.sh"
+
+# Source guard — this file is sometimes sourced via two paths in the
+# same shell (wake sources dispatch.sh directly, then sources find.sh
+# which in turn re-sources dispatch.sh). Redefining functions is
+# harmless but burns cycles; the guard skips the re-run.
+[ -n "${_DISPATCH_SH_LOADED:-}" ] && return 0
+_DISPATCH_SH_LOADED=1
 
 # Self-locate: this file IS `lib/harness/dispatch.sh`, so its own
 # directory is the harness lib dir. The env override (HARNESS_LIB_DIR)

--- a/lib/harness/dispatch.sh
+++ b/lib/harness/dispatch.sh
@@ -37,6 +37,46 @@
 HARNESS_LIB_DIR="${HARNESS_LIB_DIR:-$MISE_CONFIG_ROOT/lib/harness}"
 HARNESS_DEFAULT="pi"
 
+# --- UNSUPPORTED contract ---
+#
+# Adapters that don't (yet) implement a given operation signal so via a
+# reserved exit code. Callers of adapter functions should go through
+# `harness_call` (below), which turns the reserved code into a clean
+# user-facing error and exits with the same code so wrapping scripts
+# can branch on it. Mirrors `Unsupported` in `lib/harness/__init__.py`
+# and `Cli.Harness.UnsupportedError` in `cli/lib/harness.ex`.
+HARNESS_UNSUPPORTED_EXIT=10
+
+# Adapter helper — use inside an adapter function to signal that this
+# operation isn't supported by this harness. Writes nothing to stdout;
+# the caller's `harness_call` wrapper owns the user-facing message.
+harness_unsupported() {
+  return "$HARNESS_UNSUPPORTED_EXIT"
+}
+
+# Call an adapter function with UNSUPPORTED handling.
+#
+# Usage: harness_call <harness> <fn_suffix> [args...]
+#   e.g. harness_call pi header_entry "$id" "$ts" "$cwd"
+#
+# - Passes through stdout and stderr from the adapter function.
+# - On the reserved UNSUPPORTED exit code, prints a clean message to
+#   stderr and exits the current shell with the same code (so `set -e`
+#   callers fail fast with a useful error).
+# - Any other exit code is returned as-is; the caller can decide.
+harness_call() {
+  local harness="$1" fn_suffix="$2"
+  shift 2
+  local fn="harness_${harness}_${fn_suffix}"
+  local rc=0
+  "$fn" "$@" || rc=$?
+  if [ "$rc" -eq "$HARNESS_UNSUPPORTED_EXIT" ]; then
+    echo "sessions: '$harness' harness does not support '$fn_suffix' yet" >&2
+    exit "$HARNESS_UNSUPPORTED_EXIT"
+  fi
+  return "$rc"
+}
+
 # --- Registry ---
 
 # List available harnesses (sorted, one per line). An adapter is

--- a/lib/harness/dispatch.sh
+++ b/lib/harness/dispatch.sh
@@ -115,20 +115,29 @@ harness_of_session() {
 # Path-based detection. Given a session file path, guess the harness
 # from a path prefix. Prints the harness name or empty if no rule
 # matches.
+#
+# Kept in sync with `lib/harness/__init__.py::_from_path` and
+# `Cli.Harness.from_path/1` — review all three together when editing.
+#
+# Each prefix is normalised to end with `/` so `~/.pi-alt/...` does not
+# get claimed by the pi adapter. $PI_DIR='' and $CLAUDE_DIR='' are
+# treated as unset (not as `/`, which would match every absolute path).
 harness_from_path() {
   local path="$1"
   [ -n "$path" ] || return 0
-  # Pi sessions live under ~/.pi/agent/sessions (or $PI_DIR/agent/sessions).
-  # Strip any trailing slash so `PI_DIR=/opt/custom-pi/` still matches
-  # `/opt/custom-pi/agent/sessions/...` (case pattern `//*` wouldn't).
-  # `${PI_DIR:-...}` also protects against `PI_DIR=""` silently becoming
-  # `/` — an empty value is treated the same as unset.
+
   local pi_dir="${PI_DIR:-$HOME/.pi}"
   pi_dir="${pi_dir%/}"
   case "$path" in
     "$pi_dir"/*|"$HOME"/.pi/*) echo "pi"; return 0 ;;
   esac
-  # Future: ~/.claude/... → claude
+
+  local claude_dir="${CLAUDE_DIR:-$HOME/.claude}"
+  claude_dir="${claude_dir%/}"
+  case "$path" in
+    "$claude_dir"/*|"$HOME"/.claude/*) echo "claude"; return 0 ;;
+  esac
+
   return 0
 }
 

--- a/lib/harness/dispatch.sh
+++ b/lib/harness/dispatch.sh
@@ -34,7 +34,13 @@
 #   name=$(harness_resolve --session "$SESSION_FILE" --flag "$HARNESS_FLAG")
 #   source "$MISE_CONFIG_ROOT/lib/harness/$name.sh"
 
-HARNESS_LIB_DIR="${HARNESS_LIB_DIR:-$MISE_CONFIG_ROOT/lib/harness}"
+# Self-locate: this file IS `lib/harness/dispatch.sh`, so its own
+# directory is the harness lib dir. The env override (HARNESS_LIB_DIR)
+# still wins — tests set it to point at test fixtures — but the
+# fallback no longer depends on $MISE_CONFIG_ROOT, which can be
+# polluted when libs are sourced from a test context (see
+# KnickKnackLabs/codebase#16).
+HARNESS_LIB_DIR="${HARNESS_LIB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 HARNESS_DEFAULT="pi"
 
 # --- UNSUPPORTED contract ---

--- a/lib/harness/pi.sh
+++ b/lib/harness/pi.sh
@@ -14,7 +14,7 @@
 # All functions are prefixed `harness_pi_` to keep the namespace clean
 # when dispatched from a generic harness loader.
 #
-# Usage:
+# Usage (from task scripts, where $MISE_CONFIG_ROOT is set by mise):
 #   source "$MISE_CONFIG_ROOT/lib/harness/pi.sh"
 
 # --- Location ---

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,5 @@
+min_version = "2026.3.0"
+
 [settings]
 quiet = true
 task_output = "interleave"

--- a/test/ensure-deps.bats
+++ b/test/ensure-deps.bats
@@ -5,10 +5,10 @@
 load helpers
 
 setup() {
-  # Source the helper under test. Using MISE_CONFIG_ROOT guarantees we're
-  # sourcing the version in the tree being tested (not the shiv-installed
-  # one), consistent with how `.mise/tasks/run` resolves it.
-  source "$MISE_CONFIG_ROOT/lib/ensure-deps.sh"
+  # Source the helper under test. $REPO_DIR is derived from
+  # $BATS_TEST_DIRNAME (see test/helpers.bash), which pins us to the
+  # tree being tested regardless of how the suite was invoked.
+  source "$REPO_DIR/lib/ensure-deps.sh"
 
   TMP=$(mktemp -d)
   CLI="$TMP/cli"

--- a/test/harness_dispatch.bats
+++ b/test/harness_dispatch.bats
@@ -13,8 +13,8 @@ setup() {
   # Tests that go through `sessions new` don't need this — they use the
   # wrapper — but the resolver unit tests do.
   # shellcheck source=/dev/null
-  export HARNESS_LIB_DIR="$MISE_CONFIG_ROOT/lib/harness"
-  source "$MISE_CONFIG_ROOT/lib/harness/dispatch.sh"
+  export HARNESS_LIB_DIR="$REPO_DIR/lib/harness"
+  source "$REPO_DIR/lib/harness/dispatch.sh"
 }
 
 teardown() {
@@ -325,7 +325,7 @@ JSONL
 JSONL
 
   # shellcheck source=/dev/null
-  source "$MISE_CONFIG_ROOT/lib/find.sh"
+  source "$REPO_DIR/lib/find.sh"
   run find_session_file duplicate-name
   [ "$status" -ne 0 ]
   # The ambiguity message from the pi adapter must reach the caller —
@@ -386,7 +386,7 @@ JSONL
   run bash -c '
     source "$1/lib/harness/dispatch.sh"
     harness_unsupported
-  ' _ "$MISE_CONFIG_ROOT"
+  ' _ "$REPO_DIR"
   [ "$status" -eq 10 ]
   [ -z "$output" ]
 }
@@ -396,7 +396,7 @@ JSONL
     source "$1/lib/harness/dispatch.sh"
     harness_fake_ok() { echo "hello from fake"; }
     harness_call fake ok
-  ' _ "$MISE_CONFIG_ROOT"
+  ' _ "$REPO_DIR"
   [ "$status" -eq 0 ]
   [ "$output" = "hello from fake" ]
 }
@@ -407,7 +407,7 @@ JSONL
     harness_skel_header_entry() { harness_unsupported; }
     harness_call skel header_entry
     echo "should not reach"
-  ' _ "$MISE_CONFIG_ROOT"
+  ' _ "$REPO_DIR"
   [ "$status" -eq 10 ]
   echo "$output" | grep -qi "'skel' harness does not support 'header_entry'"
   # Ensure we really exited, not just returned.
@@ -422,7 +422,7 @@ JSONL
     source "$1/lib/harness/dispatch.sh"
     harness_fake_emit() { echo "payload"; }
     harness_call fake emit > "$2"
-  ' _ "$MISE_CONFIG_ROOT" "$tmp"
+  ' _ "$REPO_DIR" "$tmp"
   [ "$(cat "$tmp")" = "payload" ]
 }
 
@@ -435,7 +435,7 @@ JSONL
     harness_fake_boom() { return 3; }
     harness_call fake boom || echo "got rc=$?"
     echo "kept going"
-  ' _ "$MISE_CONFIG_ROOT"
+  ' _ "$REPO_DIR"
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "got rc=3"
   echo "$output" | grep -q "kept going"

--- a/test/harness_dispatch.bats
+++ b/test/harness_dispatch.bats
@@ -291,7 +291,8 @@ JSONL
   # entry then wins over path-based detection (see the priority test
   # above), so wake dispatches to claude — which errors UNSUPPORTED
   # when the Elixir run path asks claude for its default model.
-  command -v shell >/dev/null 2>&1 || skip "shell not installed"
+  # Foreground wake (no --background) — execs mise run directly, so
+  # `shell` isn't required.
 
   local sid="cccccccc-3333-3333-3333-333333333333"
   local sf="$PI_DIR/agent/sessions/--claude-acceptance--/2026-04-22T10-00-00-000Z_${sid}.jsonl"

--- a/test/harness_dispatch.bats
+++ b/test/harness_dispatch.bats
@@ -75,17 +75,32 @@ JSONL
 }
 
 @test "resolver picks most recent harness entry when multiple present" {
+  # Two-adapter version: earlier entry is pi, later entry is claude.
+  # Before claude existed, this test could only prove "pi→pi" (a
+  # tautology). With two adapters registered, we can actually assert
+  # the most-recent entry wins over an older one of a different kind.
   sf="$BATS_TEST_TMPDIR/session.jsonl"
   cat > "$sf" <<JSONL
 {"type":"session","id":"abc"}
 {"type":"harness","id":"h1","parentId":"abc","timestamp":"2026-04-22T10:00:00.000Z","name":"pi"}
 {"type":"model_change","id":"mc1"}
 {"type":"wake","id":"w1"}
-{"type":"harness","id":"h2","parentId":"w1","timestamp":"2026-04-22T11:00:00.000Z","name":"pi"}
+{"type":"harness","id":"h2","parentId":"w1","timestamp":"2026-04-22T11:00:00.000Z","name":"claude"}
 JSONL
   run harness_resolve --session "$sf"
   [ "$status" -eq 0 ]
-  [ "$output" = "pi" ]
+  [ "$output" = "claude" ]
+}
+
+@test "resolver reads a claude harness entry from the session file" {
+  sf="$BATS_TEST_TMPDIR/session.jsonl"
+  cat > "$sf" <<JSONL
+{"type":"session","version":3,"id":"abc","timestamp":"2026-04-22T10:00:00.000Z","cwd":"/tmp"}
+{"type":"harness","id":"h1","parentId":"abc","timestamp":"2026-04-22T10:00:00.000Z","name":"claude"}
+JSONL
+  run harness_resolve --session "$sf"
+  [ "$status" -eq 0 ]
+  [ "$output" = "claude" ]
 }
 
 # --- Resolver: path-based detection (fallback for legacy sessions) ---
@@ -103,22 +118,35 @@ JSONL
 }
 
 @test "path-based detection requires a '/' separator (no \`\$PI_DIR-alt\` false positive)" {
-  # TODO(step 3): with a second adapter this test becomes stronger —
-  # today both "path matched → pi" and "fell through to default → pi"
-  # produce the same answer, so we probe `harness_from_path` directly
-  # for the rule under test.
-  mkdir -p "${PI_DIR}-alt"
-  sf="${PI_DIR}-alt/legacy.jsonl"
+  # Now that a second adapter exists, we can verify this end-to-end
+  # through `harness_resolve`: a path that looks pi-adjacent but
+  # isn't under PI_DIR must fall through past path detection, past the
+  # env default, and hit the compile-time default (pi). We can tell
+  # path detection didn't fire because the sibling directory is never
+  # claimed by any adapter — if the rule were loose, a claude-adjacent
+  # path would resolve to claude, not pi. Use a claude-adjacent path
+  # so the assertion bites.
+  mkdir -p "${HOME}/.claude-alt"
+  sf="${HOME}/.claude-alt/legacy.jsonl"
   cat > "$sf" <<JSONL
 {"type":"session","id":"legacy"}
 JSONL
 
-  # Rule-level assertion: the path rule must NOT claim this sibling.
   run harness_from_path "$sf"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 
-  rm -rf "${PI_DIR}-alt"
+  rm -rf "${HOME}/.claude-alt"
+}
+
+@test "path-based detection claims \`\$CLAUDE_DIR/*\` for claude" {
+  mkdir -p "$BATS_TEST_TMPDIR/claude-home/projects"
+  sf="$BATS_TEST_TMPDIR/claude-home/projects/legacy.jsonl"
+  : > "$sf"
+
+  CLAUDE_DIR="$BATS_TEST_TMPDIR/claude-home" run harness_from_path "$sf"
+  [ "$status" -eq 0 ]
+  [ "$output" = "claude" ]
 }
 
 @test "path-based detection normalizes trailing slash on \$PI_DIR" {
@@ -168,16 +196,51 @@ JSONL
 # --- Resolver priority ordering ---
 
 @test "explicit --flag beats session file" {
+  # Two-adapter version: session file declares pi, flag says claude.
+  # If the flag weren't consulted first we'd get pi. We get claude, so
+  # the flag truly wins over the file.
   sf="$BATS_TEST_TMPDIR/session.jsonl"
   cat > "$sf" <<JSONL
 {"type":"session","id":"abc"}
 {"type":"harness","id":"h1","name":"pi"}
 JSONL
-  # Flag wins — if someone ever passes an unknown name here, it errors;
-  # proves the flag is consulted before the session file.
-  run harness_resolve --flag pi --session "$sf"
+  run harness_resolve --flag claude --session "$sf"
+  [ "$status" -eq 0 ]
+  [ "$output" = "claude" ]
+}
+
+@test "session file beats path-based detection" {
+  # File lives under PI_DIR but declares claude in its harness entry.
+  # The harness-entry rule must win over the path prefix.
+  mkdir -p "${PI_DIR}/agent/sessions/--priority--"
+  sf="${PI_DIR}/agent/sessions/--priority--/mixed.jsonl"
+  cat > "$sf" <<JSONL
+{"type":"session","id":"abc"}
+{"type":"harness","id":"h1","name":"claude"}
+JSONL
+  run harness_resolve --session "$sf"
+  [ "$status" -eq 0 ]
+  [ "$output" = "claude" ]
+}
+
+@test "path-based detection beats env default" {
+  # File under PI_DIR with no harness entry; env says claude.
+  # Path rule should fire first and pick pi.
+  mkdir -p "${PI_DIR}/agent/sessions/--priority--"
+  sf="${PI_DIR}/agent/sessions/--priority--/legacy.jsonl"
+  cat > "$sf" <<JSONL
+{"type":"session","id":"legacy"}
+JSONL
+  SESSIONS_DEFAULT_HARNESS=claude run harness_resolve --session "$sf"
   [ "$status" -eq 0 ]
   [ "$output" = "pi" ]
+}
+
+@test "env default beats compile-time default when set" {
+  # No session file, no flag, no path. Env override should win.
+  SESSIONS_DEFAULT_HARNESS=claude run harness_resolve
+  [ "$status" -eq 0 ]
+  [ "$output" = "claude" ]
 }
 
 # --- `sessions new` integration ---
@@ -206,6 +269,45 @@ JSONL
   # No new session file got created
   final_count=$(find "$PI_DIR/agent/sessions" -name '*.jsonl' 2>/dev/null | wc -l | tr -d ' ')
   [ "$final_count" = "$initial_count" ]
+}
+
+@test "new --harness claude exits UNSUPPORTED without side effects (step 3 acceptance)" {
+  # Step 3 claude is a skeleton; session_file_path is UNSUPPORTED, so
+  # `new` must fail before any directory is created. Uses \$CLAUDE_DIR
+  # for isolation so we don't poke at the real ~/.claude.
+  export CLAUDE_DIR="$BATS_TEST_TMPDIR/claude-home"
+
+  run sessions new --cwd "$BATS_TMPDIR" --harness claude acceptance-foo
+  [ "$status" -eq 10 ]
+  echo "$output" | grep -q "'claude' harness does not support 'session_file_path'"
+
+  # No artifacts: the claude projects dir should not have been created.
+  [ ! -d "$CLAUDE_DIR/projects" ]
+}
+
+@test "wake on a claude-declared session routes to claude and errors UNSUPPORTED (step 3 acceptance)" {
+  # Hand-craft a session file with a harness=claude entry. The file
+  # lives under PI_DIR so pi's find_session locates it; the harness
+  # entry then wins over path-based detection (see the priority test
+  # above), so wake dispatches to claude — which errors UNSUPPORTED
+  # when the Elixir run path asks claude for its default model.
+  command -v shell >/dev/null 2>&1 || skip "shell not installed"
+
+  local sid="cccccccc-3333-3333-3333-333333333333"
+  local sf="$PI_DIR/agent/sessions/--claude-acceptance--/2026-04-22T10-00-00-000Z_${sid}.jsonl"
+  mkdir -p "$(dirname "$sf")"
+  cat > "$sf" <<JSONL
+{"type":"session","version":3,"id":"${sid}","timestamp":"2026-04-22T10:00:00.000Z","cwd":"$BATS_TMPDIR"}
+{"type":"harness","id":"h1","parentId":"${sid}","timestamp":"2026-04-22T10:00:00.000Z","name":"claude"}
+JSONL
+
+  run sessions wake "${sid:0:8}" --message "acceptance"
+  [ "$status" -eq 10 ]
+  # The user-facing message should name the claude harness and the
+  # specific unsupported op. Which op fires first depends on the
+  # Elixir startup order; default_model is the earliest thing to need
+  # claude knowledge.
+  echo "$output" | grep -q "'claude' harness does not support"
 }
 
 # --- Cross-adapter find aggregator (hard error surfacing) ---

--- a/test/harness_dispatch.bats
+++ b/test/harness_dispatch.bats
@@ -275,3 +275,64 @@ JSONL
   [ "$status" -eq 0 ]
   echo "$output" | jq -e '.type == "harness" and .name == "pi" and .parentId == "parent1"'
 }
+
+# --- UNSUPPORTED contract ---
+
+@test "harness_unsupported returns the reserved exit code" {
+  run bash -c '
+    source "$1/lib/harness/dispatch.sh"
+    harness_unsupported
+  ' _ "$MISE_CONFIG_ROOT"
+  [ "$status" -eq 10 ]
+  [ -z "$output" ]
+}
+
+@test "harness_call passes through on success" {
+  run bash -c '
+    source "$1/lib/harness/dispatch.sh"
+    harness_fake_ok() { echo "hello from fake"; }
+    harness_call fake ok
+  ' _ "$MISE_CONFIG_ROOT"
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello from fake" ]
+}
+
+@test "harness_call prints clean UNSUPPORTED message and exits 10" {
+  run bash -c '
+    source "$1/lib/harness/dispatch.sh"
+    harness_skel_header_entry() { harness_unsupported; }
+    harness_call skel header_entry
+    echo "should not reach"
+  ' _ "$MISE_CONFIG_ROOT"
+  [ "$status" -eq 10 ]
+  echo "$output" | grep -qi "'skel' harness does not support 'header_entry'"
+  # Ensure we really exited, not just returned.
+  ! echo "$output" | grep -q "should not reach"
+}
+
+@test "harness_call preserves stdout so callers can redirect it" {
+  # Regression guard: `new` uses `harness_call ... > file`, which
+  # requires the function's stdout to reach the caller's redirect.
+  local tmp="$BATS_TEST_TMPDIR/captured"
+  bash -c '
+    source "$1/lib/harness/dispatch.sh"
+    harness_fake_emit() { echo "payload"; }
+    harness_call fake emit > "$2"
+  ' _ "$MISE_CONFIG_ROOT" "$tmp"
+  [ "$(cat "$tmp")" = "payload" ]
+}
+
+@test "harness_call returns non-UNSUPPORTED exit codes instead of exiting" {
+  # Adapters may fail for reasons other than UNSUPPORTED (e.g. a jq
+  # parse failure). Those should propagate as ordinary return values
+  # so callers can decide — not collapse into UNSUPPORTED's exit path.
+  run bash -c '
+    source "$1/lib/harness/dispatch.sh"
+    harness_fake_boom() { return 3; }
+    harness_call fake boom || echo "got rc=$?"
+    echo "kept going"
+  ' _ "$MISE_CONFIG_ROOT"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "got rc=3"
+  echo "$output" | grep -q "kept going"
+}

--- a/test/harness_dispatch.bats
+++ b/test/harness_dispatch.bats
@@ -23,10 +23,12 @@ teardown() {
 
 # --- Registry ---
 
-@test "harness_list returns installed adapters (pi today)" {
+@test "harness_list returns installed adapters" {
   run harness_list
   [ "$status" -eq 0 ]
-  [ "$output" = "pi" ]
+  # Sorted output, one per line. Update this list as adapters land.
+  [ "$output" = "claude
+pi" ]
 }
 
 @test "harness_valid accepts installed adapters" {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,18 +1,31 @@
 # Shared test helpers for sessions BATS tests
 #
 # Provides:
+#   - REPO_DIR derived from the test file location (BATS_TEST_DIRNAME)
 #   - sessions() wrapper that calls tasks through mise
 #   - PI_DIR override for test isolation
 #   - Synthetic JSONL generation (pi format)
 #   - Common setup/teardown
 
-if [ -z "${MISE_CONFIG_ROOT:-}" ]; then
-  echo "MISE_CONFIG_ROOT not set — run tests via: mise run test" >&2
-  exit 1
-fi
+# The canonical invocation is `mise run test`; that's what sets up
+# mise-managed tools (jq, bats, erlang, elixir, shell) on PATH. These
+# helpers don't try to support running bats directly — they just make
+# sure that when the suite DOES run, test code resolves repo paths to
+# the tree under test rather than reaching for any inherited env var.
+#
+# Three primitives, three contexts:
+#   - .mise/tasks/*       → $MISE_CONFIG_ROOT (mise sets it, task uses it)
+#   - lib/*.sh            → BASH_SOURCE-relative (self-locating, hermetic)
+#   - test/* (this file)  → $BATS_TEST_DIRNAME (bats sets it)
+#
+# Each layer uses its own primitive; nothing leaks across boundaries.
+# See KnickKnackLabs/codebase#16 for the broader lint that enforces
+# this.
+REPO_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+export REPO_DIR
 
 sessions() {
-  cd "$MISE_CONFIG_ROOT" && PI_DIR="$PI_DIR" mise run -q "$@"
+  cd "$REPO_DIR" && PI_DIR="$PI_DIR" mise run -q "$@"
 }
 export -f sessions
 

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -79,6 +79,35 @@ teardown() {
   grep -q 'command -v shell' "$MISE_CONFIG_ROOT/.mise/tasks/wake"
 }
 
+# --- Self-reference: call siblings through `mise -C`, not via PATH ---
+
+@test "wake calls sibling tasks through mise -C, not a PATH-resolved 'sessions' binary" {
+  # Regression guard. A shiv-installed `sessions` on PATH will lag
+  # behind the working tree during development — if wake ever calls it
+  # through PATH we route to the wrong codebase. Prove we don't by
+  # running wake with a PATH that points `sessions` at a stub that
+  # always fails; wake must still succeed because it uses
+  # `mise -C "$MISE_CONFIG_ROOT" run` for sibling dispatch.
+  command -v shell >/dev/null 2>&1 || skip "shell not installed"
+
+  local stub_dir="$BATS_TEST_TMPDIR/stub-path"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/sessions" <<'STUB'
+#!/usr/bin/env bash
+echo "stub-sessions invoked — this should never run" >&2
+exit 42
+STUB
+  chmod +x "$stub_dir/sessions"
+
+  # Keep mise itself discoverable; just shadow `sessions`.
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background
+  [ "$status" -eq 0 ]
+  # If the stub ever fired, its stderr would leak into output.
+  ! echo "$output" | grep -q "stub-sessions invoked"
+}
+
+
+
 # --- Context injection (works in both modes) ---
 
 @test "wake injects context into session file" {

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -87,7 +87,8 @@ teardown() {
   # through PATH we route to the wrong codebase. Prove we don't by
   # running wake with a PATH that points `sessions` at a stub that
   # always fails; wake must still succeed because it uses
-  # `mise -C "$REPO_DIR" run` for sibling dispatch.
+  # `mise -C "$MISE_CONFIG_ROOT" run` for sibling dispatch (production
+  # variable, not the test-level $REPO_DIR).
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
 
   local stub_dir="$BATS_TEST_TMPDIR/stub-path"
@@ -105,8 +106,6 @@ STUB
   # If the stub ever fired, its stderr would leak into output.
   ! echo "$output" | grep -q "stub-sessions invoked"
 }
-
-
 
 # --- Context injection (works in both modes) ---
 

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -76,7 +76,7 @@ teardown() {
 
 @test "wake --background checks for shell dependency" {
   # Verify the wake task source checks for shell when --background is used
-  grep -q 'command -v shell' "$MISE_CONFIG_ROOT/.mise/tasks/wake"
+  grep -q 'command -v shell' "$REPO_DIR/.mise/tasks/wake"
 }
 
 # --- Self-reference: call siblings through `mise -C`, not via PATH ---
@@ -87,7 +87,7 @@ teardown() {
   # through PATH we route to the wrong codebase. Prove we don't by
   # running wake with a PATH that points `sessions` at a stub that
   # always fails; wake must still succeed because it uses
-  # `mise -C "$MISE_CONFIG_ROOT" run` for sibling dispatch.
+  # `mise -C "$REPO_DIR" run` for sibling dispatch.
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
 
   local stub_dir="$BATS_TEST_TMPDIR/stub-path"


### PR DESCRIPTION
Closes part of #50 (step 3 of 5).

## What this PR is

Introduces a claude adapter skeleton alongside pi, proves the dispatch layer extracted in step 2 routes correctly across two adapters, and introduces the `UNSUPPORTED` contract that later steps will fill in behind.

## Commits

1. **`feat(harness): UNSUPPORTED contract`** — reserved exit code 10, `harness_call` wrapper (bash), `Unsupported` exception (Python), `Cli.Harness.UnsupportedError` (Elixir, rescued at CLI boundary). Pi behaviour unchanged.

2. **`tasks: mise hygiene + self-reference via $MISE_CONFIG_ROOT`** — pre-existing bug: `wake` called `sessions meta` / `sessions run` via `$PATH`, which hit the stale shiv-installed copy. Now uses `mise -C "$MISE_CONFIG_ROOT" run -q`. Also: `run` switches `set -e` → `set -euo pipefail`; `export`/`import` tasks switch to uv shebang for consistency; `mise.toml` gets `min_version`. Filed KnickKnackLabs/codebase#15 for the general lint.

3. **`feat(harness): claude adapter skeleton + registration`** — `lib/harness/claude.{sh,py}` and `cli/lib/harness/claude.ex`. `find_session` is structural (returns no-match) so the cross-adapter aggregator keeps working for pi; everything else raises/returns UNSUPPORTED. Registered in Elixir `@adapters`; path-based detection for `$CLAUDE_DIR/*` in all three dispatchers. Python/Elixir detection refactored from open-coded pi-only logic to a rule-table loop.

4. **`test(harness): priority ordering + step-3 acceptance cases`** — resolver priority tests now bite (pi → claude instead of tautological pi → pi). New acceptance cases verify step-3 behaviour end-to-end.

5. **`refactor: library self-location via BASH_SOURCE, tests use $REPO_DIR`** — closes a bug class surfaced mid-review (see "Investigation" below). Library files no longer reach for `$MISE_CONFIG_ROOT`; they self-locate via `BASH_SOURCE`. Test helpers derive `$REPO_DIR` from `$BATS_TEST_DIRNAME`. Filed KnickKnackLabs/codebase#16 for the lint.

## Acceptance

- `sessions new --harness claude foo` → exits 10 with `'claude' harness does not support 'session_file_path' yet`. No session file or project dir created.
- `sessions wake <claude-session>` (hand-crafted fixture) → routes through dispatcher, hits UNSUPPORTED in Elixir's `default_model` at the CLI boundary, exits 10.
- 201 BATS + 108 ExUnit, all green.
- End-to-end smoke on pi path confirms no regression.

## Out of scope for this PR

- **Step 4 (claude new + wake)** — real on-disk layout, real entry builders, real launch path. Tracked in #50.
- **Step 5 (claude run)** — Elixir command builder + stream parser for `claude -p --output-format stream-json`.
- **Notes-repo same-class fix** — zeke's investigation found 7 test files in `KnickKnackLabs/notes` with the same `$MISE_CONFIG_ROOT` pattern. Not mine to fix here.
- **Fold documentation updates** — `bats-tool-testing.md`, `mise-conventions.md`, and `mise-gotchas.md` should be updated to reflect the three-primitives-three-contexts model. Separate work.

## Investigation trail (context for commit 5)

While testing commit 1, I hit a confusing failure when running `bats test/harness_dispatch.bats` directly: the test sourced files via `$MISE_CONFIG_ROOT` which was pointing at a shimmer install (inherited from the ambient agent session). I flip-flopped between fixes. Or asked me to dispatch zeke to pin down the real problem before bolting on another band-aid.

Zeke's findings: `/tmp/ikma-mise-config-root-inherit-investigation.md` (full write-up). Key points:
- `$MISE_CONFIG_ROOT` is a task-execution variable, misused in test helpers and library files that read it directly.
- The `[ -z ... ]` guard pattern only catches "unset," not "set but wrong."
- `shiv` and `chat` use `$BATS_TEST_DIRNAME`-derived `REPO_DIR` and are immune.
- Recommendation (option d): use the primitive appropriate to each context.

Commit 5 implements that.

## Reviewers

Requesting two reviews — this touches production library paths alongside test infrastructure, and the library self-location pattern is a first for this codebase.

- @baby-joel-ricon — Elixir surface + Python adapter symmetry
- @zeke-ricon — the library self-location refactor (since he did the investigation that surfaced it)