### PR TITLE
fix: fail on harness-reported agent errors

### DIFF
--- a/cli/lib/cli/engine.ex
+++ b/cli/lib/cli/engine.ex
@@ -67,6 +67,7 @@ defmodule Cli.Engine do
         tool_input: "",
         buffer: "",
         usage: nil,
+        agent_error: nil,
         abort_seen: false,
         recent_text: "",
         flushed_chars: 0,
@@ -104,12 +105,18 @@ defmodule Cli.Engine do
         final_state = finalize_buffer(buffer, state)
         Cli.UsageReport.print(final_state)
 
-        if final_state.abort_seen do
-          IO.puts("\n---")
-          IO.puts("Agent requested session abort via [[ABORT]]")
-          1
-        else
-          status
+        cond do
+          final_state.abort_seen ->
+            IO.puts("\n---")
+            IO.puts("Agent requested session abort via [[ABORT]]")
+            1
+
+          final_state.agent_error ->
+            print_agent_error(final_state.agent_error)
+            if status == 0, do: 1, else: status
+
+          true ->
+            status
         end
     after
       @buffer_flush_timeout_ms ->
@@ -124,6 +131,24 @@ defmodule Cli.Engine do
             stream_output(port, %{state | flushed_chars: String.length(extracted)})
         end
     end
+  end
+
+  defp print_agent_error(error) do
+    source = Map.get(error, :source) || Map.get(error, "source")
+    reason = Map.get(error, :reason) || Map.get(error, "reason")
+    message = Map.get(error, :message) || Map.get(error, "message") || "unknown error"
+
+    IO.puts("\n---")
+
+    label =
+      case {source, reason} do
+        {nil, nil} -> "Agent reported an error"
+        {nil, reason} -> "Agent reported an error (#{reason})"
+        {source, nil} -> "Agent reported an error via #{source}"
+        {source, reason} -> "Agent reported an error via #{source} (#{reason})"
+      end
+
+    IO.puts("ERROR: #{label}: #{message}")
   end
 
   defp finalize_buffer("", state), do: state

--- a/cli/lib/harness/pi/stream.ex
+++ b/cli/lib/harness/pi/stream.ex
@@ -17,6 +17,7 @@ defmodule Cli.Harness.Pi.Stream do
   @typep stream_state :: %{
            tool_input: String.t(),
            usage: map() | nil,
+           agent_error: map() | nil,
            abort_seen: boolean(),
            recent_text: String.t(),
            flushed_chars: non_neg_integer(),
@@ -155,21 +156,42 @@ defmodule Cli.Harness.Pi.Stream do
         end
       )
 
