### PR TITLE
rollout codebase v0.2.0: enable 7 lint rules + fix 10 findings

### DIFF
--- a/.mise/tasks/copy
+++ b/.mise/tasks/copy
@@ -37,7 +37,7 @@ fi
 NEW_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
 NOW_ISO=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
 # Pi filename format: <timestamp>_<uuid>.jsonl (timestamp with dashes instead of colons)
-NOW_FILE=$(echo "$NOW_ISO" | sed 's/:/-/g')
+NOW_FILE="${NOW_ISO//:/-}"
 NEW_FILE="${PROJECT_DIR}${NOW_FILE}_${NEW_ID}.jsonl"
 
 # Clean up on failure

--- a/.mise/tasks/remove
+++ b/.mise/tasks/remove
@@ -43,7 +43,7 @@ fi
 if [ "$HAS_SHELL" = true ]; then
   SHELL_NAME=$(derive_shell_name "$SESSION_NAME" "$FULL_ID")
 
-  SHELL_STATUS=$(shell status "$SHELL_NAME" 2>/dev/null) || true
+  SHELL_STATUS=$(shell status "$SHELL_NAME" 2>/dev/null) || SHELL_STATUS=""
   if [ "$SHELL_STATUS" = "running" ] || [ "$SHELL_STATUS" = "unreachable" ] || [ "$SHELL_STATUS" = "exited" ]; then
     shell kill "$SHELL_NAME" 2>/dev/null && \
       echo "Killed shell '$SHELL_NAME'" >&2 || \

--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -37,14 +37,16 @@ if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "${AGENT_IDENTITY:-}" ]; then
   SYSTEM_PROMPT_FILE=$(mktemp)
   echo "$AGENT_IDENTITY" > "$SYSTEM_PROMPT_FILE"
 
-  trap "rm -f '$SYSTEM_PROMPT_FILE'" EXIT
+  trap 'rm -f "$SYSTEM_PROMPT_FILE"' EXIT
 fi
 
 # Append dispatch context (outside the conditional — applies to any prompt file)
 if [ -n "${DISPATCH_CONTEXT:-}" ] && [ -n "$SYSTEM_PROMPT_FILE" ]; then
-  echo "" >> "$SYSTEM_PROMPT_FILE"
-  echo "## Dispatch Context" >> "$SYSTEM_PROMPT_FILE"
-  echo "This session was triggered by: $DISPATCH_CONTEXT" >> "$SYSTEM_PROMPT_FILE"
+  {
+    echo ""
+    echo "## Dispatch Context"
+    echo "This session was triggered by: $DISPATCH_CONTEXT"
+  } >> "$SYSTEM_PROMPT_FILE"
 fi
 
 # Append headless session context (outside the conditional — applies whether

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,5 +1,28 @@
 #!/usr/bin/env bash
 #MISE description="Run the BATS test suite"
+#USAGE arg "[args]..." var=true help="Test files or bats flags"
+#USAGE example "all"    "mise run test"
+#USAGE example "file"   "mise run test test/wake.bats"
+#USAGE example "filter" "mise run test -- --filter 'session name'"
 set -euo pipefail
 
-bats "$MISE_CONFIG_ROOT/test/"
+TEST_DIR="$MISE_CONFIG_ROOT/test"
+
+args=()
+has_target=false
+
+for arg in "$@"; do
+  if [[ "$arg" != -* && "$arg" != *.bats && -d "$TEST_DIR/$arg" ]]; then
+    args+=("$TEST_DIR/$arg")
+    has_target=true
+  else
+    [[ "$arg" == *.bats || -d "$arg" ]] && has_target=true
+    args+=("$arg")
+  fi
+done
+
+if ! $has_target; then
+  args+=("--recursive" "$TEST_DIR/")
+fi
+
+bats "${args[@]}"

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #MISE description="Run the BATS test suite"
-#USAGE arg "[args]..." var=true help="Test files or bats flags"
-#USAGE example "all"    "mise run test"
-#USAGE example "file"   "mise run test test/wake.bats"
-#USAGE example "filter" "mise run test -- --filter 'session name'"
+#USAGE arg "[args]" var=#true help="Test files or bats flags"
+#USAGE example "mise run test" header="Run all tests"
+#USAGE example "mise run test test/wake.bats" header="Run a specific test file"
+#USAGE example "mise run test -- --filter 'session name'" header="Filter tests by name"
 set -euo pipefail
 
 TEST_DIR="$MISE_CONFIG_ROOT/test"

