### PR TITLE
feat(host): add run-as-user diagnostics

### DIFF
--- a/.mise/tasks/host/doctor
+++ b/.mise/tasks/host/doctor
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#MISE description="Check host setup for local OS-user session execution"
+#USAGE flag "--os-user <os_user>" help="Target agent OS user to check"
+set -euo pipefail
+
+OS_USER="${usage_os_user:-}"
+
+# shellcheck source=../../../lib/host.sh
+source "$MISE_CONFIG_ROOT/lib/host.sh"
+
+host_validate_user_name "$OS_USER"
+
+current_user=$(id -un)
+failures=0
+
+check_ok() {
+  printf 'OK    %s\n' "$1"
+}
+
+check_fail() {
+  printf 'FAIL  %s\n' "$1"
+  failures=$((failures + 1))
+}
+
+if host_group_exists "$HOST_HUMANS_GROUP"; then
+  check_ok "group '$HOST_HUMANS_GROUP' exists"
+else
+  check_fail "group '$HOST_HUMANS_GROUP' is missing"
+fi
+
+if host_group_exists "$HOST_AGENTS_GROUP"; then
+  check_ok "group '$HOST_AGENTS_GROUP' exists"
+else
+  check_fail "group '$HOST_AGENTS_GROUP' is missing"
+fi
+
+if host_user_exists "$OS_USER"; then
+  check_ok "target user '$OS_USER' exists"
+else
+  check_fail "target user '$OS_USER' is missing"
+fi
+
+if host_user_in_group "$current_user" "$HOST_HUMANS_GROUP"; then
+  check_ok "current user '$current_user' is in '$HOST_HUMANS_GROUP'"
+else
+  check_fail "current user '$current_user' is not in '$HOST_HUMANS_GROUP'"
+fi
+
+if host_user_exists "$OS_USER" && host_user_in_group "$OS_USER" "$HOST_AGENTS_GROUP"; then
+  check_ok "target user '$OS_USER' is in '$HOST_AGENTS_GROUP'"
+else
+  check_fail "target user '$OS_USER' is not in '$HOST_AGENTS_GROUP'"
+fi
+
+if host_sudoers_installed; then
+  check_ok "sudoers rule installed at $HOST_SUDOERS_FILE"
+else
+  check_fail "sudoers rule missing from $HOST_SUDOERS_FILE"
+fi
+
+if [ -x "$HOST_RUN_AS_USER" ]; then
+  check_ok "run-as-user helper is executable"
+else
+  check_fail "run-as-user helper is not executable: $HOST_RUN_AS_USER"
+fi
+
+if [ -x "$HOST_RUN_AS_USER" ] && "$HOST_RUN_AS_USER" --user "$OS_USER" -- whoami >/tmp/sessions-host-doctor-whoami.$$ 2>/tmp/sessions-host-doctor-err.$$; then
+  observed=$(cat /tmp/sessions-host-doctor-whoami.$$)
+  if [ "$observed" = "$OS_USER" ]; then
+    check_ok "run-as-user smoke test returned '$OS_USER'"
+  else
+    check_fail "run-as-user smoke test returned '$observed'"
+  fi
+else
+  err=$(cat /tmp/sessions-host-doctor-err.$$ 2>/dev/null || : ) # codebase:ignore or-true — diagnostic fallback when smoke test did not create stderr
+  if [ -n "$err" ]; then
+    check_fail "run-as-user smoke test failed: $err"
+  else
+    check_fail "run-as-user smoke test failed"
+  fi
+fi
+rm -f /tmp/sessions-host-doctor-whoami.$$ /tmp/sessions-host-doctor-err.$$
+
+if [ "$failures" -gt 0 ]; then
+  echo "host doctor failed: $failures issue(s)" >&2
+  exit 1
+fi

--- a/.mise/tasks/host/doctor
+++ b/.mise/tasks/host/doctor
@@ -58,6 +58,12 @@ else
   check_fail "sudoers rule missing from $HOST_SUDOERS_FILE"
 fi
 
