### PR TITLE
feat(wake): add --model flag + record model on wake event

### DIFF
--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -4,6 +4,7 @@
 #USAGE flag "--context <context>" help="Inject a context message into the session file before launching"
 #USAGE flag "--context-file <context_file>" help="File containing context message to inject"
 #USAGE flag "--message <message>" help="Message to pass to the agent"
+#USAGE flag "--model <model>" help="Model to use (forwarded to 'sessions run --model'; defaults to the harness default)"
 #USAGE flag "--headless" help="No human present — agent completes task and exits"
 #USAGE flag "--background" help="Launch in background via shell/zmx (default: foreground, blocks until done)"
 #USAGE flag "--meta <meta>" var=#true help="Metadata for the wake event (repeatable, dotted paths or jq expressions)"
@@ -15,6 +16,7 @@ CONTEXT="${usage_context:-}"
 WAKE_META_RAW="${usage_meta:-}"
 CONTEXT_FILE="${usage_context_file:-}"
 MESSAGE="${usage_message:-}"
+MODEL="${usage_model:-}"
 HEADLESS="${usage_headless:-false}"
 BACKGROUND="${usage_background:-false}"
 
@@ -112,7 +114,8 @@ wake_entry \
   "${GIT_AUTHOR_NAME:-unknown}" \
   "$HARNESS_NAME" \
   "$HEADLESS" \
-  "$WAKE_META" >> "$SESSION_FILE"
+  "$WAKE_META" \
+  "$MODEL" >> "$SESSION_FILE"
 
 # --- Inject context into session file if provided ---
 
@@ -135,6 +138,7 @@ fi
 
 RUN_CMD=("${mise_run[@]}" run --session "$SESSION_FILE")
 [ "$HEADLESS" = "true" ] && RUN_CMD+=(--headless)
+[ -n "$MODEL" ] && RUN_CMD+=(--model "$MODEL")
 if [ -n "$MESSAGE" ]; then
   RUN_CMD+=("$MESSAGE")
 fi

--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -106,6 +106,10 @@ if [ -n "$WAKE_META_RAW" ]; then
   done < <(printf '%s' "$WAKE_META_RAW" | xargs printf '%s\n')
 fi
 
+# wake_entry args: entry_id parent_id ts shell_name agent harness headless meta_json model
+# (keep in sync with the signature in lib/harness/dispatch.sh — order matters
+# because they're positional; structural refactor to named args is tracked
+# alongside sessions#61)
 wake_entry \
   "$WAKE_ID" \
   "$LAST_ID" \

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ sessions new review/pr-50 --cwd ~/agents/ikma/den \
 # Wake an agent into it (by name)
 sessions wake review/pr-50 --message "Review PR #50"
 
+# Pin the model for this wake (defaults to the harness default if omitted)
+sessions wake review/pr-50 --model claude-opus-4-7 --message "Review PR #50"
+
 # Watch what it does
 sessions read review/pr-50 --last 5
 
