### PR TITLE
fix: require explicit wake model

### DIFF
--- a/.mise/tasks/new
+++ b/.mise/tasks/new
@@ -4,7 +4,6 @@
 #USAGE flag "--cwd <cwd>" help="Working directory for the session (default: current directory)"
 #USAGE flag "--context <context>" help="Initial context message to inject"
 #USAGE flag "--context-file <context_file>" help="File containing initial context message"
-#USAGE flag "--model <model>" default="claude-sonnet-4-20250514" help="Model to set (default: claude-sonnet-4-20250514)"
 #USAGE flag "--meta <meta>" var=#true help="Metadata key=value pairs (repeatable, supports dotted paths e.g. agent.name=ikma)"
 #USAGE flag "--harness <harness>" help="Harness adapter to use (default: pi, or value of SESSIONS_DEFAULT_HARNESS)"
 
@@ -14,7 +13,6 @@ NAME="${usage_name:-}"
 CWD="${usage_cwd:-}"
 CONTEXT="${usage_context:-}"
 CONTEXT_FILE="${usage_context_file:-}"
-MODEL="${usage_model:-claude-sonnet-4-20250514}"
 META_RAW="${usage_meta:-}"
 HARNESS_FLAG="${usage_harness:-}"
 
@@ -101,14 +99,10 @@ harness_call "$HARNESS_NAME" header_entry "$SESSION_ID" "$NOW_ISO" "$CWD_ABS" "$
 HARNESS_ENTRY_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
 harness_entry "$HARNESS_ENTRY_ID" "$SESSION_ID" "$NOW_ISO" "$HARNESS_NAME" >> "$SESSION_FILE"
 
-# Model change entry
-MC_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
-harness_call "$HARNESS_NAME" model_change_entry "$MC_ID" "$NOW_ISO" "$MODEL" >> "$SESSION_FILE"
-
 # Inject context as a user message if provided
 if [ -n "$CONTEXT" ]; then
   MSG_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
-  harness_call "$HARNESS_NAME" user_message_entry "$MSG_ID" "$MC_ID" "$NOW_ISO" "$CONTEXT" >> "$SESSION_FILE"
+  harness_call "$HARNESS_NAME" user_message_entry "$MSG_ID" "$HARNESS_ENTRY_ID" "$NOW_ISO" "$CONTEXT" >> "$SESSION_FILE"
 fi
 
 # --- Output ---

--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -4,7 +4,7 @@
 #USAGE arg "<message>" help="Message for the agent"
 #USAGE flag "--system-prompt-file <file>" help="Path to system prompt file"
 #USAGE flag "--timeout <seconds>" help="Timeout in seconds (default: no timeout)"
-#USAGE flag "--model <model>" help="Model to use"
+#USAGE flag "--model <model>" help="Model to use (required; provider-qualified, e.g. openai/gpt-5.5)"
 #USAGE flag "--session <session>" help="Session file for conversation continuity"
 #USAGE flag "--cwd <cwd>" help="Working directory for pi"
 #USAGE flag "--headless" help="Non-interactive mode (appends headless context to system prompt)"
@@ -28,7 +28,18 @@ PROMPT_TEMPLATES="${usage_prompt_templates:-false}"
 
 if [ -z "$MESSAGE" ]; then
   echo "Error: message required" >&2
-  echo "Usage: sessions run --system-prompt-file <path> [options] \"message\"" >&2
+  echo "Usage: sessions run --system-prompt-file <path> --model <provider/model> [options] \"message\"" >&2
+  exit 1
+fi
+
+if [ -z "$MODEL" ]; then
+  echo "Error: --model is required" >&2
+  echo "Usage: sessions run --system-prompt-file <path> --model <provider/model> [options] \"message\"" >&2
+  exit 1
+fi
+
+if [[ "$MODEL" != */* ]]; then
+  echo "Error: --model must be provider-qualified (for example: openai/gpt-5.5)" >&2
   exit 1
 fi
 
@@ -65,7 +76,7 @@ CLI_DIR="$MISE_CONFIG_ROOT/cli"
 CLI_ARGS=(--system-prompt-file "$SYSTEM_PROMPT_FILE" --cwd "$CWD")
 
 [ -n "$TIMEOUT" ] && CLI_ARGS+=(--timeout "$TIMEOUT")
-[ -n "$MODEL" ] && CLI_ARGS+=(--model "$MODEL")
+CLI_ARGS+=(--model "$MODEL")
 [ -n "$SESSION" ] && CLI_ARGS+=(--session "$SESSION")
 # Extensions off by default — only pass --no-* when NOT explicitly enabled
 [ "$EXTENSIONS" != "true" ] && CLI_ARGS+=(--no-extensions)

--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -4,7 +4,7 @@
 #USAGE arg "<message>" help="Message for the agent"
 #USAGE flag "--system-prompt-file <file>" help="Path to system prompt file"
 #USAGE flag "--timeout <seconds>" help="Timeout in seconds (default: no timeout)"
-#USAGE flag "--model <model>" help="Model to use (required; provider-qualified, e.g. openai/gpt-5.5)"
+#USAGE flag "--model <model>" help="Model to use (required; provider-qualified, e.g. openai-codex/gpt-5.5)"
 #USAGE flag "--session <session>" help="Session file for conversation continuity"
 #USAGE flag "--cwd <cwd>" help="Working directory for pi"
 #USAGE flag "--headless" help="Non-interactive mode (appends headless context to system prompt)"
@@ -39,7 +39,7 @@ if [ -z "$MODEL" ]; then
 fi
 
 if [[ "$MODEL" != */* ]]; then
-  echo "Error: --model must be provider-qualified (for example: openai/gpt-5.5)" >&2
+  echo "Error: --model must be provider-qualified (for example: openai-codex/gpt-5.5)" >&2
   exit 1
 fi
 

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 #MISE description="Run the BATS test suite"
-#USAGE arg "[args]" var=#true help="Test files or bats flags"
+#USAGE arg "[args]..." var=#true help="Test suites, files, directories, or bats flags"
 #USAGE example "mise run test" header="Run all tests"
+#USAGE example "mise run test wake" header="Run a specific suite by bare name"
 #USAGE example "mise run test test/wake.bats" header="Run a specific test file"
-#USAGE example "mise run test -- --filter 'session name'" header="Filter tests by name"
+#USAGE example "mise run test --filter 'session name'" header="Filter tests by name"
 set -euo pipefail
 
 TEST_DIR="$MISE_CONFIG_ROOT/test"
@@ -12,7 +13,10 @@ args=()
 has_target=false
 
 for arg in "$@"; do
-  if [[ "$arg" != -* && "$arg" != *.bats && -d "$TEST_DIR/$arg" ]]; then
+  if [[ "$arg" != -* && "$arg" != *.bats && -f "$TEST_DIR/$arg.bats" ]]; then
+    args+=("$TEST_DIR/$arg.bats")
+    has_target=true
+  elif [[ "$arg" != -* && "$arg" != *.bats && -d "$TEST_DIR/$arg" ]]; then
     args+=("$TEST_DIR/$arg")
     has_target=true
   else

--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -4,7 +4,7 @@
 #USAGE flag "--context <context>" help="Inject a context message into the session file before launching"
 #USAGE flag "--context-file <context_file>" help="File containing context message to inject"
 #USAGE flag "--message <message>" help="Message to pass to the agent"
-#USAGE flag "--model <model>" help="Model to use (forwarded to 'sessions run --model'; defaults to the harness default)"
+#USAGE flag "--model <model>" help="Model to use (required; provider-qualified, e.g. openai/gpt-5.5)"
 #USAGE flag "--headless" help="No human present — agent completes task and exits"
 #USAGE flag "--background" help="Launch in background via shell/zmx (default: foreground, blocks until done)"
 #USAGE flag "--meta <meta>" var=#true help="Metadata for the wake event (repeatable, dotted paths or jq expressions)"
@@ -22,7 +22,18 @@ BACKGROUND="${usage_background:-false}"
 
 if [ -z "$SESSION_ID" ]; then
   echo "Error: session ID or name required" >&2