+if host_sudoers_valid; then
+  check_ok "sudoers file syntax is valid"
+else
+  check_fail "sudoers file syntax is invalid or cannot be validated: $HOST_SUDOERS_FILE"
+fi
+
 if [ -x "$HOST_RUN_AS_USER" ]; then
   check_ok "run-as-user helper is executable"
 else

--- a/.mise/tasks/host/doctor
+++ b/.mise/tasks/host/doctor
@@ -22,6 +22,10 @@ check_fail() {
   failures=$((failures + 1))
 }
 
+check_info() {
+  printf 'INFO  %s\n' "$1"
+}
+
 if host_group_exists "$HOST_HUMANS_GROUP"; then
   check_ok "group '$HOST_HUMANS_GROUP' exists"
 else
@@ -52,16 +56,22 @@ else
   check_fail "target user '$OS_USER' is not in '$HOST_AGENTS_GROUP'"
 fi
 
-if host_sudoers_installed; then
-  check_ok "sudoers rule installed at $HOST_SUDOERS_FILE"
+if ! host_sudoers_exists; then
+  check_fail "sudoers file missing: $HOST_SUDOERS_FILE"
+elif ! host_sudoers_readable; then
+  check_info "sudoers file exists but is not readable by '$current_user'; relying on run-as-user smoke test"
 else
-  check_fail "sudoers rule missing from $HOST_SUDOERS_FILE"
-fi
+  if host_sudoers_installed; then
+    check_ok "sudoers rule installed at $HOST_SUDOERS_FILE"
+  else
+    check_fail "sudoers rule missing from $HOST_SUDOERS_FILE"
+  fi
 
-if host_sudoers_valid; then
-  check_ok "sudoers file syntax is valid"
-else
-  check_fail "sudoers file syntax is invalid or cannot be validated: $HOST_SUDOERS_FILE"
+  if host_sudoers_valid; then
+    check_ok "sudoers file syntax is valid"
+  else
+    check_fail "sudoers file syntax is invalid or cannot be validated: $HOST_SUDOERS_FILE"
+  fi
 fi
 
 if [ -x "$HOST_RUN_AS_USER" ]; then

--- a/.mise/tasks/host/fix
+++ b/.mise/tasks/host/fix
@@ -36,7 +36,7 @@ if ! host_user_in_group "$OS_USER" "$HOST_AGENTS_GROUP"; then
   planned+=("$(host_add_user_to_group_command "$OS_USER" "$HOST_AGENTS_GROUP")")
 fi
 
-if ! host_sudoers_installed || ! host_sudoers_valid; then
+if host_sudoers_needs_repair "$OS_USER"; then
   while IFS= read -r cmd; do
     [ -n "$cmd" ] && planned+=("$cmd")
   done < <(host_install_sudoers_commands)

--- a/.mise/tasks/host/fix
+++ b/.mise/tasks/host/fix
@@ -36,7 +36,7 @@ if ! host_user_in_group "$OS_USER" "$HOST_AGENTS_GROUP"; then
   planned+=("$(host_add_user_to_group_command "$OS_USER" "$HOST_AGENTS_GROUP")")
 fi
 
-if ! host_sudoers_installed; then
+if ! host_sudoers_installed || ! host_sudoers_valid; then
   while IFS= read -r cmd; do
     [ -n "$cmd" ] && planned+=("$cmd")
   done < <(host_install_sudoers_commands)