-    %{
-      state
-      | usage: %{
-          cost_usd: totals.cost,
-          duration_ms: nil,
-          num_turns: length(assistant_msgs),
-          usage: %{
-            "input_tokens" => totals.input,
-            "output_tokens" => totals.output,
-            "cache_read_input_tokens" => totals.cache_read,
-            "cache_creation_input_tokens" => totals.cache_write
-          },
-          model_usage: nil
-        }
-    }
+    state
+    |> Map.put(:usage, %{
+      cost_usd: totals.cost,
+      duration_ms: nil,
+      num_turns: length(assistant_msgs),
+      usage: %{
+        "input_tokens" => totals.input,
+        "output_tokens" => totals.output,
+        "cache_read_input_tokens" => totals.cache_read,
+        "cache_creation_input_tokens" => totals.cache_write
+      },
+      model_usage: nil
+    })
+    |> Map.put(:agent_error, extract_agent_error(messages))
+  end
+
+  defp extract_agent_error(messages) do
+    Enum.find_value(messages, fn
+      %{"role" => "assistant"} = msg ->
+        reason = msg["stopReason"] || msg["stop_reason"]
+        message = msg["errorMessage"] || msg["error_message"]
+
+        cond do
+          is_binary(message) and message != "" ->
+            %{source: :pi, reason: reason, message: message}
+
+          reason == "error" ->
+            %{source: :pi, reason: reason, message: "assistant turn ended with stopReason=error"}
+
+          true ->
+            nil
+        end
+
+      _ ->
+        nil
+    end)
   end
 
   defp extract_tool_name_from_event(%{

--- a/cli/test/engine_test.exs
+++ b/cli/test/engine_test.exs
@@ -1,0 +1,50 @@
+defmodule Cli.EngineTest do
+  use ExUnit.Case
+  import ExUnit.CaptureIO
+
+  defmodule FakeHarness do
+    def build_command(message, _model, _system_prompt_file, _session, _timeout, _opts) do
+      {"printf '%s\\n' \"$1\"; exit 0", [message]}
+    end
+
+    def process_line("agent-error", state) do
+      Map.put(state, :agent_error, %{
+        source: :fake,
+        reason: "error",
+        message: "failed assistant turn"
+      })
+    end
+
+    def process_line(_line, state), do: state
+
+    def extract_partial_text(_partial), do: ""
+  end
+
+  defp run_engine(message) do
+    output =
+      capture_io(fn ->
+        exit_code =
+          Cli.Engine.run(FakeHarness, message, "/tmp/prompt.txt", nil, "test-model", nil, nil, [])
+
+        send(self(), {:exit_code, exit_code})
+      end)
+
+    receive do
+      {:exit_code, exit_code} -> {output, exit_code}
+    end
+  end
+
+  test "exits non-zero when the harness reports a generic agent_error" do
+    {output, exit_code} = run_engine("agent-error")
+
+    assert exit_code == 1
+    assert output =~ "ERROR: Agent reported an error via fake (error): failed assistant turn"
+  end
+
+  test "returns process status when the harness does not report agent_error" do
+    {output, exit_code} = run_engine("ok")
+
+    assert exit_code == 0
+    refute output =~ "Agent reported an error"
+  end
+end

--- a/cli/test/harness/pi/stream_test.exs
+++ b/cli/test/harness/pi/stream_test.exs
@@ -469,6 +469,74 @@ defmodule Cli.Harness.Pi.StreamTest do
       assert result_state.usage.usage["cache_read_input_tokens"] == 450
       assert result_state.usage.usage["cache_creation_input_tokens"] == 100
     end
+
+    test "maps assistant stopReason=error into generic agent_error state" do
+      line =
+        Jason.encode!(%{
+          "type" => "agent_end",
+          "messages" => [
+            %{
+              "role" => "assistant",
+              "stopReason" => "error",
+              "errorMessage" => "You're out of extra usage.",
+              "usage" => %{
+                "input" => 0,
+                "output" => 0,
+                "cacheRead" => 0,
+                "cacheWrite" => 0,
+                "cost" => %{"total" => 0.0}
+              }
+            }
+          ]
+        })
+
+      state = %{tool_input: "", usage: nil, agent_error: nil}
+      result_state = PiStream.process_line(line, state)
+
+      assert result_state.agent_error == %{
+               source: :pi,
+               reason: "error",
+               message: "You're out of extra usage."
+             }
+
+      assert result_state.usage.num_turns == 1
+      assert result_state.usage.usage["input_tokens"] == 0
+      assert result_state.usage.usage["output_tokens"] == 0
+    end
+
+    test "maps stopReason=error without errorMessage into generic agent_error state" do
+      line =
+        Jason.encode!(%{
+          "type" => "agent_end",
+          "messages" => [
+            %{"role" => "assistant", "stopReason" => "error", "usage" => %{}}
+          ]
+        })
+
+      state = %{tool_input: "", usage: nil, agent_error: nil}
+      result_state = PiStream.process_line(line, state)
+
+      assert result_state.agent_error == %{
+               source: :pi,
+               reason: "error",
+               message: "assistant turn ended with stopReason=error"
+             }
+    end
+
+    test "does not set agent_error for successful assistant stopReason" do
+      line =
+        Jason.encode!(%{
+          "type" => "agent_end",
+          "messages" => [
+            %{"role" => "assistant", "stopReason" => "stop", "usage" => %{}}
+          ]
+        })
+
+      state = %{tool_input: "", usage: nil, agent_error: nil}
+      result_state = PiStream.process_line(line, state)
+
+      assert result_state.agent_error == nil
+    end
   end
 
   describe "process_line/2 — general" do


### PR DESCRIPTION
## Summary

Add a generic `agent_error` state path so `sessions run` fails when a harness reports that the agent turn failed, even if the harness process exits 0.

The pi-specific schema stays in the pi adapter:
- `Cli.Harness.Pi.Stream` maps assistant `stopReason=error` and/or `errorMessage` from pi `agent_end` events into `state.agent_error`
- `Cli.Engine` only checks the generic `agent_error` field, prints a visible error banner, and returns non-zero

This is intentionally separate from Junior's model-plumbing work. It does not change default model behavior or `wake --model` forwarding.

## Verification

- `cd cli && mix test`
- `mise run test`
- `for target in lint:mise-settings lint:gum-table lint:bats-test-helper lint:bats-test-task lint:mcr-scope lint:or-true lint:shellcheck; do
  codebase "$target" "$PWD"
done`
