### PR TITLE
fix(host): quote sudoers printf dry-run

### DIFF
--- a/lib/host.sh
+++ b/lib/host.sh
@@ -52,7 +52,7 @@ host_add_user_to_group_command() {
 host_install_sudoers_commands() {
   local rule
   rule=$(host_sudoers_rule)
-  printf 'printf %%s\\n %q | sudo tee %q >/dev/null\n' "$rule" "$HOST_SUDOERS_FILE"
+  printf "printf '%%s\\\\n' %q | sudo tee %q >/dev/null\n" "$rule" "$HOST_SUDOERS_FILE"
   printf 'sudo chmod 0440 %q\n' "$HOST_SUDOERS_FILE"
   printf 'sudo visudo -cf %q\n' "$HOST_SUDOERS_FILE"
 }

--- a/test/host.bats
+++ b/test/host.bats
@@ -142,9 +142,26 @@ EOF
 
   run sessions host:fix --os-user iris --dry-run
   [ "$status" -eq 0 ]
+  [[ "$output" == *"printf '%s\\n'"* ]]
   [[ "$output" == *"sudo tee $SESSIONS_SUDOERS_FILE"* ]]
   [[ "$output" == *"sudo chmod 0440 $SESSIONS_SUDOERS_FILE"* ]]
   [[ "$output" == *"sudo visudo -cf $SESSIONS_SUDOERS_FILE"* ]]
+
+  cat > "$BIN/sudo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = "tee" ]
+shift
+exec tee "$@"
+EOF
+  chmod +x "$BIN/sudo"
+
+  install_cmd=$(printf '%s\n' "$output" | grep "printf '%s\\\\n'")
+  install_cmd=${install_cmd#  }
+  : > "$SESSIONS_SUDOERS_FILE"
+  bash -c "$install_cmd"
+  printf '%%humans ALL=(%%agents) NOPASSWD: ALL\n' > "$TMP/expected-sudoers"
+  cmp -s "$TMP/expected-sudoers" "$SESSIONS_SUDOERS_FILE"
 }
 
 @test "host:fix without --dry-run refuses to mutate in first slice" {


### PR DESCRIPTION
Fix-it for #74.\n\n## Problem\n\nThe dry-run sudoers install command emitted:\n\n```bash\nprintf %s\n <rule> | sudo tee <file> >/dev/null\n```\n\nWhen pasted into a shell, the unquoted backslash is consumed, so printf receives `%sn` and writes the sudoers rule with a trailing literal `n` instead of a newline.\n\n## Fix\n\nEmit the command as:\n\n```bash\nprintf '%s\n' <rule> | sudo tee <file> >/dev/null\n```\n\nCoverage now executes the generated install command through fake sudo/tee and verifies the resulting sudoers file content.\n\n## Validation\n\n- `mise run test run_as_user host`