--- a/.mise/tasks/host/fix
+++ b/.mise/tasks/host/fix
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#MISE description="Repair host setup for local OS-user session execution"
+#USAGE flag "--os-user <os_user>" help="Target agent OS user to include in the agents group"
+#USAGE flag "--dry-run" help="Print planned host changes without applying them"
+set -euo pipefail
+
+OS_USER="${usage_os_user:-}"
+DRY_RUN="${usage_dry_run:-false}"
+
+# shellcheck source=../../../lib/host.sh
+source "$MISE_CONFIG_ROOT/lib/host.sh"
+
+host_validate_user_name "$OS_USER"
+
+current_user=$(id -un)
+planned=()
+
+if ! host_group_exists "$HOST_HUMANS_GROUP"; then
+  planned+=("$(host_create_group_command "$HOST_HUMANS_GROUP")")
+fi
+
+if ! host_group_exists "$HOST_AGENTS_GROUP"; then
+  planned+=("$(host_create_group_command "$HOST_AGENTS_GROUP")")
+fi
+
+if ! host_user_exists "$OS_USER"; then
+  echo "Error: target user '$OS_USER' does not exist; create the agent OS user first" >&2
+  exit 1
+fi
+
+if ! host_user_in_group "$current_user" "$HOST_HUMANS_GROUP"; then
+  planned+=("$(host_add_user_to_group_command "$current_user" "$HOST_HUMANS_GROUP")")
+fi
+
+if ! host_user_in_group "$OS_USER" "$HOST_AGENTS_GROUP"; then
+  planned+=("$(host_add_user_to_group_command "$OS_USER" "$HOST_AGENTS_GROUP")")
+fi
+
+if ! host_sudoers_installed; then
+  while IFS= read -r cmd; do
+    [ -n "$cmd" ] && planned+=("$cmd")
+  done < <(host_install_sudoers_commands)
+fi
+
+if [ ${#planned[@]} -eq 0 ]; then
+  echo "Host setup already matches the sessions humans→agents policy."
+  exit 0
+fi
+
+if [ "$DRY_RUN" = "true" ]; then
+  echo "Would apply these host changes:"
+  printf '  %s\n' "${planned[@]}"
+  exit 0
+fi
+
+echo "Error: mutating host:fix is not implemented yet; rerun with --dry-run to inspect planned changes" >&2
+exit 2

--- a/lib/host.sh
+++ b/lib/host.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Shared host policy helpers for local OS-user session execution.
+
+HOST_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOST_REPO_DIR="$(cd "$HOST_LIB_DIR/.." && pwd)"
+HOST_HUMANS_GROUP="${SESSIONS_HUMANS_GROUP:-humans}"
+HOST_AGENTS_GROUP="${SESSIONS_AGENTS_GROUP:-agents}"
+HOST_SUDOERS_FILE="${SESSIONS_SUDOERS_FILE:-/etc/sudoers.d/sessions-humans-agents}"
+HOST_RUN_AS_USER="${SESSIONS_RUN_AS_USER:-$HOST_REPO_DIR/libexec/run-as-user}"
+
+host_user_exists() {
+  id -u "$1" >/dev/null 2>&1
+}
+
+host_group_exists() {
+  if command -v dscl >/dev/null 2>&1; then
+    dscl . -read "/Groups/$1" >/dev/null 2>&1
+  else
+    getent group "$1" >/dev/null 2>&1
+  fi
+}
+
+host_user_in_group() {
+  local user="$1" group="$2"
+  id -Gn "$user" 2>/dev/null | tr ' ' '\n' | grep -Fxq "$group"
+}
+
+host_sudoers_rule() {
+  printf '%%%s ALL=(%%%s) NOPASSWD: ALL\n' "$HOST_HUMANS_GROUP" "$HOST_AGENTS_GROUP"
+}
+
+host_sudoers_installed() {
+  [ -f "$HOST_SUDOERS_FILE" ] && grep -Fxq "$(host_sudoers_rule)" "$HOST_SUDOERS_FILE"
+}
+
+host_create_group_command() {
+  local group="$1"
+  printf 'sudo dseditgroup -o create %q\n' "$group"
+}
+
+host_add_user_to_group_command() {
+  local user="$1" group="$2"
+  printf 'sudo dseditgroup -o edit -a %q -t user %q\n' "$user" "$group"
+}
+
+host_install_sudoers_commands() {
+  local rule
+  rule=$(host_sudoers_rule)
+  printf 'printf %%s\\n %q | sudo tee %q >/dev/null\n' "$rule" "$HOST_SUDOERS_FILE"
+  printf 'sudo chmod 0440 %q\n' "$HOST_SUDOERS_FILE"
+  printf 'sudo visudo -cf %q\n' "$HOST_SUDOERS_FILE"
+}
+
+host_validate_user_name() {
+  local user="$1"
+  if [ -z "$user" ]; then
+    echo "Error: --os-user is required" >&2
+    return 2
+  fi
+  if [[ "$user" == -* ]]; then
+    echo "Error: --os-user value cannot start with a dash: '$user'" >&2
+    return 2
+  fi
+  if ! [[ "$user" =~ ^[a-zA-Z_][a-zA-Z0-9._-]*[$]?$ ]]; then
+    echo "Error: invalid --os-user value '$user'" >&2
+    return 2
+  fi
+}

--- a/lib/host.sh
+++ b/lib/host.sh
@@ -29,14 +29,42 @@ host_sudoers_rule() {
   printf '%%%s ALL=(%%%s) NOPASSWD: ALL\n' "$HOST_HUMANS_GROUP" "$HOST_AGENTS_GROUP"
 }
 
+host_sudoers_exists() {
+  [ -e "$HOST_SUDOERS_FILE" ]
+}
+
+host_sudoers_readable() {
+  [ -r "$HOST_SUDOERS_FILE" ]
+}
+
 host_sudoers_installed() {
-  [ -f "$HOST_SUDOERS_FILE" ] && grep -Fxq "$(host_sudoers_rule)" "$HOST_SUDOERS_FILE"
+  host_sudoers_readable && grep -Fxq "$(host_sudoers_rule)" "$HOST_SUDOERS_FILE"
 }
 
 host_sudoers_valid() {
-  [ -f "$HOST_SUDOERS_FILE" ] \
+  host_sudoers_readable \
     && command -v visudo >/dev/null 2>&1 \
     && visudo -cf "$HOST_SUDOERS_FILE" >/dev/null 2>&1
+}
+
+host_run_as_user_smoke() {
+  local user="$1"
+  [ -x "$HOST_RUN_AS_USER" ] && "$HOST_RUN_AS_USER" --user "$user" -- true >/dev/null 2>&1
+}
+
+host_sudoers_needs_repair() {
+  local user="$1"
+
+  if ! host_sudoers_exists; then
+    return 0
+  fi
+
+  if host_sudoers_readable; then
+    ! host_sudoers_installed || ! host_sudoers_valid
+    return $?
+  fi
+
+  ! host_run_as_user_smoke "$user"
 }
 
 host_create_group_command() {

--- a/lib/host.sh
+++ b/lib/host.sh
@@ -52,7 +52,7 @@ host_add_user_to_group_command() {
 host_install_sudoers_commands() {
   local rule
   rule=$(host_sudoers_rule)
-  printf 'printf %%s\\n %q | sudo tee %q >/dev/null\n' "$rule" "$HOST_SUDOERS_FILE"
+  printf "printf '%%s\\\\n' %q | sudo tee %q >/dev/null\n" "$rule" "$HOST_SUDOERS_FILE"
   printf 'sudo chmod 0440 %q\n' "$HOST_SUDOERS_FILE"
   printf 'sudo visudo -cf %q\n' "$HOST_SUDOERS_FILE"
 }

--- a/lib/host.sh
+++ b/lib/host.sh
@@ -33,6 +33,12 @@ host_sudoers_installed() {
   [ -f "$HOST_SUDOERS_FILE" ] && grep -Fxq "$(host_sudoers_rule)" "$HOST_SUDOERS_FILE"
 }
 
+host_sudoers_valid() {
+  [ -f "$HOST_SUDOERS_FILE" ] \
+    && command -v visudo >/dev/null 2>&1 \
+    && visudo -cf "$HOST_SUDOERS_FILE" >/dev/null 2>&1
+}
+
 host_create_group_command() {
   local group="$1"
   printf 'sudo dseditgroup -o create %q\n' "$group"

--- a/libexec/run-as-user
+++ b/libexec/run-as-user
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: run-as-user --user <user> -- <command...>" >&2
+}
+
+user=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --user)
+      if [ $# -lt 2 ]; then
+        echo "Error: --user requires a value" >&2
+        usage
+        exit 2
+      fi
+      user="$2"
+      shift 2
+    ;;
+    --)
+      shift
+      break
+    ;;
+    *)
+      echo "Error: unexpected argument '$1'" >&2
+      usage
+      exit 2
+    ;;
+  esac
+done
+
+if [ -z "$user" ]; then
+  echo "Error: --user is required" >&2
+  usage
+  exit 2
+fi
+
+if [[ "$user" == -* ]]; then
+  echo "Error: --user value cannot start with a dash: '$user'" >&2
+  exit 2
+fi
+
+if ! [[ "$user" =~ ^[a-zA-Z_][a-zA-Z0-9._-]*[$]?$ ]]; then
+  echo "Error: invalid --user value '$user'" >&2
+  echo "  User names must start with a letter or underscore and contain only letters, numbers, dots, underscores, hyphens, or a trailing dollar" >&2
+  exit 2
+fi
+
+if [ $# -eq 0 ]; then
+  echo "Error: command required after --" >&2
+  usage
+  exit 2
+fi
+
+if ! id -u "$user" >/dev/null 2>&1; then
+  echo "Error: target user '$user' does not exist" >&2
+  exit 1
+fi
+
+home=""
+shell=""
+if command -v dscl >/dev/null 2>&1; then
+  if home_line=$(dscl . -read "/Users/$user" NFSHomeDirectory 2>/dev/null); then
+    home=$(awk '{print $2; exit}' <<< "$home_line")
+  fi
+  if shell_line=$(dscl . -read "/Users/$user" UserShell 2>/dev/null); then
+    shell=$(awk '{print $2; exit}' <<< "$shell_line")
+  fi
+elif command -v getent >/dev/null 2>&1; then
+  if passwd_line=$(getent passwd "$user" 2>/dev/null); then
+    home=$(awk -F: '{print $6; exit}' <<< "$passwd_line")
+    shell=$(awk -F: '{print $7; exit}' <<< "$passwd_line")
+  fi
+fi
+
+home="${home:-/Users/$user}"
+shell="${shell:-/bin/bash}"
+controlled_path="$home/.local/bin:$home/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+exec sudo -n -H -u "$user" -- \
+  env -i \
+    HOME="$home" \
+    USER="$user" \
+    LOGNAME="$user" \
+    SHELL="$shell" \
+    PATH="$controlled_path" \
+    "$@"

--- a/test/host.bats
+++ b/test/host.bats
@@ -142,9 +142,26 @@ EOF
 
   run sessions host:fix --os-user iris --dry-run
   [ "$status" -eq 0 ]
+  [[ "$output" == *"printf '%s\\n'"* ]]
   [[ "$output" == *"sudo tee $SESSIONS_SUDOERS_FILE"* ]]
   [[ "$output" == *"sudo chmod 0440 $SESSIONS_SUDOERS_FILE"* ]]
   [[ "$output" == *"sudo visudo -cf $SESSIONS_SUDOERS_FILE"* ]]
+
+  cat > "$BIN/sudo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = "tee" ]
+shift
+exec tee "$@"
+EOF
+  chmod +x "$BIN/sudo"
+
+  install_cmd=$(printf '%s\n' "$output" | grep "printf '%s\\\\n'")
+  install_cmd=${install_cmd#  }
+  : > "$SESSIONS_SUDOERS_FILE"
+  bash -c "$install_cmd"
+  printf '%%humans ALL=(%%agents) NOPASSWD: ALL\n' > "$TMP/expected-sudoers"
+  cmp -s "$TMP/expected-sudoers" "$SESSIONS_SUDOERS_FILE"
 }
 
 @test "host:fix without --dry-run refuses to mutate in first slice" {

--- a/test/host.bats
+++ b/test/host.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+
+load helpers
+
+setup() {
+  TMP=$(mktemp -d)
+  BIN="$TMP/bin"
+  mkdir -p "$BIN"
+  export PATH="$BIN:$PATH"
+  export SESSIONS_SUDOERS_FILE="$TMP/sudoers.d/sessions-humans-agents"
+  export SESSIONS_RUN_AS_USER="$TMP/run-as-user"
+
+  cat > "$BIN/id" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "-un" ]; then
+  echo rikonor
+elif [ "${1:-}" = "-u" ]; then
+  case "${2:-}" in
+    iris|rikonor) echo 500 ;;
+    *) exit 1 ;;
+  esac
+elif [ "${1:-}" = "-Gn" ]; then
+  case "${2:-}" in
+    rikonor) echo "staff humans" ;;
+    iris) echo "staff agents" ;;
+    *) exit 1 ;;
+  esac
+else
+  echo "unexpected id args: $*" >&2
+  exit 64
+fi
+EOF
+  chmod +x "$BIN/id"
+
+  cat > "$BIN/dscl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  ". -read /Groups/humans"|". -read /Groups/agents") exit 0 ;;
+  *) echo "unexpected dscl args: $*" >&2; exit 64 ;;
+esac
+EOF
+  chmod +x "$BIN/dscl"
+
+  mkdir -p "$(dirname "$SESSIONS_SUDOERS_FILE")"
+  printf '%%humans ALL=(%%agents) NOPASSWD: ALL\n' > "$SESSIONS_SUDOERS_FILE"
+
+  cat > "$SESSIONS_RUN_AS_USER" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = "--user" ]
+[ "$2" = "iris" ]
+[ "$3" = "--" ]
+shift 3
+if [ "$1" = "whoami" ]; then
+  echo iris
+else
+  exec "$@"
+fi
+EOF
+  chmod +x "$SESSIONS_RUN_AS_USER"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "host:doctor succeeds when groups sudoers and smoke test are healthy" {
+  run sessions host:doctor --os-user iris
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK    group 'humans' exists"* ]]
+  [[ "$output" == *"OK    run-as-user smoke test returned 'iris'"* ]]
+}
+
+@test "host:fix --dry-run prints missing host changes" {
+  rm -f "$SESSIONS_SUDOERS_FILE"
+  cat > "$BIN/dscl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  ". -read /Groups/agents") exit 0 ;;
+  ". -read /Groups/humans") exit 1 ;;
+  *) echo "unexpected dscl args: $*" >&2; exit 64 ;;
+esac
+EOF
+  chmod +x "$BIN/dscl"
+
+  cat > "$BIN/id" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "-un" ]; then
+  echo rikonor
+elif [ "${1:-}" = "-u" ]; then
+  case "${2:-}" in
+    iris|rikonor) echo 500 ;;
+    *) exit 1 ;;
+  esac
+elif [ "${1:-}" = "-Gn" ]; then
+  case "${2:-}" in
+    rikonor) echo "staff" ;;
+    iris) echo "staff" ;;
+    *) exit 1 ;;
+  esac
+else
+  exit 64
+fi
+EOF
+  chmod +x "$BIN/id"
+
+  run sessions host:fix --os-user iris --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"sudo dseditgroup -o create humans"* ]]
+  [[ "$output" == *"sudo dseditgroup -o edit -a rikonor -t user humans"* ]]
+  [[ "$output" == *"sudo dseditgroup -o edit -a iris -t user agents"* ]]
+  [[ "$output" == *"sudo visudo -cf"* ]]
+}
+
+@test "host:fix without --dry-run refuses to mutate in first slice" {
+  rm -f "$SESSIONS_SUDOERS_FILE"
+  run sessions host:fix --os-user iris
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"mutating host:fix is not implemented yet"* ]]
+}