@@ -84,6 +87,8 @@ sessions wake review/pr-50 --message "You missed the edge case in line 42"
 ```
 
 The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for persistent zmx sessions. `sessions wake` calls `sessions run` directly for execution — identity (AGENT_IDENTITY, etc.) must already be in the environment, typically set upstream via `eval $(shimmer as <agent>)`.
+
+`--model` on `sessions wake` is a one-shot override for this wake only; it's not currently remembered across wakes (tracked in [issue #61](https://github.com/KnickKnackLabs/sessions/issues/61)). If you pass `sessions new --model X` and then `sessions wake` without `--model`, the wake falls back to the harness default — pass `--model X` to both, or wait for #61 to land.
 
 ## Metadata
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ sessions wake review/pr-50 --message "You missed the edge case in line 42"
 
 The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for persistent zmx sessions. `sessions wake` calls `sessions run` directly for execution — identity (AGENT_IDENTITY, etc.) must already be in the environment, typically set upstream via `eval $(shimmer as <agent>)`.
 
-`--model` on `sessions wake` is a one-shot override for this wake only; it's not currently remembered across wakes (tracked in [issue #61](https://github.com/KnickKnackLabs/sessions/issues/61)). If you pass `sessions new --model X` and then `sessions wake` without `--model`, the wake falls back to the harness default — pass `--model X` to both, or wait for #61 to land.
+`--model` on `sessions wake` is a one-shot override; it is not remembered across wakes — pass `--model X` on each wake, or track [issue #61](https://github.com/KnickKnackLabs/sessions/issues/61).
 
 ## Metadata
 

--- a/lib/harness/dispatch.sh
+++ b/lib/harness/dispatch.sh
@@ -243,14 +243,23 @@ harness_entry() {
 #   $5 agent, $6 harness_name, $7 headless ("true" | "false"),
 #   $8 meta_json (optional, "{}" or "" for none),
 #   $9 model   (optional, "" for none — absence of `.model` on the
-#              output signals "harness default was used"; readers
-#              should treat both absent and explicit null the same way)
+#              output signals "harness default was used". `wake_entry`
+#              itself never writes null; readers processing wake events
+#              from other sources should normalize null to absent.)
 #
 # Field-placement rule: fields that `sessions wake` itself owns
 # (`.headless`, `.model`) go top-level; caller-provided key=value pairs
 # passed via `--meta` go inside `.meta`. Apply this rule when adding
 # new fields: if wake owns the flag, top-level; if it's user-space,
 # stuff it into `meta_json` at the callsite.
+#
+# Schema-evolution risk: `.model` is written as a bare string in
+# harness-native vocabulary (e.g. pi's "claude-opus-4-7"). Readers
+# that consume wake events across harnesses must branch on `.harness`
+# to interpret `.model` correctly. If per-harness model vocabularies
+# diverge further (e.g. structured fields, different naming schemes),
+# revisit: either namespace the field (`.harness_model`) or push it
+# into a per-harness sub-object. Tracked as an open question on #61.
 wake_entry() {
   local entry_id="$1"
   local parent_id="$2"

--- a/lib/harness/dispatch.sh
+++ b/lib/harness/dispatch.sh
@@ -241,7 +241,16 @@ harness_entry() {
 #
 #   $1 entry_id, $2 parent_id, $3 timestamp_iso, $4 shell_name,
 #   $5 agent, $6 harness_name, $7 headless ("true" | "false"),
-#   $8 meta_json (optional, "{}" or "" for none)
+#   $8 meta_json (optional, "{}" or "" for none),
+#   $9 model   (optional, "" for none — absence of `.model` on the
+#              output signals "harness default was used"; readers
+#              should treat both absent and explicit null the same way)
+#
+# Field-placement rule: fields that `sessions wake` itself owns
+# (`.headless`, `.model`) go top-level; caller-provided key=value pairs
+# passed via `--meta` go inside `.meta`. Apply this rule when adding
+# new fields: if wake owns the flag, top-level; if it's user-space,
+# stuff it into `meta_json` at the callsite.
 wake_entry() {
   local entry_id="$1"
   local parent_id="$2"
@@ -251,6 +260,7 @@ wake_entry() {
   local harness_name="$6"
   local headless="$7"
   local meta_json="${8:-}"
+  local model="${9:-}"
 
   # Intentionally strict: only the exact string "true" maps to true.
   # Any other value ("false", "", "TRUE", "yes", "1") maps to false.
@@ -258,6 +268,17 @@ wake_entry() {
   # always "true" or the empty string — no need to be lenient here.
   local headless_bool=false
   [ "$headless" = "true" ] && headless_bool=true
+
+  # `.model` is written only when explicitly provided. Absent means
+  # "harness default was used"; readers can distinguish the two cases.
+  # `"${arr[@]+"${arr[@]}"}"` is the nounset-safe empty-array expansion
+  # (bash < 4.4 treats `"${empty[@]}"` as an unset reference under -u).
+  local model_args=()
+  local model_fragment=''
+  if [ -n "$model" ]; then
+    model_args=(--arg model "$model")
+    model_fragment=' + {model: $model}'
+  fi
 
   if [ -z "$meta_json" ] || [ "$meta_json" = "{}" ]; then
     jq -nc \
@@ -268,6 +289,7 @@ wake_entry() {
       --arg agent "$agent" \
       --arg harness "$harness_name" \
       --argjson headless "$headless_bool" \
+      "${model_args[@]+"${model_args[@]}"}" \
       '{
         type: "wake",
         id: $id,
@@ -277,7 +299,7 @@ wake_entry() {
         agent: $agent,
         harness: $harness,
         headless: $headless
-      }'
+      }'"$model_fragment"
   else
     jq -nc \
       --arg id "$entry_id" \
@@ -288,6 +310,7 @@ wake_entry() {
       --arg harness "$harness_name" \
       --argjson headless "$headless_bool" \
       --argjson meta "$meta_json" \
+      "${model_args[@]+"${model_args[@]}"}" \
       '{
         type: "wake",
         id: $id,
@@ -298,6 +321,6 @@ wake_entry() {
         harness: $harness,
         headless: $headless,
         meta: $meta
-      }'
+      }'"$model_fragment"
   fi
 }

--- a/test/harness_dispatch.bats
+++ b/test/harness_dispatch.bats
@@ -373,6 +373,35 @@ JSONL
   echo "$output" | jq -e 'has("meta") | not'
 }
 
+@test "wake_entry records .model when 9th arg is non-empty" {
+  run wake_entry w1 parent1 "2026-04-22T10:00:00.000Z" shellA ikma pi true "{}" "claude-opus-4-7"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.model == "claude-opus-4-7"'
+}
+
+@test "wake_entry omits .model when 9th arg is absent" {
+  # Absence signals "harness default was used" — readers should treat
+  # the missing field identically to explicit null.
+  run wake_entry w1 parent1 "2026-04-22T10:00:00.000Z" shellA ikma pi true "{}"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e 'has("model") | not'
+}
+
+@test "wake_entry omits .model when 9th arg is empty string" {
+  # Exercises the `[ -n "$model" ]` gate — must distinguish "" from unset
+  # both with the same "no model field" outcome.
+  run wake_entry w1 parent1 "2026-04-22T10:00:00.000Z" shellA ikma pi true "{}" ""
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e 'has("model") | not'
+}
+
+@test "wake_entry includes both .meta and .model when both are non-empty" {
+  # Second jq branch (meta present) with fragment concatenation for model.
+  run wake_entry w1 parent1 "2026-04-22T10:00:00.000Z" shellA ikma pi true '{"by":"zeke"}' "claude-opus-4-7"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.meta.by == "zeke" and .model == "claude-opus-4-7"'
+}
+
 # --- harness_entry builder ---
 
 @test "harness_entry produces a well-formed declaration entry" {

--- a/test/harness_dispatch.bats
+++ b/test/harness_dispatch.bats
@@ -379,20 +379,23 @@ JSONL
   echo "$output" | jq -e '.model == "claude-opus-4-7"'
 }
 
-@test "wake_entry omits .model when 9th arg is absent" {
-  # Absence signals "harness default was used" — readers should treat
-  # the missing field identically to explicit null.
-  run wake_entry w1 parent1 "2026-04-22T10:00:00.000Z" shellA ikma pi true "{}"
-  [ "$status" -eq 0 ]
-  echo "$output" | jq -e 'has("model") | not'
-}
-
-@test "wake_entry omits .model when 9th arg is empty string" {
-  # Exercises the `[ -n "$model" ]` gate — must distinguish "" from unset
-  # both with the same "no model field" outcome.
-  run wake_entry w1 parent1 "2026-04-22T10:00:00.000Z" shellA ikma pi true "{}" ""
-  [ "$status" -eq 0 ]
-  echo "$output" | jq -e 'has("model") | not'
+@test "wake_entry omits .model when 9th arg is absent or empty" {
+  # Both absent (no 9th arg) and explicit empty string must produce no
+  # `.model` field. Absence signals "harness default was used"; the
+  # empty-string case exercises the `[ -n "$model" ]` gate so it
+  # doesn't accidentally emit `{"model": ""}`.
+  for arg in absent empty; do
+    if [ "$arg" = "absent" ]; then
+      run wake_entry w1 parent1 "2026-04-22T10:00:00.000Z" shellA ikma pi true "{}"
+    else
+      run wake_entry w1 parent1 "2026-04-22T10:00:00.000Z" shellA ikma pi true "{}" ""
+    fi
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'has("model") | not' >/dev/null || {
+      echo "case=$arg leaked a .model field: $output" >&2
+      return 1
+    }
+  done
 }
 
 @test "wake_entry includes both .meta and .model when both are non-empty" {

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -199,9 +199,17 @@ STUB
   #
   # We stub `shell` (which wake's --background path invokes with the full
   # RUN_CMD as argv) to dump its arguments to a file, then assert the
-  # dumped argv contains `--model claude-opus-4-7`. This is a runtime
-  # check, not a grep against source — it survives refactors of the wake
-  # task (variable renames, reordering of the RUN_CMD build).
+  # dumped argv contains `--model claude-opus-4-7` with the value
+  # immediately following the flag. This is a runtime check, not a grep
+  # against source — it survives refactors of the wake task (variable
+  # renames, reordering of the RUN_CMD build).
+  #
+  # Coverage caveat: the foreground path (`.mise/tasks/wake:165`,
+  # `exec "${RUN_CMD[@]}"`) is NOT covered by this test — it exec's
+  # directly rather than going through `shell`. Both branches build
+  # the same RUN_CMD array, so the background test implicitly covers
+  # foreground's argv shape; if those construction paths diverge,
+  # adjust the test.
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
 
   local stub_dir="$BATS_TEST_TMPDIR/stub-shell"
@@ -218,9 +226,15 @@ STUB
   [ "$status" -eq 0 ]
   [ -f "$capture" ]
 
-  # Captured argv must contain `--model claude-opus-4-7` in sequence.
-  grep -q '^--model$' "$capture"
-  grep -q '^claude-opus-4-7$' "$capture"
+  # Adjacency check: the line AFTER `--model` must be the exact model
+  # value. Independent presence checks (grep for each) would pass even
+  # if a future refactor inserted args between flag and value.
+  local line_after_flag
+  line_after_flag=$(grep -A1 '^--model$' "$capture" | tail -1)
+  [ "$line_after_flag" = "claude-opus-4-7" ]
+
+  # Cardinality: exactly one --model in the argv (not duplicated).
+  [ "$(grep -c '^--model$' "$capture")" = 1 ]
 
   # Sanity: `sessions run` is also in the argv (confirms we're stubbing
   # the right layer).

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -171,3 +171,86 @@ STUB
   src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
   jq -e 'select(.type == "wake" and .meta.timeout == "900")' "$src_file"
 }
+
+# --- Model pass-through ---
+
+@test "wake --model records model on wake event" {
+  command -v shell >/dev/null 2>&1 || skip "shell not installed"
+  run sessions wake "$SESSION_1" --background --model "claude-opus-4-7"
+  [ "$status" -eq 0 ]
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  jq -e 'select(.type == "wake" and .model == "claude-opus-4-7")' "$src_file"
+}
+
+@test "wake without --model omits .model from wake event (harness default)" {
+  command -v shell >/dev/null 2>&1 || skip "shell not installed"
+  run sessions wake "$SESSION_1" --background
+  [ "$status" -eq 0 ]
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  # .model should be absent (null when queried), signaling "harness default used"
+  run jq -e 'select(.type == "wake") | has("model") | not' "$src_file"
+  [ "$status" -eq 0 ]
+}
+
+@test "wake --model forwards --model to sessions run in RUN_CMD" {
+  # Regression guard against the hardcoded @default_model in sessions run's
+  # Elixir CLI. `sessions wake --model X` must pass `--model X` down so the
+  # CLI doesn't fall back to its own default.
+  #
+  # We stub `shell` (which wake's --background path invokes with the full
+  # RUN_CMD as argv) to dump its arguments to a file, then assert the
+  # dumped argv contains `--model claude-opus-4-7`. This is a runtime
+  # check, not a grep against source — it survives refactors of the wake
+  # task (variable renames, reordering of the RUN_CMD build).
+  command -v shell >/dev/null 2>&1 || skip "shell not installed"
+
+  local stub_dir="$BATS_TEST_TMPDIR/stub-shell"
+  local capture="$BATS_TEST_TMPDIR/shell-argv"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/shell" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/shell"
+
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "claude-opus-4-7"
+  [ "$status" -eq 0 ]
+  [ -f "$capture" ]
+
+  # Captured argv must contain `--model claude-opus-4-7` in sequence.
+  grep -q '^--model$' "$capture"
+  grep -q '^claude-opus-4-7$' "$capture"
+
+  # Sanity: `sessions run` is also in the argv (confirms we're stubbing
+  # the right layer).
+  grep -q '^run$' "$capture"
+}
+
+@test "wake without --model omits --model from RUN_CMD" {
+  # Mirror of the forwarding test: when `--model` isn't passed, the
+  # string `--model` must NOT appear in the argv at all (otherwise the
+  # Elixir CLI would receive a bare flag with no value).
+  command -v shell >/dev/null 2>&1 || skip "shell not installed"
+
+  local stub_dir="$BATS_TEST_TMPDIR/stub-shell-nomodel"
+  local capture="$BATS_TEST_TMPDIR/shell-argv-nomodel"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/shell" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/shell"
+
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background
+  [ "$status" -eq 0 ]
+  [ -f "$capture" ]
+  ! grep -q '^--model$' "$capture"
+}
+
+@test "wake --model is advertised in --help" {
+  run sessions wake --help
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q -- "--model"
+}


### PR DESCRIPTION
## Why

`sessions run` hardcodes `@default_model "claude-opus-4-6"` in the pi harness adapter ([cli/lib/harness/pi/command.ex:14](../blob/main/cli/lib/harness/pi/command.ex#L14)) and consumes it via `model = opts[:model] || harness.default_model()` at [cli/lib/cli.ex:50](../blob/main/cli/lib/cli.ex#L50). `sessions wake` invokes `sessions run` without passing `--model`, so every wake silently falls back to `opus-4-6` — regardless of:

- `pi`'s `defaultModel` in `~/.pi/agent/settings.json`
- Any `model_change` event already in the session file
- What the agent spawning the session actually wants

Caught this while trying to wake a peer agent on `claude-opus-4-7`. Even after `sessions new --model claude-opus-4-7`, the wake flipped it back to `opus-4-6` two seconds in (pi writes its own `model_change` at startup using whatever model `sessions run` told it).

## What

Minimal pass-through fix:

- **New `--model <model>` flag** on `sessions wake`, forwarded to `sessions run --model $MODEL`.
- **New optional `.model` field** on the wake event. Written only when `--model` was explicit. Absence (or explicit null) signals "harness default was used" — readers should treat both states the same.
- **`wake_entry` grows an optional 9th parameter** (`model`). Empty means "don't write the field", so existing callers are unaffected.
- **Field-placement rule documented** in `wake_entry` docstring: wake-owned flags (`.headless`, `.model`) go top-level; caller-provided `--meta` pairs live in `.meta`. Apply to future fields.
- Uses nounset-safe `"${arr[@]+"${arr[@]}"}"` array expansion to keep working under `set -u` on older bash.

## What this is *not*

This is the shallow fix. The deeper bug — **`sessions new --model X` should stick across wake even without re-specifying `--model`** — lives in `sessions run`'s model resolution (cli.ex:50). Fixing that properly needs a harness-aware hook `current_model(session)` with the fallback order `opts[:model] → harness.current_model(session) → harness.default_model()`. Tracked in **#61**.

## Tests

+9 tests added, 210/210 green (was 201/201):

**Unit layer (`test/harness_dispatch.bats`):** 4 new `wake_entry` tests exercising the new 9th parameter:
- `.model == "X"` when 9th arg non-empty
- `.model` absent when 9th arg missing
- `.model` absent when 9th arg is explicit `""` (proves the `[ -n "$model" ]` gate vs. `-z`)
- Both `.meta` and `.model` present when both provided (exercises second jq branch + fragment concatenation)

**Integration layer (`test/wake.bats`):**
- `wake --model X` records `.model == "X"` on the wake event (end-to-end)
- `wake` without `--model` omits `.model` entirely
- `wake --model X` forwards `--model X` to `sessions run`'s argv (stubs `shell`, captures argv, asserts `--model claude-opus-4-7` is present — replaces an earlier tautological grep test)
- `wake` without `--model` emits *no* `--model` flag in argv (prevents a bare flag reaching the Elixir CLI)
- `--model` is advertised in `sessions wake --help`

**Combination paths not explicitly tested:** `--headless + --model + --context`, `--background + --model + --context`. The flags are orthogonal in the wake task (MODEL only feeds `RUN_CMD` and `wake_entry`), so the risk is low — but coverage is not complete. If that matters, I'll parameterize the existing `--model` tests in a follow-up.

## Verification

Before:
```
$ sessions new foo --model claude-opus-4-7 --cwd /tmp/work
$ sessions wake foo --headless --message "..."
# → session JSONL shows model_change to claude-opus-4-6, 2s after wake
```

After:
```
$ sessions new foo --model claude-opus-4-7 --cwd /tmp/work
$ sessions wake foo --headless --model claude-opus-4-7 --message "..."
# → runs on claude-opus-4-7; wake event has .model=claude-opus-4-7
```

The `sessions wake --model X` path has been dogfooded end-to-end for this session and two other active work/review sessions on the machine — it works.

## Review history

- Round 1: opened, tests 205/205 green
- Self-review via `notes/self-review-via-sessions.md` pattern ([findings](/tmp/sessions-60-self-review-by-baby-joel.md)) — requested changes on: stale docstring, tautological grep test, missing dispatch-layer unit tests, incorrect file reference in commit body + PR body, missing README line
- Round 2: all findings addressed (amended commit, +5 new tests, README update, docstring expanded). 210/210 green.

## Follow-up

- **#61** (deeper fix): `sessions new --model X` sticks across wake via harness-aware `current_model(session)` hook.
- **wake_entry signature refactor:** 9 positional parameters with a growing optional tail is the last responsible moment to refactor. Naturally bundled with #61 since that change wants to read session state anyway.