--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -132,7 +132,7 @@ fi
 
 # --- Resolve working directory from session ---
 
-SESSION_CWD=$("${mise_run[@]}" meta "${FULL_SESSION_ID:0:8}" --field .cwd 2>/dev/null) || true
+SESSION_CWD=$("${mise_run[@]}" meta "${FULL_SESSION_ID:0:8}" --field .cwd 2>/dev/null) || SESSION_CWD=""
 if [ -z "$SESSION_CWD" ] || [ ! -d "$SESSION_CWD" ]; then
   echo "Warning: session cwd '$SESSION_CWD' not found, using current directory" >&2
   SESSION_CWD="."

--- a/lib/harness/dispatch.sh
+++ b/lib/harness/dispatch.sh
@@ -286,6 +286,7 @@ wake_entry() {
   local model_fragment=''
   if [ -n "$model" ]; then
     model_args=(--arg model "$model")
+    # shellcheck disable=SC2016  # jq expression: $model is a jq variable bound by --arg model, not a bash expansion
     model_fragment=' + {model: $model}'
   fi
 

--- a/lib/harness/pi.sh
+++ b/lib/harness/pi.sh
@@ -30,8 +30,7 @@ harness_pi_sessions_dir() {
 # Pi uses double-dash bookends: /Users/foo/bar -> --Users-foo-bar--
 harness_pi_encode_cwd() {
   local cwd_abs="$1"
-  local encoded
-  encoded=$(echo "$cwd_abs" | sed 's|/|-|g')
+  local encoded="${cwd_abs//\//-}"
   echo "-${encoded}-"
 }
 
@@ -47,7 +46,7 @@ harness_pi_session_file_path() {
   project_dir="$sessions_dir/$(harness_pi_encode_cwd "$cwd_abs")/"
   mkdir -p "$project_dir"
 
-  now_file=$(echo "$now_iso" | sed 's/:/-/g')
+  now_file="${now_iso//:/-}"
   echo "${project_dir}${now_file}_${session_id}.jsonl"
 }
 
@@ -148,6 +147,7 @@ harness_pi_header_entry() {
     --arg ts "$ts"
     --arg cwd "$cwd_abs"
   )
+  # shellcheck disable=SC2016  # jq expression: $id, $ts, $cwd are jq variables bound by --arg, not bash expansions
   local expr='{type: "session", version: 3, id: $id, timestamp: $ts, cwd: $cwd}'
 
   if [ -n "$name" ]; then

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,10 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 usage = "latest"
 uv = "latest"
 bats = "1.13.0"
+"shiv:codebase" = "0.2.0"                  # Codebase linting + migrations
 "shiv:shell" = "0.1.0"                     # Persistent terminal sessions (used by wake)
 erlang = "28.4.1"
 elixir = "1.19.5-otp-27"
+
+[_.codebase]
+lint = ["mise-settings", "gum-table", "bats-test-helper", "bats-test-task", "mcr-scope", "or-true", "shellcheck"]


### PR DESCRIPTION
Enable codebase v0.2.0's 7 lint rules and resolve every finding surfaced against sessions. Sibling to the codebase rollout series:

- shimmer#731 — initial 5-rule enablement
- shimmer#734 — `lint:or-true` rollout
- shimmer#735 — `lint:shellcheck` rollout

## Survey

10 findings total: **2 or-true + 7 shellcheck + 1 bats-test-task**. The 4 other rules (`mise-settings`, `gum-table`, `bats-test-helper`, `mcr-scope`) were clean as-is.

## Framing

Same toolkit as the shimmer rollouts: prefer **convert** over **annotate**. Each `# shellcheck disable=…` carries a specific rationale at the call site. Each `|| true` becomes an explicit assignment fallback. Treat `# codebase:ignore` as a last resort.

## Per-rule breakdown

### bats-test-task (1)

`.mise/tasks/test`: adopted the canonical USAGE shape from shimmer's test task — `#USAGE arg "[args]..." var=true help=...` plus three `#USAGE example` directives. Invocation styles now discoverable via `mise run test --help`. Same arg-forwarding logic (suite name → directory, `*.bats` → file, anything else → bats flag).

### or-true (2)

| Site | Fix |
|---|---|
| `.mise/tasks/remove:46` | `SHELL_STATUS=$(...) \|\| true` → `\|\| SHELL_STATUS=""` (assignment fallback; downstream `[ "$SHELL_STATUS" = "running" ]` works fine on empty). |
| `.mise/tasks/wake:135` | `SESSION_CWD=$(...) \|\| true` → `\|\| SESSION_CWD=""` (same pattern; defensive `[ -z "$SESSION_CWD" ]` check already in place at the next line). |

### shellcheck (7)

| Code | Count | Fix |
|---|---|---|
| **SC2001** | 3 | `echo \|\| sed` → bash parameter expansion. `lib/harness/pi.sh:34` (`s\|/\|-\|g` → `${cwd_abs//\//-}`), `lib/harness/pi.sh:50` and `.mise/tasks/copy:40` (`s/:/-/g` → `${var//:/-}`). |
| **SC2064** | 1 | `.mise/tasks/run:40` — `trap "rm -f '$SYSTEM_PROMPT_FILE'" EXIT` → `trap 'rm -f "$SYSTEM_PROMPT_FILE"' EXIT`. Single-quote the trap body so the variable resolves at trap-time, not install-time. Same latent-bug fix as shimmer#735's trap fixes. |
| **SC2129** | 1 | `.mise/tasks/run:45-48` — three sequential `echo >> FILE` redirects grouped into `{ ... } >> FILE` for the dispatch-context block. |
| **SC2016** | 2 | Disabled with rationale. Both sites are jq expressions where `$id` / `$ts` / `$cwd` / `$model` are jq variables bound by `--arg name=value`, not bash expansions. Bash-expanding would replace the jq placeholders with empty strings and break the JSON construction. Each disable names the exact construct: `lib/harness/pi.sh:151` (session-entry jq expression), `lib/harness/dispatch.sh:289` (model-fragment jq expression). |

## Exit criteria

1. ✅ All 7 lint rules pass clean (`codebase lint:<rule> "$PWD"` for each).
2. ✅ `[_.codebase].lint` enabled in `mise.toml` with all 7 rules.
3. ✅ `shiv:codebase = "0.2.0"` pinned in `[tools]`.
4. ✅ Test suite parity vs `main`:
   - `main @ 1531a02`: **209 ok / 0 not ok**
   - `baby-joel/codebase-rollout @ 48f1c2f`: **209 ok / 0 not ok**

## Disable accounting

- 2 disables added (both SC2016, jq-expression rationale)
- 0 `# codebase:ignore` annotations introduced

## Sibling work + remaining queue

Codebase rollout sweep (codebase#4):

- ✅ shimmer (#731 + #734 + #735) — done.
- ✅ sessions (this PR) — in flight.
- ⏳ chat — ~15 findings expected (12 or-true + 1 shellcheck + 2 mcr-scope).
- ⏳ notes — ~85 findings expected (48 or-true + 11 shellcheck + 26 mcr-scope). Largest; may split into pre-req mcr-scope PR + main rollout PR.

— baby-joel