--- a/test/host.bats
+++ b/test/host.bats
@@ -94,6 +94,15 @@ teardown() {
   [[ "$output" == *"FAIL  sudoers file syntax is invalid or cannot be validated: $SESSIONS_SUDOERS_FILE"* ]]
 }
 
+@test "host:doctor allows unreadable sudoers file when smoke test passes" {
+  chmod 000 "$SESSIONS_SUDOERS_FILE"
+
+  run sessions host:doctor --os-user iris
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"INFO  sudoers file exists but is not readable by 'rikonor'; relying on run-as-user smoke test"* ]]
+  [[ "$output" == *"OK    run-as-user smoke test returned 'iris'"* ]]
+}
+
 @test "host:fix --dry-run prints missing host changes" {
   rm -f "$SESSIONS_SUDOERS_FILE"
   cat > "$BIN/dscl" <<'EOF'
@@ -162,6 +171,15 @@ EOF
   bash -c "$install_cmd"
   printf '%%humans ALL=(%%agents) NOPASSWD: ALL\n' > "$TMP/expected-sudoers"
   cmp -s "$TMP/expected-sudoers" "$SESSIONS_SUDOERS_FILE"
+}
+
+@test "host:fix --dry-run does not repair unreadable sudoers file when smoke test passes" {
+  chmod 000 "$SESSIONS_SUDOERS_FILE"
+
+  run sessions host:fix --os-user iris --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Host setup already matches the sessions humans→agents policy."* ]]
+  [[ "$output" != *"sudo tee $SESSIONS_SUDOERS_FILE"* ]]
 }
 
 @test "host:fix without --dry-run refuses to mutate in first slice" {

--- a/test/host.bats
+++ b/test/host.bats
@@ -137,6 +137,16 @@ EOF
   [[ "$output" == *"sudo visudo -cf"* ]]
 }
 
