### PR TITLE
Use sessions-specific caller cwd

### DIFF
--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -19,7 +19,7 @@ SYSTEM_PROMPT_FILE="${usage_system_prompt_file:-}"
 TIMEOUT="${usage_timeout:-}"
 MODEL="${usage_model:-}"
 SESSION="${usage_session:-}"
-CWD="${usage_cwd:-${CALLER_PWD:-.}}"
+CWD="${usage_cwd:-${SESSIONS_CALLER_PWD:-${CALLER_PWD:-.}}}"
 HEADLESS="${usage_headless:-false}"
 # Extensions disabled by default (determinism for CI). Pass --extensions etc. to enable.
 EXTENSIONS="${usage_extensions:-false}"

--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -20,6 +20,15 @@ MODEL="${usage_model:-}"
 HEADLESS="${usage_headless:-false}"
 BACKGROUND="${usage_background:-false}"
 
+scrub_caller_pwd_env() {
+  local name
+  while IFS= read -r name; do
+    case "$name" in
+      CALLER_PWD|*_CALLER_PWD) unset "$name" ;;
+    esac
+  done < <(compgen -e)
+}
+
 if [ -z "$SESSION_ID" ]; then
   echo "Error: session ID or name required" >&2
   echo "Usage: sessions wake <name-or-id> --model <provider/model> [--message '...']" >&2
@@ -157,6 +166,8 @@ RUN_CMD=("${mise_run[@]}" run --session "$SESSION_FILE" --cwd "$SESSION_CWD" --m
 if [ -n "$MESSAGE" ]; then
   RUN_CMD+=("$MESSAGE")
 fi
+
+scrub_caller_pwd_env
 
 if [ "$BACKGROUND" = "true" ]; then
   # Background: launch via shell/zmx (fire-and-forget)

--- a/cli/lib/cli/engine.ex
+++ b/cli/lib/cli/engine.ex
@@ -61,7 +61,7 @@ defmodule Cli.Engine do
       :exit_status,
       :stderr_to_stdout,
       {:args, args},
-      {:env, [{~c"CALLER_PWD", false}, {~c"SHIV_CALLER_PWD", false}]}
+      {:env, caller_pwd_env_scrub()}
     ]
 
     port_opts = if cwd, do: [{:cd, cwd} | port_opts], else: port_opts
@@ -87,6 +87,13 @@ defmodule Cli.Engine do
     end
 
     status
+  end
+
+  defp caller_pwd_env_scrub do
+    System.get_env()
+    |> Map.keys()
+    |> Enum.filter(&(&1 == "CALLER_PWD" or String.ends_with?(&1, "_CALLER_PWD")))
+    |> Enum.map(&{String.to_charlist(&1), false})
   end
 
   defp stream_output(port, %{buffer: buffer} = state) do

--- a/cli/test/engine_test.exs
+++ b/cli/test/engine_test.exs
@@ -50,11 +50,13 @@ defmodule Cli.EngineTest do
 
   test "scrubs caller context from harness process environment" do
     previous_caller = System.get_env("CALLER_PWD")
-    previous_shiv_caller = System.get_env("SHIV_CALLER_PWD")
+    previous_sessions_caller = System.get_env("SESSIONS_CALLER_PWD")
+    previous_other_caller = System.get_env("OTHER_CALLER_PWD")
 
     try do
       System.put_env("CALLER_PWD", "/stale/caller")
-      System.put_env("SHIV_CALLER_PWD", "/stale/shiv/caller")
+      System.put_env("SESSIONS_CALLER_PWD", "/stale/sessions/caller")
+      System.put_env("OTHER_CALLER_PWD", "/stale/other/caller")
 
       output =
         capture_io(fn ->
@@ -75,18 +77,21 @@ defmodule Cli.EngineTest do
 
       assert_receive {:exit_code, 0}
       assert output =~ "CALLER_PWD="
-      assert output =~ "SHIV_CALLER_PWD="
+      assert output =~ "SESSIONS_CALLER_PWD="
+      assert output =~ "OTHER_CALLER_PWD="
       refute output =~ "/stale/caller"
-      refute output =~ "/stale/shiv/caller"
+      refute output =~ "/stale/sessions/caller"
+      refute output =~ "/stale/other/caller"
     after
       restore_env("CALLER_PWD", previous_caller)
-      restore_env("SHIV_CALLER_PWD", previous_shiv_caller)
+      restore_env("SESSIONS_CALLER_PWD", previous_sessions_caller)
+      restore_env("OTHER_CALLER_PWD", previous_other_caller)
     end
   end
 
   defmodule EnvHarness do
     def build_command(_message, _model, _system_prompt_file, _session, _timeout, _opts) do
-      {"printf 'CALLER_PWD=%s\\n' \"${CALLER_PWD-}\"; printf 'SHIV_CALLER_PWD=%s\\n' \"${SHIV_CALLER_PWD-}\"", []}
+      {"printf 'CALLER_PWD=%s\\n' \"${CALLER_PWD-}\"; printf 'SESSIONS_CALLER_PWD=%s\\n' \"${SESSIONS_CALLER_PWD-}\"; printf 'OTHER_CALLER_PWD=%s\\n' \"${OTHER_CALLER_PWD-}\"", []}
     end
 
     def process_line(line, state) do

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -286,6 +286,38 @@ STUB
   [ "$run_cwd" = "$expected_cwd" ]
 }
 
+@test "wake scrubs caller cwd variables before background shell launch" {
+  # `sessions wake --background` starts a long-lived shell/zmx process.
+  # Caller-cwd vars describe the immediate shiv invocation and become stale
+  # ambient state once the shell outlives that invocation, so wake must scrub
+  # them after materializing the explicit --cwd arguments.
+  command -v shell >/dev/null 2>&1 || skip "shell not installed"
+
+  local stub_dir="$BATS_TEST_TMPDIR/stub-shell-env"
+  local capture="$BATS_TEST_TMPDIR/shell-env"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/shell" <<STUB
+#!/usr/bin/env bash
+printf 'CALLER_PWD=%s\n' "\${CALLER_PWD-}" > "$capture"
+printf 'SESSIONS_CALLER_PWD=%s\n' "\${SESSIONS_CALLER_PWD-}" >> "$capture"
+printf 'OTHER_CALLER_PWD=%s\n' "\${OTHER_CALLER_PWD-}" >> "$capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/shell"
+
+  export CALLER_PWD="/stale/legacy"
+  export SESSIONS_CALLER_PWD="/stale/sessions"
+  export OTHER_CALLER_PWD="/stale/other"
+
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai-codex/gpt-5.5"
+  [ "$status" -eq 0 ]
+  [ -f "$capture" ]
+
+  grep -q '^CALLER_PWD=$' "$capture"
+  grep -q '^SESSIONS_CALLER_PWD=$' "$capture"
+  grep -q '^OTHER_CALLER_PWD=$' "$capture"
+}
+
 @test "wake normalizes invalid session cwd fallback before forwarding" {
   # When a persisted session cwd is missing, wake falls back to "current
   # directory". Once wake explicitly forwards --cwd to sessions run, that


### PR DESCRIPTION
## Summary
- prefer `SESSIONS_CALLER_PWD` over legacy `CALLER_PWD` for `sessions run` cwd defaults
- scrub `CALLER_PWD` and all `*_CALLER_PWD` variables from harness process environments

## Verification
- `mise run test`
- `cd cli && mix test`
- `git diff --check`
- `codebase lint:caller-pwd-contract` across shiv/shimmer/sessions/modules/threads/codebase
- `codebase lint:shellcheck` across shiv/shimmer/sessions/modules/threads
