### PR TITLE
ci: run sessions tests on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up mise
+        uses: jdx/mise-action@v3
+        with:
+          install: true
+
+      - name: Run BATS tests
+        run: mise run test
+
+      - name: Install CLI dependencies
+        run: mise run cli:build
+
+      - name: Run CLI tests
+        run: cd cli && mix test
+
+      - name: Run codebase lints
+        run: |
+          for target in \
+            lint:mise-settings \
+            lint:gum-table \
+            lint:bats-test-helper \
+            lint:bats-test-task \
+            lint:mcr-scope \
+            lint:or-true \
+            lint:shellcheck
+          do
+            codebase "$target" "$PWD"
+          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+env:
+  GH_TOKEN: ${{ github.token }}
+  GITHUB_TOKEN: ${{ github.token }}
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ permissions:
 env:
   GH_TOKEN: ${{ github.token }}
   GITHUB_TOKEN: ${{ github.token }}
+  MISE_JOBS: 1
 
 jobs:
   test:
@@ -29,11 +30,11 @@ jobs:
         with:
           install: true
 
-      - name: Run BATS tests
-        run: mise run test
-
       - name: Install CLI dependencies
         run: mise run cli:build
+
+      - name: Run BATS tests
+        run: mise run test
 
       - name: Run CLI tests
         run: cd cli && mix test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up mise
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
         with:
           install: true
 

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@ min_version = "2026.3.0"
 [settings]
 quiet = true
 task_output = "interleave"
+experimental = true
 
 [plugins]
 shiv = "https://github.com/KnickKnackLabs/vfox-shiv"

--- a/test/harness_dispatch.bats
+++ b/test/harness_dispatch.bats
@@ -302,7 +302,7 @@ JSONL
 {"type":"harness","id":"h1","parentId":"${sid}","timestamp":"2026-04-22T10:00:00.000Z","name":"claude"}
 JSONL
 
-  run sessions wake "${sid:0:8}" --model "openai-codex/gpt-5.5" --message "acceptance"
+  AGENT_IDENTITY="test identity" run sessions wake "${sid:0:8}" --model "openai-codex/gpt-5.5" --message "acceptance"
   [ "$status" -eq 10 ]
   # The user-facing message should name the claude harness and the
   # specific unsupported op.


### PR DESCRIPTION
## Summary

Add GitHub Actions CI for sessions so PRs get real checks instead of relying only on local verification.

- run on pull requests, pushes to main, and manual dispatch
- test on both `ubuntu-latest` and `macos-latest`
- run BATS, CLI ExUnit tests, and configured codebase lints

## Verification

- `mise run test`
- `mise run cli:build`
- `(cd cli && mix test)`
- `codebase lint:mise-settings "$PWD"`
- `codebase lint:gum-table "$PWD"`
- `codebase lint:bats-test-helper "$PWD"`
- `codebase lint:bats-test-task "$PWD"`
- `codebase lint:mcr-scope "$PWD"`
- `codebase lint:or-true "$PWD"`
- `codebase lint:shellcheck "$PWD"`

`actionlint` is not installed locally, so workflow syntax lint was skipped.