+@test "host:fix --dry-run repairs installed sudoers file with invalid syntax" {
+  printf 'INVALID\n' >> "$SESSIONS_SUDOERS_FILE"
+
+  run sessions host:fix --os-user iris --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"sudo tee $SESSIONS_SUDOERS_FILE"* ]]
+  [[ "$output" == *"sudo chmod 0440 $SESSIONS_SUDOERS_FILE"* ]]
+  [[ "$output" == *"sudo visudo -cf $SESSIONS_SUDOERS_FILE"* ]]
+}
+
 @test "host:fix without --dry-run refuses to mutate in first slice" {
   rm -f "$SESSIONS_SUDOERS_FILE"
   run sessions host:fix --os-user iris

--- a/test/host.bats
+++ b/test/host.bats
@@ -43,6 +43,18 @@ esac
 EOF
   chmod +x "$BIN/dscl"
 
+  cat > "$BIN/visudo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = "-cf" ]
+[ -f "$2" ]
+if grep -Fxq INVALID "$2"; then
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "$BIN/visudo"
+
   mkdir -p "$(dirname "$SESSIONS_SUDOERS_FILE")"
   printf '%%humans ALL=(%%agents) NOPASSWD: ALL\n' > "$SESSIONS_SUDOERS_FILE"
 
@@ -71,6 +83,15 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"OK    group 'humans' exists"* ]]
   [[ "$output" == *"OK    run-as-user smoke test returned 'iris'"* ]]