-  echo "Usage: sessions wake <name-or-id> [--message '...']" >&2
+  echo "Usage: sessions wake <name-or-id> --model <provider/model> [--message '...']" >&2
+  exit 1
+fi
+
+if [ -z "$MODEL" ]; then
+  echo "Error: --model is required" >&2
+  echo "Usage: sessions wake <name-or-id> --model <provider/model> [--message '...']" >&2
+  exit 1
+fi
+
+if [[ "$MODEL" != */* ]]; then
+  echo "Error: --model must be provider-qualified (for example: openai/gpt-5.5)" >&2
   exit 1
 fi
 
@@ -141,9 +152,8 @@ SESSION_CWD=$(cd "$SESSION_CWD" && pwd -P)
 
 # --- Launch ---
 
-RUN_CMD=("${mise_run[@]}" run --session "$SESSION_FILE" --cwd "$SESSION_CWD")
+RUN_CMD=("${mise_run[@]}" run --session "$SESSION_FILE" --cwd "$SESSION_CWD" --model "$MODEL")
 [ "$HEADLESS" = "true" ] && RUN_CMD+=(--headless)
-[ -n "$MODEL" ] && RUN_CMD+=(--model "$MODEL")
 if [ -n "$MESSAGE" ]; then
   RUN_CMD+=("$MESSAGE")
 fi

--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -4,7 +4,7 @@
 #USAGE flag "--context <context>" help="Inject a context message into the session file before launching"
 #USAGE flag "--context-file <context_file>" help="File containing context message to inject"
 #USAGE flag "--message <message>" help="Message to pass to the agent"
-#USAGE flag "--model <model>" help="Model to use (required; provider-qualified, e.g. openai/gpt-5.5)"
+#USAGE flag "--model <model>" help="Model to use (required; provider-qualified, e.g. openai-codex/gpt-5.5)"
 #USAGE flag "--headless" help="No human present — agent completes task and exits"
 #USAGE flag "--background" help="Launch in background via shell/zmx (default: foreground, blocks until done)"
 #USAGE flag "--meta <meta>" var=#true help="Metadata for the wake event (repeatable, dotted paths or jq expressions)"
@@ -33,7 +33,7 @@ if [ -z "$MODEL" ]; then
 fi
 
 if [[ "$MODEL" != */* ]]; then
