### PR TITLE
test(host): validate sudoers syntax in doctor

### DIFF
--- a/.mise/tasks/host/doctor
+++ b/.mise/tasks/host/doctor
@@ -58,6 +58,12 @@ else
   check_fail "sudoers rule missing from $HOST_SUDOERS_FILE"
 fi
 
+if host_sudoers_valid; then
+  check_ok "sudoers file syntax is valid"
+else
+  check_fail "sudoers file syntax is invalid or cannot be validated: $HOST_SUDOERS_FILE"
+fi
+
 if [ -x "$HOST_RUN_AS_USER" ]; then
   check_ok "run-as-user helper is executable"
 else

--- a/lib/host.sh
+++ b/lib/host.sh
@@ -33,6 +33,12 @@ host_sudoers_installed() {
   [ -f "$HOST_SUDOERS_FILE" ] && grep -Fxq "$(host_sudoers_rule)" "$HOST_SUDOERS_FILE"
 }
 
+host_sudoers_valid() {
+  [ -f "$HOST_SUDOERS_FILE" ] \
+    && command -v visudo >/dev/null 2>&1 \
+    && visudo -cf "$HOST_SUDOERS_FILE" >/dev/null 2>&1
+}
+
 host_create_group_command() {
   local group="$1"
   printf 'sudo dseditgroup -o create %q\n' "$group"

--- a/test/host.bats
+++ b/test/host.bats
@@ -43,6 +43,18 @@ esac
 EOF
   chmod +x "$BIN/dscl"
 
+  cat > "$BIN/visudo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = "-cf" ]
+[ -f "$2" ]
+if grep -Fxq INVALID "$2"; then
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "$BIN/visudo"
+
   mkdir -p "$(dirname "$SESSIONS_SUDOERS_FILE")"
   printf '%%humans ALL=(%%agents) NOPASSWD: ALL\n' > "$SESSIONS_SUDOERS_FILE"
 
@@ -71,6 +83,15 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"OK    group 'humans' exists"* ]]
   [[ "$output" == *"OK    run-as-user smoke test returned 'iris'"* ]]
+}
+
+@test "host:doctor fails when sudoers file syntax is invalid" {
+  printf 'INVALID\n' >> "$SESSIONS_SUDOERS_FILE"
+
+  run sessions host:doctor --os-user iris
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"OK    sudoers rule installed at $SESSIONS_SUDOERS_FILE"* ]]
+  [[ "$output" == *"FAIL  sudoers file syntax is invalid or cannot be validated: $SESSIONS_SUDOERS_FILE"* ]]
 }
 
 @test "host:fix --dry-run prints missing host changes" {


### PR DESCRIPTION
Fix-it for #74.\n\nAdds a visudo-backed sudoers syntax check to host:doctor and covers the invalid-file case with fake-host BATS coverage.\n\nValidation: mise run test run_as_user host