### PR TITLE
fix(host): repair invalid sudoers dry-run

### DIFF
--- a/.mise/tasks/host/fix
+++ b/.mise/tasks/host/fix
@@ -36,7 +36,7 @@ if ! host_user_in_group "$OS_USER" "$HOST_AGENTS_GROUP"; then
   planned+=("$(host_add_user_to_group_command "$OS_USER" "$HOST_AGENTS_GROUP")")
 fi
 
-if ! host_sudoers_installed; then
+if ! host_sudoers_installed || ! host_sudoers_valid; then
   while IFS= read -r cmd; do
     [ -n "$cmd" ] && planned+=("$cmd")
   done < <(host_install_sudoers_commands)

--- a/test/host.bats
+++ b/test/host.bats
@@ -137,6 +137,16 @@ EOF
   [[ "$output" == *"sudo visudo -cf"* ]]
 }
 
+@test "host:fix --dry-run repairs installed sudoers file with invalid syntax" {
+  printf 'INVALID\n' >> "$SESSIONS_SUDOERS_FILE"
+
+  run sessions host:fix --os-user iris --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"sudo tee $SESSIONS_SUDOERS_FILE"* ]]
+  [[ "$output" == *"sudo chmod 0440 $SESSIONS_SUDOERS_FILE"* ]]
+  [[ "$output" == *"sudo visudo -cf $SESSIONS_SUDOERS_FILE"* ]]
+}
+
 @test "host:fix without --dry-run refuses to mutate in first slice" {
   rm -f "$SESSIONS_SUDOERS_FILE"
   run sessions host:fix --os-user iris


### PR DESCRIPTION
## Summary\n\n- Make host:fix --dry-run plan sudoers reinstall when the drop-in contains the expected rule but fails visudo validation.\n- Add fake-host coverage for invalid sudoers syntax on host:fix.\n\n## Validation\n\n- mise run test run_as_user host (8/8)\n- mise run test (fails in pre-existing unrelated tests: meta/search/wake; host/run_as_user pass)