-  echo "Error: --model must be provider-qualified (for example: openai/gpt-5.5)" >&2
+  echo "Error: --model must be provider-qualified (for example: openai-codex/gpt-5.5)" >&2
   exit 1
 fi
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 161 passing](https://img.shields.io/badge/tests-161%20passing-brightgreen?style=flat)](test/)
+[![tests: 323 passing](https://img.shields.io/badge/tests-323%20passing-brightgreen?style=flat)](test/)
 ![commands: 13](https://img.shields.io/badge/commands-13-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -18,7 +18,7 @@ observe transcripts in real time, and query your history.
 $ sessions new review/pr-50 --cwd ~/agents/ikma/den --meta agent.name=ikma
 e96bd43a
 
-$ sessions wake review/pr-50 --message "review PR #50"
+$ sessions wake review/pr-50 --model openai/gpt-5.5 --message "review PR #50"
 Woke session 'review/pr-50'
 
 $ sessions read review/pr-50 --last 3
@@ -73,22 +73,19 @@ sessions new review/pr-50 --cwd ~/agents/ikma/den \
   --meta purpose=review \
   --context "Background: this PR refactors the auth module"
 
-# Wake an agent into it (by name)
-sessions wake review/pr-50 --message "Review PR #50"
-
-# Pin the model for this wake (defaults to the harness default if omitted)
-sessions wake review/pr-50 --model claude-opus-4-7 --message "Review PR #50"
+# Wake an agent into it (by name). Model is required at wake time.
+sessions wake review/pr-50 --model openai/gpt-5.5 --message "Review PR #50"
 
 # Watch what it does
 sessions read review/pr-50 --last 5
 
 # Something went wrong? Wake the same session again.
-sessions wake review/pr-50 --message "You missed the edge case in line 42"
+sessions wake review/pr-50 --model openai/gpt-5.5 --message "You missed the edge case in line 42"
 ```
 
 The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for persistent zmx sessions. `sessions wake` calls `sessions run` directly for execution — identity (AGENT_IDENTITY, etc.) must already be in the environment, typically set upstream via `eval $(shimmer as <agent>)`.
 
-`--model` on `sessions wake` is a one-shot override; it is not remembered across wakes — pass `--model X` on each wake, or track [issue #61](https://github.com/KnickKnackLabs/sessions/issues/61).
+`--model` on `sessions wake` is required and is not remembered across wakes — pass a provider-qualified model (for example `openai/gpt-5.5`) on each wake.
 
 ## Metadata
 
@@ -115,6 +112,7 @@ Wake events carry their own metadata, separate from the session header. This rec
 
 ```bash
 sessions wake review/pr-50 \
+  --model openai/gpt-5.5 \
   --meta by.agent.name=ikma \
   --message "check the CI results"
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ observe transcripts in real time, and query your history.
 $ sessions new review/pr-50 --cwd ~/agents/ikma/den --meta agent.name=ikma
 e96bd43a
 
-$ sessions wake review/pr-50 --model openai/gpt-5.5 --message "review PR #50"
+$ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "review PR #50"
 Woke session 'review/pr-50'
 
 $ sessions read review/pr-50 --last 3
@@ -74,18 +74,18 @@ sessions new review/pr-50 --cwd ~/agents/ikma/den \
   --context "Background: this PR refactors the auth module"
 
 # Wake an agent into it (by name). Model is required at wake time.
-sessions wake review/pr-50 --model openai/gpt-5.5 --message "Review PR #50"
+sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "Review PR #50"
 
 # Watch what it does
 sessions read review/pr-50 --last 5
 
 # Something went wrong? Wake the same session again.
-sessions wake review/pr-50 --model openai/gpt-5.5 --message "You missed the edge case in line 42"
+sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed the edge case in line 42"
 ```
 
 The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for persistent zmx sessions. `sessions wake` calls `sessions run` directly for execution — identity (AGENT_IDENTITY, etc.) must already be in the environment, typically set upstream via `eval $(shimmer as <agent>)`.
 
-`--model` on `sessions wake` is required and is not remembered across wakes — pass a provider-qualified model (for example `openai/gpt-5.5`) on each wake.
+`--model` on `sessions wake` is required and is not remembered across wakes — pass a provider-qualified model (for example `openai-codex/gpt-5.5`) on each wake.
 
 ## Metadata
 
@@ -112,7 +112,7 @@ Wake events carry their own metadata, separate from the session header. This rec
 
 ```bash
 sessions wake review/pr-50 \
-  --model openai/gpt-5.5 \
+  --model openai-codex/gpt-5.5 \
   --meta by.agent.name=ikma \
   --message "check the CI results"
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -19,13 +19,13 @@ Identity-agnostic Elixir wrapper around pi. It:
 
 ```bash
 # Via the sessions run task (typical)
-sessions run --system-prompt-file /tmp/prompt.txt --model openai/gpt-5.5 --timeout 300 "Your message"
+sessions run --system-prompt-file /tmp/prompt.txt --model openai-codex/gpt-5.5 --timeout 300 "Your message"
 
 # Direct CLI invocation (rare)
-cd cli && mix sessions --system-prompt-file /tmp/prompt.txt --model openai/gpt-5.5 "Your message"
+cd cli && mix sessions --system-prompt-file /tmp/prompt.txt --model openai-codex/gpt-5.5 "Your message"
 
 # With session file for conversation continuity
-mix sessions --system-prompt-file ./prompt.txt --model openai/gpt-5.5 --session ./session.jsonl "Continue"
+mix sessions --system-prompt-file ./prompt.txt --model openai-codex/gpt-5.5 --session ./session.jsonl "Continue"
 ```
 
 ## Options

--- a/cli/README.md
+++ b/cli/README.md
@@ -19,13 +19,13 @@ Identity-agnostic Elixir wrapper around pi. It:
 
 ```bash
 # Via the sessions run task (typical)
-sessions run --system-prompt-file /tmp/prompt.txt --timeout 300 "Your message"
+sessions run --system-prompt-file /tmp/prompt.txt --model openai/gpt-5.5 --timeout 300 "Your message"
 
 # Direct CLI invocation (rare)
-cd cli && mix sessions --system-prompt-file /tmp/prompt.txt "Your message"
+cd cli && mix sessions --system-prompt-file /tmp/prompt.txt --model openai/gpt-5.5 "Your message"
 
 # With session file for conversation continuity
-mix sessions --system-prompt-file ./prompt.txt --session ./session.jsonl "Continue"
+mix sessions --system-prompt-file ./prompt.txt --model openai/gpt-5.5 --session ./session.jsonl "Continue"
 ```
 
 ## Options
@@ -34,7 +34,7 @@ mix sessions --system-prompt-file ./prompt.txt --session ./session.jsonl "Contin
 |--------|-------------|
 | `--system-prompt-file <path>` | Required. Path to system prompt file |
 | `--timeout <seconds>` | Optional. Timeout in seconds (default: no timeout) |
-| `--model <model>` | Optional. Model (default: `claude-opus-4-6`) |
+| `--model <provider/model>` | Required. Provider-qualified model to use |
 | `--session <path>` | Optional. Session file for conversation continuity |
 | `--cwd <path>` | Optional. Working directory for pi |
 | `--no-extensions` | Disable pi extensions |

--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -47,7 +47,7 @@ defmodule Cli do
     # used to re-resolve from the session file, which meant reading
     # the JSONL twice on every invocation.
     harness = Cli.Harness.resolve(session: session)
-    model = opts[:model] || harness.default_model()
+    model = opts[:model]
     cwd = opts[:cwd]
 
     # Extension flags default to true (enabled) unless explicitly disabled.
@@ -57,7 +57,7 @@ defmodule Cli do
 
     print_header(opts, message, timeout, model)
 
-    case validate_args(message, opts[:system_prompt_file]) do
+    case validate_args(message, opts) do
       {:error, msg} ->
         IO.puts("ERROR: #{msg}")
         1
@@ -89,10 +89,17 @@ defmodule Cli do
     IO.puts("---")
   end
 
-  defp validate_args(message, system_prompt_file) do
+  defp validate_args(message, opts) do
+    system_prompt_file = opts[:system_prompt_file]
     cond do
       String.trim(message) == "" ->
         {:error, "No message provided"}
+
+      opts[:model] == nil or opts[:model] == "" ->
+        {:error, "--model is required"}
+
+      not String.contains?(opts[:model], "/") ->
+        {:error, "--model must be provider-qualified (for example: openai/gpt-5.5)"}
 
       system_prompt_file == nil or system_prompt_file == "" ->
         {:error, "--system-prompt-file is required"}
@@ -137,19 +144,17 @@ defmodule Cli do
   end
 
   defp print_help do
-    default_model = Cli.Harness.resolve().default_model()
-
     IO.puts("""
-    Usage: sessions run --system-prompt-file <path> [options] <message>
+    Usage: sessions run --system-prompt-file <path> --model <provider/model> [options] <message>
 
     Run a pi agent session with streaming output, timeout, and ABORT detection.
 
     Required:
       --system-prompt-file <path>  Path to the system prompt file
+      --model <provider/model>     Provider-qualified model to use
 
     Options:
       --timeout <seconds>          Maximum runtime in seconds (default: no timeout)
-      --model <model>              Model to use (default: #{default_model})
       --cwd <path>                 Working directory for pi
       --session <path>             Session file for conversation continuity
       --no-extensions              Disable pi extensions
@@ -158,9 +163,9 @@ defmodule Cli do
       -h, --help                   Show this help message
 
     Examples:
-      sessions run --system-prompt-file /tmp/prompt.txt "Fix the bug"
-      sessions run --system-prompt-file ./prompt.txt --timeout 300 "Explore"
-      sessions run --session ./session.jsonl --system-prompt-file ./prompt.txt "Continue"
+      sessions run --system-prompt-file /tmp/prompt.txt --model openai/gpt-5.5 "Fix the bug"
+      sessions run --system-prompt-file ./prompt.txt --model openai/gpt-5.5 --timeout 300 "Explore"
+      sessions run --session ./session.jsonl --system-prompt-file ./prompt.txt --model openai/gpt-5.5 "Continue"
     """)
   end
 end

--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -99,7 +99,7 @@ defmodule Cli do
         {:error, "--model is required"}
 
       not String.contains?(opts[:model], "/") ->
-        {:error, "--model must be provider-qualified (for example: openai/gpt-5.5)"}
+        {:error, "--model must be provider-qualified (for example: openai-codex/gpt-5.5)"}
 
       system_prompt_file == nil or system_prompt_file == "" ->
         {:error, "--system-prompt-file is required"}
@@ -163,9 +163,9 @@ defmodule Cli do
       -h, --help                   Show this help message
 
     Examples:
-      sessions run --system-prompt-file /tmp/prompt.txt --model openai/gpt-5.5 "Fix the bug"
-      sessions run --system-prompt-file ./prompt.txt --model openai/gpt-5.5 --timeout 300 "Explore"
-      sessions run --session ./session.jsonl --system-prompt-file ./prompt.txt --model openai/gpt-5.5 "Continue"
+      sessions run --system-prompt-file /tmp/prompt.txt --model openai-codex/gpt-5.5 "Fix the bug"
+      sessions run --system-prompt-file ./prompt.txt --model openai-codex/gpt-5.5 --timeout 300 "Explore"
+      sessions run --session ./session.jsonl --system-prompt-file ./prompt.txt --model openai-codex/gpt-5.5 "Continue"
     """)
   end
 end

--- a/cli/lib/harness.ex
+++ b/cli/lib/harness.ex
@@ -41,8 +41,8 @@ defmodule Cli.Harness do
     5. Compile-time default: `:pi`
 
   Each adapter module exposes the public API the engine uses
-  (`build_command/6`, `default_model/0`, `process_line/2`,
-  `extract_partial_text/1`). See `Cli.Harness.Pi` for the reference.
+  (`build_command/6`, `process_line/2`, `extract_partial_text/1`).
+  See `Cli.Harness.Pi` for the reference.
   """
 
   @default :pi

--- a/cli/lib/harness/claude.ex
+++ b/cli/lib/harness/claude.ex
@@ -14,10 +14,6 @@ defmodule Cli.Harness.Claude do
     raise UnsupportedError, harness: :claude, op: :build_command
   end
 
-  def default_model do
-    raise UnsupportedError, harness: :claude, op: :default_model
-  end
-
   def process_line(_line, _state) do
     raise UnsupportedError, harness: :claude, op: :process_line
   end

--- a/cli/lib/harness/pi.ex
+++ b/cli/lib/harness/pi.ex
@@ -12,8 +12,6 @@ defmodule Cli.Harness.Pi do
   defdelegate build_command(message, model, system_prompt_file, session, timeout, opts),
     to: Cli.Harness.Pi.Command
 
-  defdelegate default_model(), to: Cli.Harness.Pi.Command
-
   defdelegate process_line(line, state), to: Cli.Harness.Pi.Stream
 
   defdelegate extract_partial_text(partial), to: Cli.Harness.Pi.Stream

--- a/cli/lib/harness/pi/command.ex
+++ b/cli/lib/harness/pi/command.ex
@@ -11,11 +11,6 @@ defmodule Cli.Harness.Pi.Command do
   multi-harness plan.
   """
 
-  @default_model "claude-opus-4-6"
-
-  @doc "Default model when the caller doesn't pass --model."
-  @spec default_model() :: String.t()
-  def default_model, do: @default_model
 
   @typep build_opts :: [
            extensions: boolean(),
@@ -45,8 +40,7 @@ defmodule Cli.Harness.Pi.Command do
     skills = Keyword.get(opts, :skills, true)
     prompt_templates = Keyword.get(opts, :prompt_templates, true)
 
-    qualified_model =
-      if String.contains?(model, "/"), do: model, else: "anthropic/#{model}"
+    qualified_model = model
 
     session_flag =
       if session, do: ~s( --session "$4"), else: " --no-session"

--- a/cli/test/cli_test.exs
+++ b/cli/test/cli_test.exs
@@ -78,14 +78,14 @@ defmodule CliTest do
     end
 
     test "requires system-prompt-file" do
-      {output, exit_code} = run_cli(["--timeout", "60", "--model", "openai/gpt-5.5", "hello"])
+      {output, exit_code} = run_cli(["--timeout", "60", "--model", "openai-codex/gpt-5.5", "hello"])
       assert exit_code == 1
       assert output =~ "--system-prompt-file is required"
     end
 
     test "rejects non-existent system-prompt-file" do
       {output, exit_code} =
-        run_cli(["--system-prompt-file", "/nonexistent/path.txt", "--model", "openai/gpt-5.5", "--timeout", "60", "hello"])
+        run_cli(["--system-prompt-file", "/nonexistent/path.txt", "--model", "openai-codex/gpt-5.5", "--timeout", "60", "hello"])
 
       assert exit_code == 1
       assert output =~ "System prompt file not found"
@@ -93,7 +93,7 @@ defmodule CliTest do
 
     test "timeout is optional" do
       # Should not error on missing timeout — only on missing prompt.
-      {output, exit_code} = run_cli(["--system-prompt-file", "/nonexistent/path.txt", "--model", "openai/gpt-5.5", "hello"])
+      {output, exit_code} = run_cli(["--system-prompt-file", "/nonexistent/path.txt", "--model", "openai-codex/gpt-5.5", "hello"])
       assert exit_code == 1
       assert output =~ "System prompt file not found"
     end

--- a/cli/test/cli_test.exs
+++ b/cli/test/cli_test.exs
@@ -51,23 +51,49 @@ defmodule CliTest do
       end
     end
 
+    test "requires model" do
+      prompt = System.tmp_dir!() <> "/sessions-cli-test-prompt-#{System.unique_integer([:positive])}.txt"
+      File.write!(prompt, "prompt")
+
+      try do
+        {output, exit_code} = run_cli(["--system-prompt-file", prompt, "hello"])
+        assert exit_code == 1
+        assert output =~ "--model is required"
+      after
+        File.rm(prompt)
+      end
+    end
+
+    test "requires provider-qualified model" do
+      prompt = System.tmp_dir!() <> "/sessions-cli-test-prompt-#{System.unique_integer([:positive])}.txt"
+      File.write!(prompt, "prompt")
+
+      try do
+        {output, exit_code} = run_cli(["--system-prompt-file", prompt, "--model", "gpt-5.5", "hello"])
+        assert exit_code == 1
+        assert output =~ "--model must be provider-qualified"
+      after
+        File.rm(prompt)
+      end
+    end
+
     test "requires system-prompt-file" do
-      {output, exit_code} = run_cli(["--timeout", "60", "hello"])
+      {output, exit_code} = run_cli(["--timeout", "60", "--model", "openai/gpt-5.5", "hello"])
       assert exit_code == 1
       assert output =~ "--system-prompt-file is required"
     end
 
     test "rejects non-existent system-prompt-file" do
       {output, exit_code} =
-        run_cli(["--system-prompt-file", "/nonexistent/path.txt", "--timeout", "60", "hello"])
+        run_cli(["--system-prompt-file", "/nonexistent/path.txt", "--model", "openai/gpt-5.5", "--timeout", "60", "hello"])
 
       assert exit_code == 1
       assert output =~ "System prompt file not found"
     end
 
     test "timeout is optional" do
-      # Should not error on missing timeout — only on missing message/prompt.
-      {output, exit_code} = run_cli(["--system-prompt-file", "/nonexistent/path.txt", "hello"])
+      # Should not error on missing timeout — only on missing prompt.
+      {output, exit_code} = run_cli(["--system-prompt-file", "/nonexistent/path.txt", "--model", "openai/gpt-5.5", "hello"])
       assert exit_code == 1
       assert output =~ "System prompt file not found"
     end

--- a/cli/test/harness/pi/command_test.exs
+++ b/cli/test/harness/pi/command_test.exs
@@ -98,31 +98,31 @@ defmodule Cli.Harness.Pi.CommandTest do
   describe "build_command/6 — positional args" do
     test "returns [message, model, system_prompt_file] without session" do
       {_script, args} =
-        Command.build_command("hello world", "openai/gpt-5.5", "/tmp/p.txt", nil, nil)
+        Command.build_command("hello world", "openai-codex/gpt-5.5", "/tmp/p.txt", nil, nil)
 
-      assert args == ["hello world", "openai/gpt-5.5", "/tmp/p.txt"]
+      assert args == ["hello world", "openai-codex/gpt-5.5", "/tmp/p.txt"]
     end
 
     test "appends session path to positional args when given" do
       {_script, args} =
         Command.build_command(
           "hello",
-          "openai/gpt-5.5",
+          "openai-codex/gpt-5.5",
           "/tmp/p.txt",
           "/tmp/s.jsonl",
           nil
         )
 
-      assert args == ["hello", "openai/gpt-5.5", "/tmp/p.txt", "/tmp/s.jsonl"]
+      assert args == ["hello", "openai-codex/gpt-5.5", "/tmp/p.txt", "/tmp/s.jsonl"]
     end
   end
 
   describe "build_command/6 — model qualification" do
     test "leaves provider-qualified model names unchanged" do
       {_, args} =
-        Command.build_command("hi", "openai/gpt-5.5", "/tmp/p.txt", nil, nil)
+        Command.build_command("hi", "openai-codex/gpt-5.5", "/tmp/p.txt", nil, nil)
 
-      assert Enum.at(args, 1) == "openai/gpt-5.5"
+      assert Enum.at(args, 1) == "openai-codex/gpt-5.5"
     end
   end
 end

--- a/cli/test/harness/pi/command_test.exs
+++ b/cli/test/harness/pi/command_test.exs
@@ -3,14 +3,6 @@ defmodule Cli.Harness.Pi.CommandTest do
 
   alias Cli.Harness.Pi.Command
 
-  describe "default_model/0" do
-    test "returns a non-empty model id" do
-      model = Command.default_model()
-      assert is_binary(model)
-      assert String.length(model) > 0
-    end
-  end
-
   describe "build_command/6 — shell script" do
     test "builds a basic invocation with no timeout, session, or flags" do
       {script, _args} =
@@ -104,47 +96,33 @@ defmodule Cli.Harness.Pi.CommandTest do
   end
 
   describe "build_command/6 — positional args" do
-    test "returns [message, qualified_model, system_prompt_file] without session" do
+    test "returns [message, model, system_prompt_file] without session" do
       {_script, args} =
-        Command.build_command("hello world", "claude-sonnet-4-5", "/tmp/p.txt", nil, nil)
+        Command.build_command("hello world", "openai/gpt-5.5", "/tmp/p.txt", nil, nil)
 
-      assert args == ["hello world", "anthropic/claude-sonnet-4-5", "/tmp/p.txt"]
+      assert args == ["hello world", "openai/gpt-5.5", "/tmp/p.txt"]
     end
 
     test "appends session path to positional args when given" do
       {_script, args} =
         Command.build_command(
           "hello",
-          "claude-sonnet-4-5",
+          "openai/gpt-5.5",
           "/tmp/p.txt",
           "/tmp/s.jsonl",
           nil
         )
 
-      assert args == ["hello", "anthropic/claude-sonnet-4-5", "/tmp/p.txt", "/tmp/s.jsonl"]
+      assert args == ["hello", "openai/gpt-5.5", "/tmp/p.txt", "/tmp/s.jsonl"]
     end
   end
 
   describe "build_command/6 — model qualification" do
-    test "prefixes bare model names with `anthropic/`" do
+    test "leaves provider-qualified model names unchanged" do
       {_, args} =
-        Command.build_command("hi", "claude-opus-4-6", "/tmp/p.txt", nil, nil)
+        Command.build_command("hi", "openai/gpt-5.5", "/tmp/p.txt", nil, nil)
 
-      assert Enum.at(args, 1) == "anthropic/claude-opus-4-6"
-    end
-
-    test "leaves already-qualified model names unchanged" do
-      {_, args} =
-        Command.build_command("hi", "anthropic/claude-opus-4-6", "/tmp/p.txt", nil, nil)
-
-      assert Enum.at(args, 1) == "anthropic/claude-opus-4-6"
-    end
-
-    test "leaves other-provider model names unchanged" do
-      {_, args} =
-        Command.build_command("hi", "openai/gpt-4o", "/tmp/p.txt", nil, nil)
-
-      assert Enum.at(args, 1) == "openai/gpt-4o"
+      assert Enum.at(args, 1) == "openai/gpt-5.5"
     end
   end
 end

--- a/lib/harness/dispatch.sh
+++ b/lib/harness/dispatch.sh
@@ -242,10 +242,10 @@ harness_entry() {
 #   $1 entry_id, $2 parent_id, $3 timestamp_iso, $4 shell_name,
 #   $5 agent, $6 harness_name, $7 headless ("true" | "false"),
 #   $8 meta_json (optional, "{}" or "" for none),
-#   $9 model   (optional, "" for none — absence of `.model` on the
-#              output signals "harness default was used". `wake_entry`
-#              itself never writes null; readers processing wake events
-#              from other sources should normalize null to absent.)
+#   $9 model   (optional for low-level callers, but required by
+#              `sessions wake`. `wake_entry` itself never writes null;
+#              readers processing wake events from other sources should
+#              normalize null to absent.)
 #
 # Field-placement rule: fields that `sessions wake` itself owns
 # (`.headless`, `.model`) go top-level; caller-provided key=value pairs
@@ -278,8 +278,8 @@ wake_entry() {
   local headless_bool=false
   [ "$headless" = "true" ] && headless_bool=true
 
-  # `.model` is written only when explicitly provided. Absent means
-  # "harness default was used"; readers can distinguish the two cases.
+  # `.model` is written only when explicitly provided. `sessions wake`
+  # requires it; absence is reserved for legacy/imported wake events.
   # `"${arr[@]+"${arr[@]}"}"` is the nounset-safe empty-array expansion
   # (bash < 4.4 treats `"${empty[@]}"` as an unset reference under -u).
   local model_args=()

--- a/test/export.bats
+++ b/test/export.bats
@@ -4,7 +4,7 @@ load helpers
 
 setup() {
   setup_test_sessions
-  export EXPORT_DIR="$BATS_TMPDIR/export-test-$$"
+  export EXPORT_DIR="$BATS_TEST_TMPDIR/export-test"
   mkdir -p "$EXPORT_DIR"
 }
 

--- a/test/harness_dispatch.bats
+++ b/test/harness_dispatch.bats
@@ -246,7 +246,7 @@ JSONL
 # --- `sessions new` integration ---
 
 @test "new writes a harness entry as line 2" {
-  run sessions new --cwd "$BATS_TMPDIR"
+  run sessions new --cwd "$BATS_TEST_TMPDIR"
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
@@ -254,7 +254,7 @@ JSONL
 }
 
 @test "new --harness pi produces same header shape" {
-  run sessions new --cwd "$BATS_TMPDIR" --harness pi
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --harness pi
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
@@ -263,7 +263,7 @@ JSONL
 
 @test "new --harness xyz errors before writing a session file" {
   initial_count=$(find "$PI_DIR/agent/sessions" -name '*.jsonl' 2>/dev/null | wc -l | tr -d ' ')
-  run sessions new --cwd "$BATS_TMPDIR" --harness xyz
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --harness xyz
   [ "$status" -ne 0 ]
   echo "$output" | grep -qi "unknown harness"
   # No new session file got created
@@ -277,7 +277,7 @@ JSONL
   # for isolation so we don't poke at the real ~/.claude.
   export CLAUDE_DIR="$BATS_TEST_TMPDIR/claude-home"
 
-  run sessions new --cwd "$BATS_TMPDIR" --harness claude acceptance-foo
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --harness claude acceptance-foo
   [ "$status" -eq 10 ]
   echo "$output" | grep -q "'claude' harness does not support 'session_file_path'"
 
@@ -290,7 +290,7 @@ JSONL
   # lives under PI_DIR so pi's find_session locates it; the harness
   # entry then wins over path-based detection (see the priority test
   # above), so wake dispatches to claude — which errors UNSUPPORTED
-  # when the Elixir run path asks claude for its default model.
+  # when the Elixir run path asks claude to build the harness command.
   # Foreground wake (no --background) — execs mise run directly, so
   # `shell` isn't required.
 
@@ -298,17 +298,15 @@ JSONL
   local sf="$PI_DIR/agent/sessions/--claude-acceptance--/2026-04-22T10-00-00-000Z_${sid}.jsonl"
   mkdir -p "$(dirname "$sf")"
   cat > "$sf" <<JSONL
-{"type":"session","version":3,"id":"${sid}","timestamp":"2026-04-22T10:00:00.000Z","cwd":"$BATS_TMPDIR"}
+{"type":"session","version":3,"id":"${sid}","timestamp":"2026-04-22T10:00:00.000Z","cwd":"$BATS_TEST_TMPDIR"}
 {"type":"harness","id":"h1","parentId":"${sid}","timestamp":"2026-04-22T10:00:00.000Z","name":"claude"}
 JSONL
 
-  run sessions wake "${sid:0:8}" --message "acceptance"
+  run sessions wake "${sid:0:8}" --model "openai/gpt-5.5" --message "acceptance"
   [ "$status" -eq 10 ]
   # The user-facing message should name the claude harness and the
-  # specific unsupported op. Which op fires first depends on the
-  # Elixir startup order; default_model is the earliest thing to need
-  # claude knowledge.
-  echo "$output" | grep -q "'claude' harness does not support"
+  # specific unsupported op.
+  echo "$output" | grep -q "'claude' harness does not support 'build_command'"
 }
 
 # --- Cross-adapter find aggregator (hard error surfacing) ---
@@ -381,9 +379,9 @@ JSONL
 
 @test "wake_entry omits .model when 9th arg is absent or empty" {
   # Both absent (no 9th arg) and explicit empty string must produce no
-  # `.model` field. Absence signals "harness default was used"; the
-  # empty-string case exercises the `[ -n "$model" ]` gate so it
-  # doesn't accidentally emit `{"model": ""}`.
+  # `.model` field. `sessions wake` requires a model; this low-level
+  # behavior is for legacy/imported wake entries and exercises the
+  # `[ -n "$model" ]` gate so it doesn't accidentally emit `{"model": ""}`.
   for arg in absent empty; do
     if [ "$arg" = "absent" ]; then
       run wake_entry w1 parent1 "2026-04-22T10:00:00.000Z" shellA ikma pi true "{}"

--- a/test/harness_dispatch.bats
+++ b/test/harness_dispatch.bats
@@ -302,7 +302,7 @@ JSONL
 {"type":"harness","id":"h1","parentId":"${sid}","timestamp":"2026-04-22T10:00:00.000Z","name":"claude"}
 JSONL
 
-  run sessions wake "${sid:0:8}" --model "openai/gpt-5.5" --message "acceptance"
+  run sessions wake "${sid:0:8}" --model "openai-codex/gpt-5.5" --message "acceptance"
   [ "$status" -eq 10 ]
   # The user-facing message should name the claude harness and the
   # specific unsupported op.

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -7,11 +7,10 @@
 #   - Synthetic JSONL generation (pi format)
 #   - Common setup/teardown
 
-# The canonical invocation is `mise run test`; that's what sets up
-# mise-managed tools (jq, bats, erlang, elixir, shell) on PATH. These
-# helpers don't try to support running bats directly — they just make
-# sure that when the suite DOES run, test code resolves repo paths to
-# the tree under test rather than reaching for any inherited env var.
+# test/setup_suite.bash loads this repo's mise environment once per bats
+# invocation so both `mise run test` and direct `bats test/foo.bats` exercise
+# the same tool versions. This helper still derives REPO_DIR from bats as a
+# fallback so individual files remain anchored to the tree under test.
 #
 # Three primitives, three contexts:
 #   - .mise/tasks/*       → $MISE_CONFIG_ROOT (mise sets it, task uses it)
@@ -21,7 +20,7 @@
 # Each layer uses its own primitive; nothing leaks across boundaries.
 # See KnickKnackLabs/codebase#16 for the broader lint that enforces
 # this.
-REPO_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+REPO_DIR="${REPO_DIR:-$(cd "$BATS_TEST_DIRNAME/.." && pwd)}"
 export REPO_DIR
 
 sessions() {
@@ -34,7 +33,7 @@ SESSION_1="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 SESSION_2="11111111-2222-3333-4444-555555555555"
 
 setup_test_sessions() {
-  export PI_DIR="$BATS_TMPDIR/pi-test-$$"
+  export PI_DIR="$BATS_TEST_TMPDIR/pi-test"
   export PROJECT_DIR="$PI_DIR/agent/sessions/--test-project--/"
   mkdir -p "$PROJECT_DIR"
 

--- a/test/import.bats
+++ b/test/import.bats
@@ -4,7 +4,7 @@ load helpers
 
 setup() {
   setup_test_sessions
-  export EXPORT_DIR="$BATS_TMPDIR/import-test-$$"
+  export EXPORT_DIR="$BATS_TEST_TMPDIR/import-test"
   mkdir -p "$EXPORT_DIR"
 
   # Export session 1 as a bundle to use for import tests

--- a/test/new.bats
+++ b/test/new.bats
@@ -119,7 +119,7 @@ teardown() { teardown_test_sessions; }
 }
 
 @test "new rejects --model" {
-  run sessions new --cwd "$BATS_TEST_TMPDIR" --model "openai/gpt-5.5"
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --model "openai-codex/gpt-5.5"
   [ "$status" -ne 0 ]
   echo "$output" | grep -q "unexpected"
 }

--- a/test/new.bats
+++ b/test/new.bats
@@ -8,7 +8,7 @@ teardown() { teardown_test_sessions; }
 # --- basic creation ---
 
 @test "new creates a session file (cwd defaults to .)" {
-  run sessions new --cwd "$BATS_TMPDIR"
+  run sessions new --cwd "$BATS_TEST_TMPDIR"
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   found=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl" | wc -l | tr -d ' ')
@@ -16,13 +16,13 @@ teardown() { teardown_test_sessions; }
 }
 
 @test "new outputs a valid UUID" {
-  run sessions new --cwd "$BATS_TMPDIR"
+  run sessions new --cwd "$BATS_TEST_TMPDIR"
   [ "$status" -eq 0 ]
   echo "$output" | head -1 | grep -qE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
 }
 
 @test "new creates valid session header" {
-  run sessions new --cwd "$BATS_TMPDIR"
+  run sessions new --cwd "$BATS_TEST_TMPDIR"
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
@@ -43,12 +43,12 @@ teardown() { teardown_test_sessions; }
 }
 
 @test "new --cwd stores absolute path in header" {
-  run sessions new --cwd "$BATS_TMPDIR"
+  run sessions new --cwd "$BATS_TEST_TMPDIR"
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
   header=$(head -1 "$new_file")
-  echo "$header" | jq -r '.cwd' | grep -q "$BATS_TMPDIR"
+  echo "$header" | jq -r '.cwd' | grep -q "$BATS_TEST_TMPDIR"
 }
 
 @test "new --cwd errors on nonexistent directory" {
@@ -60,7 +60,7 @@ teardown() { teardown_test_sessions; }
 # --- naming ---
 
 @test "new with name stores it in session header" {
-  run sessions new pr-review-50 --cwd "$BATS_TMPDIR"
+  run sessions new pr-review-50 --cwd "$BATS_TEST_TMPDIR"
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
@@ -69,7 +69,7 @@ teardown() { teardown_test_sessions; }
 }
 
 @test "new without name has no name field in header" {
-  run sessions new --cwd "$BATS_TMPDIR"
+  run sessions new --cwd "$BATS_TEST_TMPDIR"
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
@@ -78,13 +78,13 @@ teardown() { teardown_test_sessions; }
 }
 
 @test "new with name shows name in output" {
-  run sessions new scout-report --cwd "$BATS_TMPDIR"
+  run sessions new scout-report --cwd "$BATS_TEST_TMPDIR"
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "scout-report"
 }
 
 @test "named session is findable by name" {
-  run sessions new find-me-by-name --cwd "$BATS_TMPDIR"
+  run sessions new find-me-by-name --cwd "$BATS_TEST_TMPDIR"
   [ "$status" -eq 0 ]
   run sessions meta find-me-by-name
   [ "$status" -eq 0 ]
@@ -92,7 +92,7 @@ teardown() { teardown_test_sessions; }
 }
 
 @test "name supports slashes for namespacing" {
-  run sessions new feature/reddit/auth --cwd "$BATS_TMPDIR"
+  run sessions new feature/reddit/auth --cwd "$BATS_TEST_TMPDIR"
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
@@ -100,59 +100,57 @@ teardown() { teardown_test_sessions; }
   echo "$header" | jq -e '.name == "feature/reddit/auth"'
 }
 
-# --- model ---
+# --- harness ---
 
 @test "new includes harness entry as line 2" {
-  run sessions new --cwd "$BATS_TMPDIR"
+  run sessions new --cwd "$BATS_TEST_TMPDIR"
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
   sed -n '2p' "$new_file" | jq -e '.type == "harness" and .name == "pi"'
 }
 
-@test "new includes model_change entry as line 3" {
-  run sessions new --cwd "$BATS_TMPDIR"
+@test "new does not write a synthetic model_change entry" {
+  run sessions new --cwd "$BATS_TEST_TMPDIR"
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
-  sed -n '3p' "$new_file" | jq -e '.type == "model_change"'
+  ! jq -e 'select(.type == "model_change")' "$new_file"
 }
 
-@test "new respects --model flag" {
-  run sessions new --cwd "$BATS_TMPDIR" --model "claude-opus-4-6"
-  [ "$status" -eq 0 ]
-  new_id=$(echo "$output" | head -1)
-  new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
-  sed -n '3p' "$new_file" | jq -e '.modelId == "claude-opus-4-6"'
+@test "new rejects --model" {
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --model "openai/gpt-5.5"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "unexpected"
 }
 
 # --- context ---
 
 @test "new injects context as user message" {
-  run sessions new --cwd "$BATS_TMPDIR" --context "You are reviewing PR #42"
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --context "You are reviewing PR #42"
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
   lines=$(wc -l < "$new_file" | tr -d ' ')
-  # session + harness + model_change + message = 4 lines
-  [ "$lines" -eq 4 ]
+  # session + harness + message = 3 lines
+  [ "$lines" -eq 3 ]
   tail -1 "$new_file" | jq -e '.type == "message"'
   tail -1 "$new_file" | jq -r '.message.content[0].text' | grep -q "PR #42"
 }
 
-@test "new without context creates 3-entry session" {
-  run sessions new --cwd "$BATS_TMPDIR"
+@test "new without context creates 2-entry session" {
+  run sessions new --cwd "$BATS_TEST_TMPDIR"
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
   lines=$(wc -l < "$new_file" | tr -d ' ')
-  # session + harness + model_change = 3 lines
-  [ "$lines" -eq 3 ]
+  # session + harness = 2 lines
+  [ "$lines" -eq 2 ]
 }
 
 @test "new --context-file reads from file" {
-  echo "You are agent Ikma. Review the following diff." > "$BATS_TMPDIR/ctx.md"
-  run sessions new --cwd "$BATS_TMPDIR" --context-file "$BATS_TMPDIR/ctx.md"
+  echo "You are agent Ikma. Review the following diff." > "$BATS_TEST_TMPDIR/ctx.md"
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --context-file "$BATS_TEST_TMPDIR/ctx.md"
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
@@ -160,7 +158,7 @@ teardown() { teardown_test_sessions; }
 }
 
 @test "new errors with nonexistent context file" {
-  run sessions new --cwd "$BATS_TMPDIR" --context-file "/tmp/nonexistent-$$"
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --context-file "/tmp/nonexistent-$$"
   [ "$status" -eq 1 ]
   echo "$output" | grep -q "not found"
 }
@@ -168,7 +166,7 @@ teardown() { teardown_test_sessions; }
 # --- pi naming ---
 
 @test "new creates file with pi naming convention" {
-  run sessions new --cwd "$BATS_TMPDIR"
+  run sessions new --cwd "$BATS_TEST_TMPDIR"
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
@@ -179,7 +177,7 @@ teardown() { teardown_test_sessions; }
 # --- integration ---
 
 @test "new session is readable by sessions read" {
-  run sessions new --cwd "$BATS_TMPDIR" --context "hello from new"
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --context "hello from new"
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   run sessions read "$new_id"
@@ -187,11 +185,11 @@ teardown() { teardown_test_sessions; }
   echo "$output" | grep -q "hello from new"
 }
 
-@test "new session appears in sessions list" {
-  run sessions new --cwd "$BATS_TMPDIR" --context "list test"
+@test "new stub session is omitted from default sessions list" {
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --context "list test"
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
   run sessions list
   [ "$status" -eq 0 ]
-  echo "$output" | grep -q "${new_id:0:8}"
+  ! echo "$output" | grep -q "${new_id:0:8}"
 }

--- a/test/remove.bats
+++ b/test/remove.bats
@@ -23,7 +23,7 @@ teardown() { teardown_test_sessions; }
 
 @test "remove deletes a session by name" {
   # Create a named session
-  run sessions new --cwd "$BATS_TMPDIR" test-named
+  run sessions new --cwd "$BATS_TEST_TMPDIR" test-named
   [ "$status" -eq 0 ]
   new_id=$(echo "$output" | head -1)
 
@@ -61,7 +61,7 @@ teardown() { teardown_test_sessions; }
 }
 
 @test "remove shows display name for named sessions" {
-  run sessions new --cwd "$BATS_TMPDIR" my-cool-session
+  run sessions new --cwd "$BATS_TEST_TMPDIR" my-cool-session
   [ "$status" -eq 0 ]
 
   run sessions remove --force my-cool-session

--- a/test/setup_suite.bash
+++ b/test/setup_suite.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+setup_suite() {
+  REPO_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  export REPO_DIR
+
+  # Let direct `bats test/foo.bats` invocations load this repo's mise tool
+  # environment instead of inheriting an agent launcher's PATH/MCR context.
+  if [ -n "${MISE_TRUSTED_CONFIG_PATHS:-}" ]; then
+    export MISE_TRUSTED_CONFIG_PATHS="$REPO_DIR:$MISE_TRUSTED_CONFIG_PATHS"
+  else
+    export MISE_TRUSTED_CONFIG_PATHS="$REPO_DIR"
+  fi
+
+  eval "$(cd "$REPO_DIR" && mise env)"
+}

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -26,13 +26,13 @@ teardown() {
 # --- Validation ---
 
 @test "wake errors on nonexistent session" {
-  run sessions wake "deadbeef" --model "openai/gpt-5.5"
+  run sessions wake "deadbeef" --model "openai-codex/gpt-5.5"
   [ "$status" -eq 1 ]
   echo "$output" | grep -qi "no session"
 }
 
 @test "wake errors when context file missing" {
-  run sessions wake "$SESSION_1" --model "openai/gpt-5.5" --context-file "/tmp/nonexistent-$$"
+  run sessions wake "$SESSION_1" --model "openai-codex/gpt-5.5" --context-file "/tmp/nonexistent-$$"
   [ "$status" -eq 1 ]
   echo "$output" | grep -q "not found"
 }
@@ -41,7 +41,7 @@ teardown() {
 
 @test "wake --background launches session via shell" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "${SESSION_1:0:8}" --background --model "openai/gpt-5.5"
+  run sessions wake "${SESSION_1:0:8}" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "$SESSION_1"
   shell list 2>/dev/null | grep -q "${SESSION_1:0:8}"
@@ -52,7 +52,7 @@ teardown() {
   run sessions new "wake-bg-name-test-$$"
   [ "$status" -eq 0 ]
 
-  run sessions wake "wake-bg-name-test-$$" --background --model "openai/gpt-5.5"
+  run sessions wake "wake-bg-name-test-$$" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   shell list 2>/dev/null | grep -q "wake-bg-name-test-$$"
 }
@@ -62,14 +62,14 @@ teardown() {
   run sessions new "feature/bg-test-$$"
   [ "$status" -eq 0 ]
 
-  run sessions wake "feature/bg-test-$$" --background --model "openai/gpt-5.5"
+  run sessions wake "feature/bg-test-$$" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   shell list 2>/dev/null | grep -q "feature-bg-test-$$"
 }
 
 @test "wake --background shows monitor instructions" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "$SESSION_1" --background --model "openai/gpt-5.5"
+  run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "Monitor:"
 }
@@ -101,7 +101,7 @@ STUB
   chmod +x "$stub_dir/sessions"
 
   # Keep mise itself discoverable; just shadow `sessions`.
-  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai/gpt-5.5"
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   # If the stub ever fired, its stderr would leak into output.
   ! echo "$output" | grep -q "stub-sessions invoked"
@@ -111,7 +111,7 @@ STUB
 
 @test "wake injects context into session file" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "$SESSION_1" --background --model "openai/gpt-5.5" --context "Review PR #42"
+  run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5" --context "Review PR #42"
   [ "$status" -eq 0 ]
   src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
   grep -q "PR #42" "$src_file"
@@ -122,7 +122,7 @@ STUB
 @test "wake records wake event in session file" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
   export GIT_AUTHOR_NAME="test-agent"
-  run sessions wake "$SESSION_1" --background --model "openai/gpt-5.5"
+  run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
   jq -e 'select(.type == "wake")' "$src_file"
@@ -130,7 +130,7 @@ STUB
 
 @test "wake --headless records harness=pi and headless=true" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "$SESSION_1" --headless --background --model "openai/gpt-5.5"
+  run sessions wake "$SESSION_1" --headless --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
   jq -e 'select(.type == "wake" and .harness == "pi" and .headless == true)' "$src_file"
@@ -138,7 +138,7 @@ STUB
 
 @test "wake without --headless records harness=pi and headless=false" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "$SESSION_1" --background --model "openai/gpt-5.5"
+  run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
   jq -e 'select(.type == "wake" and .harness == "pi" and .headless == false)' "$src_file"
@@ -158,7 +158,7 @@ STUB
   # and confirming the same code path writes events for foreground.
   # The real foreground integration test would need the Elixir CLI.
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "$SESSION_1" --background --model "openai/gpt-5.5"
+  run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
 }
 
@@ -166,7 +166,7 @@ STUB
 
 @test "wake --meta records metadata in wake event" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "$SESSION_1" --background --model "openai/gpt-5.5" --meta "timeout=900"
+  run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5" --meta "timeout=900"
   [ "$status" -eq 0 ]
   src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
   jq -e 'select(.type == "wake" and .meta.timeout == "900")' "$src_file"
@@ -176,10 +176,10 @@ STUB
 
 @test "wake --model records model on wake event" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "$SESSION_1" --background --model "openai/gpt-5.5"
+  run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
-  jq -e 'select(.type == "wake" and .model == "openai/gpt-5.5")' "$src_file"
+  jq -e 'select(.type == "wake" and .model == "openai-codex/gpt-5.5")' "$src_file"
 }
 
 @test "wake requires --model" {
@@ -202,7 +202,7 @@ STUB
   #
   # We stub `shell` (which wake's --background path invokes with the full
   # RUN_CMD as argv) to dump its arguments to a file, then assert the
-  # dumped argv contains `--model openai/gpt-5.5` with the value
+  # dumped argv contains `--model openai-codex/gpt-5.5` with the value
   # immediately following the flag. This is a runtime check, not a grep
   # against source — it survives refactors of the wake task (variable
   # renames, reordering of the RUN_CMD build).
@@ -225,7 +225,7 @@ exit 0
 STUB
   chmod +x "$stub_dir/shell"
 
-  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai/gpt-5.5"
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   [ -f "$capture" ]
 
@@ -234,7 +234,7 @@ STUB
   # if a future refactor inserted args between flag and value.
   local line_after_flag
   line_after_flag=$(grep -A1 '^--model$' "$capture" | tail -1)
-  [ "$line_after_flag" = "openai/gpt-5.5" ]
+  [ "$line_after_flag" = "openai-codex/gpt-5.5" ]
 
   # Cardinality: exactly one --model in the argv (not duplicated).
   [ "$(grep -c '^--model$' "$capture")" = 1 ]
@@ -272,7 +272,7 @@ exit 0
 STUB
   chmod +x "$stub_dir/shell"
 
-  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai/gpt-5.5"
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   [ -f "$capture" ]
 
@@ -313,7 +313,7 @@ exit 0
 STUB
   chmod +x "$stub_dir/shell"
 
-  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai/gpt-5.5"
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   [ -f "$capture" ]
 

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -26,13 +26,13 @@ teardown() {
 # --- Validation ---
 
 @test "wake errors on nonexistent session" {
-  run sessions wake "deadbeef"
+  run sessions wake "deadbeef" --model "openai/gpt-5.5"
   [ "$status" -eq 1 ]
   echo "$output" | grep -qi "no session"
 }
 
 @test "wake errors when context file missing" {
-  run sessions wake "$SESSION_1" --context-file "/tmp/nonexistent-$$"
+  run sessions wake "$SESSION_1" --model "openai/gpt-5.5" --context-file "/tmp/nonexistent-$$"
   [ "$status" -eq 1 ]
   echo "$output" | grep -q "not found"
 }
@@ -41,7 +41,7 @@ teardown() {
 
 @test "wake --background launches session via shell" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "${SESSION_1:0:8}" --background
+  run sessions wake "${SESSION_1:0:8}" --background --model "openai/gpt-5.5"
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "$SESSION_1"
   shell list 2>/dev/null | grep -q "${SESSION_1:0:8}"
@@ -52,7 +52,7 @@ teardown() {
   run sessions new "wake-bg-name-test-$$"
   [ "$status" -eq 0 ]
 
-  run sessions wake "wake-bg-name-test-$$" --background
+  run sessions wake "wake-bg-name-test-$$" --background --model "openai/gpt-5.5"
   [ "$status" -eq 0 ]
   shell list 2>/dev/null | grep -q "wake-bg-name-test-$$"
 }
@@ -62,14 +62,14 @@ teardown() {
   run sessions new "feature/bg-test-$$"
   [ "$status" -eq 0 ]
 
-  run sessions wake "feature/bg-test-$$" --background
+  run sessions wake "feature/bg-test-$$" --background --model "openai/gpt-5.5"
   [ "$status" -eq 0 ]
   shell list 2>/dev/null | grep -q "feature-bg-test-$$"
 }
 
 @test "wake --background shows monitor instructions" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "$SESSION_1" --background
+  run sessions wake "$SESSION_1" --background --model "openai/gpt-5.5"
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "Monitor:"
 }
@@ -101,7 +101,7 @@ STUB
   chmod +x "$stub_dir/sessions"
 
   # Keep mise itself discoverable; just shadow `sessions`.
-  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai/gpt-5.5"
   [ "$status" -eq 0 ]
   # If the stub ever fired, its stderr would leak into output.
   ! echo "$output" | grep -q "stub-sessions invoked"
@@ -111,7 +111,7 @@ STUB
 
 @test "wake injects context into session file" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "$SESSION_1" --background --context "Review PR #42"
+  run sessions wake "$SESSION_1" --background --model "openai/gpt-5.5" --context "Review PR #42"
   [ "$status" -eq 0 ]
   src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
   grep -q "PR #42" "$src_file"
@@ -122,7 +122,7 @@ STUB
 @test "wake records wake event in session file" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
   export GIT_AUTHOR_NAME="test-agent"
-  run sessions wake "$SESSION_1" --background
+  run sessions wake "$SESSION_1" --background --model "openai/gpt-5.5"
   [ "$status" -eq 0 ]
   src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
   jq -e 'select(.type == "wake")' "$src_file"
@@ -130,7 +130,7 @@ STUB
 
 @test "wake --headless records harness=pi and headless=true" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "$SESSION_1" --headless --background
+  run sessions wake "$SESSION_1" --headless --background --model "openai/gpt-5.5"
   [ "$status" -eq 0 ]
   src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
   jq -e 'select(.type == "wake" and .harness == "pi" and .headless == true)' "$src_file"
@@ -138,7 +138,7 @@ STUB
 
 @test "wake without --headless records harness=pi and headless=false" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "$SESSION_1" --background
+  run sessions wake "$SESSION_1" --background --model "openai/gpt-5.5"
   [ "$status" -eq 0 ]
   src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
   jq -e 'select(.type == "wake" and .harness == "pi" and .headless == false)' "$src_file"
@@ -158,7 +158,7 @@ STUB
   # and confirming the same code path writes events for foreground.
   # The real foreground integration test would need the Elixir CLI.
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "$SESSION_1" --background
+  run sessions wake "$SESSION_1" --background --model "openai/gpt-5.5"
   [ "$status" -eq 0 ]
 }
 
@@ -166,7 +166,7 @@ STUB
 
 @test "wake --meta records metadata in wake event" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "$SESSION_1" --background --meta "timeout=900"
+  run sessions wake "$SESSION_1" --background --model "openai/gpt-5.5" --meta "timeout=900"
   [ "$status" -eq 0 ]
   src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
   jq -e 'select(.type == "wake" and .meta.timeout == "900")' "$src_file"
@@ -176,30 +176,33 @@ STUB
 
 @test "wake --model records model on wake event" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "$SESSION_1" --background --model "claude-opus-4-7"
+  run sessions wake "$SESSION_1" --background --model "openai/gpt-5.5"
   [ "$status" -eq 0 ]
   src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
-  jq -e 'select(.type == "wake" and .model == "claude-opus-4-7")' "$src_file"
+  jq -e 'select(.type == "wake" and .model == "openai/gpt-5.5")' "$src_file"
 }
 
-@test "wake without --model omits .model from wake event (harness default)" {
+@test "wake requires --model" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
   run sessions wake "$SESSION_1" --background
-  [ "$status" -eq 0 ]
-  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
-  # .model should be absent (null when queried), signaling "harness default used"
-  run jq -e 'select(.type == "wake") | has("model") | not' "$src_file"
-  [ "$status" -eq 0 ]
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q -- "--model is required"
+}
+
+@test "wake requires provider-qualified --model" {
+  command -v shell >/dev/null 2>&1 || skip "shell not installed"
+  run sessions wake "$SESSION_1" --background --model "gpt-5.5"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q -- "--model must be provider-qualified"
 }
 
 @test "wake --model forwards --model to sessions run in RUN_CMD" {
-  # Regression guard against the hardcoded @default_model in sessions run's
-  # Elixir CLI. `sessions wake --model X` must pass `--model X` down so the
-  # CLI doesn't fall back to its own default.
+  # Regression guard: `sessions wake --model X` must pass `--model X`
+  # down to the CLI so the execution-time model is explicit end to end.
   #
   # We stub `shell` (which wake's --background path invokes with the full
   # RUN_CMD as argv) to dump its arguments to a file, then assert the
-  # dumped argv contains `--model claude-opus-4-7` with the value
+  # dumped argv contains `--model openai/gpt-5.5` with the value
   # immediately following the flag. This is a runtime check, not a grep
   # against source — it survives refactors of the wake task (variable
   # renames, reordering of the RUN_CMD build).
@@ -222,7 +225,7 @@ exit 0
 STUB
   chmod +x "$stub_dir/shell"
 
-  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "claude-opus-4-7"
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai/gpt-5.5"
   [ "$status" -eq 0 ]
   [ -f "$capture" ]
 
@@ -231,7 +234,7 @@ STUB
   # if a future refactor inserted args between flag and value.
   local line_after_flag
   line_after_flag=$(grep -A1 '^--model$' "$capture" | tail -1)
-  [ "$line_after_flag" = "claude-opus-4-7" ]
+  [ "$line_after_flag" = "openai/gpt-5.5" ]
 
   # Cardinality: exactly one --model in the argv (not duplicated).
   [ "$(grep -c '^--model$' "$capture")" = 1 ]
@@ -239,28 +242,6 @@ STUB
   # Sanity: `sessions run` is also in the argv (confirms we're stubbing
   # the right layer).
   grep -q '^run$' "$capture"
-}
-
-@test "wake without --model omits --model from RUN_CMD" {
-  # Mirror of the forwarding test: when `--model` isn't passed, the
-  # string `--model` must NOT appear in the argv at all (otherwise the
-  # Elixir CLI would receive a bare flag with no value).
-  command -v shell >/dev/null 2>&1 || skip "shell not installed"
-
-  local stub_dir="$BATS_TEST_TMPDIR/stub-shell-nomodel"
-  local capture="$BATS_TEST_TMPDIR/shell-argv-nomodel"
-  mkdir -p "$stub_dir"
-  cat > "$stub_dir/shell" <<STUB
-#!/usr/bin/env bash
-printf '%s\n' "\$@" > "$capture"
-exit 0
-STUB
-  chmod +x "$stub_dir/shell"
-
-  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background
-  [ "$status" -eq 0 ]
-  [ -f "$capture" ]
-  ! grep -q '^--model$' "$capture"
 }
 
 @test "wake forwards session cwd to sessions run" {
@@ -291,7 +272,7 @@ exit 0
 STUB
   chmod +x "$stub_dir/shell"
 
-  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai/gpt-5.5"
   [ "$status" -eq 0 ]
   [ -f "$capture" ]
 
@@ -332,7 +313,7 @@ exit 0
 STUB
   chmod +x "$stub_dir/shell"
 
-  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai/gpt-5.5"
   [ "$status" -eq 0 ]
   [ -f "$capture" ]
 


### PR DESCRIPTION
## Summary

Require model selection at the execution boundary instead of silently falling back to Claude defaults.

- remove `sessions new --model` and stop writing synthetic `model_change` entries for stub sessions
- require `--model` on `sessions wake` and `sessions run`
- require provider-qualified model IDs (for example `openai-codex/gpt-5.5`)
- remove pi/claude harness default-model fallbacks
- update BATS harness setup so direct `bats test/foo.bats` and bare suite names via `mise run test wake` work

Closes #64. This also supersedes the default-model portion of #61.

## Notes

This intentionally does not update shimmer/fold dispatch plumbing. That is the next integration step: shimmer should stop passing model to `sessions new`, require model for dispatch/headless paths, and fold workflows should carry explicit provider-qualified models.

## Verification

- `mise run test` (211 BATS)
- `(cd cli && mix test)` (112 ExUnit + 4 doctests)
- `codebase lint:mise-settings "$PWD"`
- `codebase lint:gum-table "$PWD"`
- `codebase lint:bats-test-helper "$PWD"`
- `codebase lint:bats-test-task "$PWD"`
- `codebase lint:mcr-scope "$PWD"`
- `codebase lint:or-true "$PWD"`
- `codebase lint:shellcheck "$PWD"`