+}
+
+@test "host:doctor fails when sudoers file syntax is invalid" {
+  printf 'INVALID\n' >> "$SESSIONS_SUDOERS_FILE"
+
+  run sessions host:doctor --os-user iris
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"OK    sudoers rule installed at $SESSIONS_SUDOERS_FILE"* ]]
+  [[ "$output" == *"FAIL  sudoers file syntax is invalid or cannot be validated: $SESSIONS_SUDOERS_FILE"* ]]
 }
 
 @test "host:fix --dry-run prints missing host changes" {

--- a/test/run_as_user.bats
+++ b/test/run_as_user.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+load helpers
+
+setup() {
+  TMP=$(mktemp -d)
+  BIN="$TMP/bin"
+  mkdir -p "$BIN"
+  export RUN_AS_USER_LOG="$TMP/run-as-user.log"
+  export PATH="$BIN:$PATH"
+
+  cat > "$BIN/id" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "-u" ]; then
+  case "${2:-}" in
+    iris) echo 503 ;;
+    *) exit 1 ;;
+  esac
+elif [ "${1:-}" = "-un" ]; then
+  echo rikonor
+elif [ "${1:-}" = "-Gn" ]; then
+  case "${2:-}" in
+    rikonor) echo "staff humans" ;;
+    iris) echo "staff agents" ;;
+    *) exit 1 ;;
+  esac
+else
+  echo "unexpected id args: $*" >&2
+  exit 64
+fi
+EOF
+  chmod +x "$BIN/id"
+
+  cat > "$BIN/dscl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1 $2 $3" = ". -read /Users/iris" ]; then
+  case "${4:-}" in
+    NFSHomeDirectory) echo "NFSHomeDirectory: /Users/iris" ;;
+    UserShell) echo "UserShell: /bin/zsh" ;;
+    *) exit 1 ;;
+  esac
+else
+  echo "unexpected dscl args: $*" >&2
+  exit 64
+fi
+EOF
+  chmod +x "$BIN/dscl"
+
+  cat > "$BIN/sudo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${RUN_AS_USER_LOG:?}"
+# Simulate sudo by executing the command after: -n -H -u <user> --
+[ "$1" = "-n" ]
+[ "$2" = "-H" ]
+[ "$3" = "-u" ]
+[ "$4" = "iris" ]
+[ "$5" = "--" ]
+shift 5
+exec "$@"
+EOF
+  chmod +x "$BIN/sudo"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "run-as-user runs command through sudo with explicit target env" {
+  run "$REPO_DIR/libexec/run-as-user" --user iris -- sh -c 'printf "%s|%s|%s|%s|%s" "$HOME" "$USER" "$LOGNAME" "$SHELL" "$PATH"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == /Users/iris\|iris\|iris\|/bin/zsh\|/Users/iris/.local/bin:* ]]
+  grep -q -- '-n -H -u iris -- env -i HOME=/Users/iris USER=iris LOGNAME=iris SHELL=/bin/zsh' "$RUN_AS_USER_LOG"
+}
+
+@test "run-as-user rejects invalid users" {
+  run "$REPO_DIR/libexec/run-as-user" --user '../bad' -- whoami
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"invalid --user"* ]]
+}
+
+@test "run-as-user requires command after separator" {
+  run "$REPO_DIR/libexec/run-as-user" --user iris --
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"command required"* ]]
+}


### PR DESCRIPTION
## Summary

First implementation slice for #73.

- Add internal `libexec/run-as-user` helper with contract `--user <user> -- <cmd...>`.
- Execute target commands through sudo with an explicit `env -i` environment instead of inheriting the caller env.
- Add `host:doctor --os-user <user>` to inspect local humans→agents host setup and smoke-test the helper.
- Add `host:fix --os-user <user> --dry-run` to print planned group/sudoers changes.
- Intentionally leave mutating `host:fix` unimplemented in this slice; it refuses without `--dry-run`.

## Context

`shell` and zmx stay caller-owned. `sessions` will own OS-user orchestration in a follow-up by wrapping only the payload command. This PR provides the runtime primitive and host diagnostics without wiring `wake --os-user` yet.

Policy model is intentionally sudoers-backed, not custom auth:

```sudoers
%humans ALL=(%agents) NOPASSWD: ALL
```

## Validation

- `mise run test run_as_user host`
- configured codebase lint rules:
  - `mise-settings`
  - `gum-table`
  - `bats-test-helper`
  - `bats-test-task`
  - `mcr-scope`
  - `or-true`
  - `shellcheck`
- `mise run test` — 218/218
