### PR TITLE
fix: scrub caller context before harness spawn

### DIFF
--- a/cli/lib/cli/engine.ex
+++ b/cli/lib/cli/engine.ex
@@ -56,7 +56,14 @@ defmodule Cli.Engine do
 
     args = ["-c", shell_script, "--"] ++ positional_args
 
-    port_opts = [:binary, :exit_status, :stderr_to_stdout, {:args, args}]
+    port_opts = [
+      :binary,
+      :exit_status,
+      :stderr_to_stdout,
+      {:args, args},
+      {:env, [{~c"CALLER_PWD", false}, {~c"SHIV_CALLER_PWD", false}]}
+    ]
+
     port_opts = if cwd, do: [{:cd, cwd} | port_opts], else: port_opts
 
     port = Port.open({:spawn_executable, "/bin/sh"}, port_opts)

--- a/cli/test/engine_test.exs
+++ b/cli/test/engine_test.exs
@@ -47,4 +47,56 @@ defmodule Cli.EngineTest do
     assert exit_code == 0
     refute output =~ "Agent reported an error"
   end
+
+  test "scrubs caller context from harness process environment" do
+    previous_caller = System.get_env("CALLER_PWD")
+    previous_shiv_caller = System.get_env("SHIV_CALLER_PWD")
+
+    try do
+      System.put_env("CALLER_PWD", "/stale/caller")
+      System.put_env("SHIV_CALLER_PWD", "/stale/shiv/caller")
+
+      output =
+        capture_io(fn ->
+          exit_code =
+            Cli.Engine.run(
+              __MODULE__.EnvHarness,
+              "ignored",
+              "/tmp/prompt.txt",
+              nil,
+              "test-model",
+              nil,
+              nil,
+              []
+            )
+
+          send(self(), {:exit_code, exit_code})
+        end)
+
+      assert_receive {:exit_code, 0}
+      assert output =~ "CALLER_PWD="
+      assert output =~ "SHIV_CALLER_PWD="
+      refute output =~ "/stale/caller"
+      refute output =~ "/stale/shiv/caller"
+    after
+      restore_env("CALLER_PWD", previous_caller)
+      restore_env("SHIV_CALLER_PWD", previous_shiv_caller)
+    end
+  end
+
+  defmodule EnvHarness do
+    def build_command(_message, _model, _system_prompt_file, _session, _timeout, _opts) do
+      {"printf 'CALLER_PWD=%s\\n' \"${CALLER_PWD-}\"; printf 'SHIV_CALLER_PWD=%s\\n' \"${SHIV_CALLER_PWD-}\"", []}
+    end
+
+    def process_line(line, state) do
+      IO.puts(line)
+      state
+    end
+
+    def extract_partial_text(_partial), do: ""
+  end
+
+  defp restore_env(name, nil), do: System.delete_env(name)
+  defp restore_env(name, value), do: System.put_env(name, value)
 end


### PR DESCRIPTION
## Summary
- Remove `CALLER_PWD` and `SHIV_CALLER_PWD` from the harness process environment in `Cli.Engine`
- Add ExUnit coverage proving stale caller context does not reach the spawned harness

Part of KnickKnackLabs/shiv#104. This keeps cwd explicit via `--cwd`; caller-context env vars should not leak into long-lived agent harness processes.

## Verification
- `mise run cli:build`
- `mise run test wake`
- `mise run test`
- `(cd cli && mix test)`
