### PR TITLE
feat(wake): route payloads through OS user

### DIFF
--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -200,7 +200,7 @@ if [ -n "$MESSAGE" ]; then
 fi
 
 if [ -n "$OS_USER" ]; then
-  RUN_CMD=("$MISE_CONFIG_ROOT/libexec/run-as-user" --user "$OS_USER" -- "${RUN_CMD[@]}")
+  RUN_CMD=("$HOST_RUN_AS_USER" --user "$OS_USER" -- "${RUN_CMD[@]}")
 fi
 
 scrub_caller_pwd_env

--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -5,6 +5,7 @@
 #USAGE flag "--context-file <context_file>" help="File containing context message to inject"
 #USAGE flag "--message <message>" help="Message to pass to the agent"
 #USAGE flag "--model <model>" help="Model to use (required; provider-qualified, e.g. openai-codex/gpt-5.5)"
+#USAGE flag "--os-user <os_user>" help="Run the session payload as this local OS user (default: $SHIMMER_OS_USER)"
 #USAGE flag "--headless" help="No human present — agent completes task and exits"
 #USAGE flag "--background" help="Launch in background via shell/zmx (default: foreground, blocks until done)"
 #USAGE flag "--meta <meta>" var=#true help="Metadata for the wake event (repeatable, dotted paths or jq expressions)"
@@ -17,6 +18,7 @@ WAKE_META_RAW="${usage_meta:-}"
 CONTEXT_FILE="${usage_context_file:-}"
 MESSAGE="${usage_message:-}"
 MODEL="${usage_model:-}"
+OS_USER="${usage_os_user:-}"
 HEADLESS="${usage_headless:-false}"
 BACKGROUND="${usage_background:-false}"
 
@@ -44,6 +46,19 @@ fi
 if [[ "$MODEL" != */* ]]; then
   echo "Error: --model must be provider-qualified (for example: openai-codex/gpt-5.5)" >&2
   exit 1
+fi
+
+# --- OS-user target ---
+
+if [ -z "$OS_USER" ]; then
+  OS_USER="${SHIMMER_OS_USER:-}"
+fi
+
+# shellcheck source=/dev/null
+source "$MISE_CONFIG_ROOT/lib/host.sh"
+
+if [ -n "$OS_USER" ]; then
+  host_validate_user_name "$OS_USER"
 fi
 
 # --- Dependencies ---
@@ -88,6 +103,22 @@ fi
 SESSION_NAME=$(head -1 "$SESSION_FILE" | jq -r '.name // empty')
 SHELL_NAME=$(derive_shell_name "$SESSION_NAME" "$FULL_SESSION_ID")
 
+# --- Preflight OS-user execution before mutating the session file ---
+
+if [ -n "$OS_USER" ]; then
+  if ! host_user_exists "$OS_USER"; then
+    echo "Error: target OS user '$OS_USER' does not exist" >&2
+    echo "Run: sessions host:doctor --os-user $OS_USER" >&2
+    exit 1
+  fi
+
+  if ! host_run_as_user_smoke "$OS_USER"; then
+    echo "Error: cannot run payload as OS user '$OS_USER'" >&2
+    echo "Run: sessions host:doctor --os-user $OS_USER" >&2
+    exit 1
+  fi
+fi
+
 # --- Resolve context from file ---
 
 if [ -n "$CONTEXT_FILE" ]; then
@@ -126,7 +157,7 @@ if [ -n "$WAKE_META_RAW" ]; then
   done < <(printf '%s' "$WAKE_META_RAW" | xargs printf '%s\n')
 fi
 
-# wake_entry args: entry_id parent_id ts shell_name agent harness headless meta_json model
+# wake_entry args: entry_id parent_id ts shell_name agent harness headless meta_json model os_user
 # (keep in sync with the signature in lib/harness/dispatch.sh — order matters
 # because they're positional; structural refactor to named args is tracked
 # alongside sessions#61)
@@ -139,7 +170,8 @@ wake_entry \
   "$HARNESS_NAME" \
   "$HEADLESS" \
   "$WAKE_META" \
-  "$MODEL" >> "$SESSION_FILE"
+  "$MODEL" \
+  "$OS_USER" >> "$SESSION_FILE"
 
 # --- Inject context into session file if provided ---
 
@@ -165,6 +197,10 @@ RUN_CMD=("${mise_run[@]}" run --session "$SESSION_FILE" --cwd "$SESSION_CWD" --m
 [ "$HEADLESS" = "true" ] && RUN_CMD+=(--headless)
 if [ -n "$MESSAGE" ]; then
   RUN_CMD+=("$MESSAGE")
+fi
+
+if [ -n "$OS_USER" ]; then
+  RUN_CMD=("$MISE_CONFIG_ROOT/libexec/run-as-user" --user "$OS_USER" -- "${RUN_CMD[@]}")
 fi
 
 scrub_caller_pwd_env

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 323 passing](https://img.shields.io/badge/tests-323%20passing-brightgreen?style=flat)](test/)
-![commands: 13](https://img.shields.io/badge/commands-13-blue?style=flat)
+[![tests: 232 passing](https://img.shields.io/badge/tests-232%20passing-brightgreen?style=flat)](test/)
+![commands: 14](https://img.shields.io/badge/commands-14-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
 </div>
@@ -57,9 +57,10 @@ Sessions aren't just transcript files agents leave behind — they're managed ar
 ```
   sessions new              create session with metadata + context
   sessions wake             wake an agent into it via shell
-    └─ shell run            persistent zmx session
-         └─ shimmer agent   identity + chat attribution
-              └─ pi         harness — processes message, exits
+    └─ shell run            persistent zmx session (caller-owned)
+         └─ run-as-user     optional --os-user payload boundary
+              └─ sessions run
+                   └─ pi    harness — processes message, exits
   sessions read             observe the transcript
   sessions wake (again)     re-enter with corrections
 ```
@@ -86,6 +87,15 @@ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed th
 The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for persistent zmx sessions. `sessions wake` calls `sessions run` directly for execution — identity (AGENT_IDENTITY, etc.) must already be in the environment, typically set upstream via `eval $(shimmer as <agent>)`.
 
 `--model` on `sessions wake` is required and is not remembered across wakes — pass a provider-qualified model (for example `openai-codex/gpt-5.5`) on each wake.
+
+To run only the payload process as a local agent OS user, pass `--os-user` or set `SHIMMER_OS_USER`. The shell/zmx session remains owned by the caller. This does not copy caller environment, secrets, or auth into the target account; the target user's session environment is a separate setup step.
+
+```bash
+sessions wake iris-first-wake \
+  --model openai-codex/gpt-5.5 \
+  --os-user iris \
+  --message "Continue Iris onboarding"
+```
 
 ## Metadata
 
@@ -165,7 +175,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**161 tests** across 12 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 434 lines of Python in `lib/`.
+**232 tests** across 15 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -195,7 +205,7 @@ sessions/
 │   ├── shell.sh        # Shell helpers
 │   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats          # 161 tests
+    └── *.bats          # 232 tests
 ```
 
 </details>

--- a/README.tsx
+++ b/README.tsx
@@ -49,7 +49,7 @@ const lifecycle = [
   "$ sessions new review/pr-50 --cwd ~/agents/ikma/den --meta agent.name=ikma",
   "e96bd43a",
   "",
-  "$ sessions wake review/pr-50 --message \"review PR #50\"",
+  "$ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message \"review PR #50\"",
   "Woke session 'review/pr-50'",
   "",
   "$ sessions read review/pr-50 --last 3",
@@ -65,9 +65,10 @@ const lifecycle = [
 const stack = [
   "  sessions new              create session with metadata + context",
   "  sessions wake             wake an agent into it via shell",
-  "    └─ shell run            persistent zmx session",
-  "         └─ shimmer agent   identity + chat attribution",
-  "              └─ pi         harness — processes message, exits",
+  "    └─ shell run            persistent zmx session (caller-owned)",
+  "         └─ run-as-user     optional --os-user payload boundary",
+  "              └─ sessions run",
+  "                   └─ pi    harness — processes message, exits",
   "  sessions read             observe the transcript",
   "  sessions wake (again)     re-enter with corrections",
 ].join("\n");
@@ -161,14 +162,14 @@ sessions new review/pr-50 --cwd ~/agents/ikma/den \\
   --meta purpose=review \\
   --context "Background: this PR refactors the auth module"
 
-# Wake an agent into it (by name)
-sessions wake review/pr-50 --message "Review PR #50"
+# Wake an agent into it (by name). Model is required at wake time.
+sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "Review PR #50"
 
 # Watch what it does
 sessions read review/pr-50 --last 5
 
 # Something went wrong? Wake the same session again.
-sessions wake review/pr-50 --message "You missed the edge case in line 42"`}</CodeBlock>
+sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed the edge case in line 42"`}</CodeBlock>
 
       <Paragraph>
         {"The spawning stack uses "}
@@ -181,6 +182,28 @@ sessions wake review/pr-50 --message "You missed the edge case in line 42"`}</Co
         <Code>{"eval $(shimmer as <agent>)"}</Code>
         {"."}
       </Paragraph>
+
+      <Paragraph>
+        <Code>--model</Code>
+        {" on "}
+        <Code>sessions wake</Code>
+        {" is required and is not remembered across wakes — pass a provider-qualified model (for example "}
+        <Code>openai-codex/gpt-5.5</Code>
+        {") on each wake."}
+      </Paragraph>
+
+      <Paragraph>
+        {"To run only the payload process as a local agent OS user, pass "}
+        <Code>--os-user</Code>
+        {" or set "}
+        <Code>SHIMMER_OS_USER</Code>
+        {". The shell/zmx session remains owned by the caller. This does not copy caller environment, secrets, or auth into the target account; the target user's session environment is a separate setup step."}
+      </Paragraph>
+
+      <CodeBlock lang="bash">{`sessions wake iris-first-wake \\
+  --model openai-codex/gpt-5.5 \\
+  --os-user iris \\
+  --message "Continue Iris onboarding"`}</CodeBlock>
     </Section>
 
     <Section title="Metadata">
@@ -212,6 +235,7 @@ sessions meta e96bd43a --field .meta.agent   # by ID prefix`}</CodeBlock>
       </Paragraph>
 
       <CodeBlock lang="bash">{`sessions wake review/pr-50 \\
+  --model openai-codex/gpt-5.5 \\
   --meta by.agent.name=ikma \\
   --message "check the CI results"`}</CodeBlock>
     </Section>

--- a/lib/harness/dispatch.sh
+++ b/lib/harness/dispatch.sh
@@ -245,13 +245,14 @@ harness_entry() {
 #   $9 model   (optional for low-level callers, but required by
 #              `sessions wake`. `wake_entry` itself never writes null;
 #              readers processing wake events from other sources should
-#              normalize null to absent.)
+#              normalize null to absent.),
+#   $10 os_user (optional; local OS user that the payload runs as.)
 #
 # Field-placement rule: fields that `sessions wake` itself owns
-# (`.headless`, `.model`) go top-level; caller-provided key=value pairs
-# passed via `--meta` go inside `.meta`. Apply this rule when adding
-# new fields: if wake owns the flag, top-level; if it's user-space,
-# stuff it into `meta_json` at the callsite.
+# (`.headless`, `.model`, `.os_user`) go top-level; caller-provided
+# key=value pairs passed via `--meta` go inside `.meta`. Apply this rule
+# when adding new fields: if wake owns the flag, top-level; if it's
+# user-space, stuff it into `meta_json` at the callsite.
 #
 # Schema-evolution risk: `.model` is written as a bare string in
 # harness-native vocabulary (e.g. pi's "claude-opus-4-7"). Readers
@@ -270,6 +271,7 @@ wake_entry() {
   local headless="$7"
   local meta_json="${8:-}"
   local model="${9:-}"
+  local os_user="${10:-}"
 
   # Intentionally strict: only the exact string "true" maps to true.
   # Any other value ("false", "", "TRUE", "yes", "1") maps to false.
@@ -290,6 +292,14 @@ wake_entry() {
     model_fragment=' + {model: $model}'
   fi
 
+  local os_user_args=()
+  local os_user_fragment=''
+  if [ -n "$os_user" ]; then
+    os_user_args=(--arg os_user "$os_user")
+    # shellcheck disable=SC2016  # jq expression: $os_user is a jq variable bound by --arg os_user, not a bash expansion
+    os_user_fragment=' + {os_user: $os_user}'
+  fi
+
   if [ -z "$meta_json" ] || [ "$meta_json" = "{}" ]; then
     jq -nc \
       --arg id "$entry_id" \
@@ -300,6 +310,7 @@ wake_entry() {
       --arg harness "$harness_name" \
       --argjson headless "$headless_bool" \
       "${model_args[@]+"${model_args[@]}"}" \
+      "${os_user_args[@]+"${os_user_args[@]}"}" \
       '{
         type: "wake",
         id: $id,
@@ -309,7 +320,7 @@ wake_entry() {
         agent: $agent,
         harness: $harness,
         headless: $headless
-      }'"$model_fragment"
+      }'"$model_fragment""$os_user_fragment"
   else
     jq -nc \
       --arg id "$entry_id" \
@@ -321,6 +332,7 @@ wake_entry() {
       --argjson headless "$headless_bool" \
       --argjson meta "$meta_json" \
       "${model_args[@]+"${model_args[@]}"}" \
+      "${os_user_args[@]+"${os_user_args[@]}"}" \
       '{
         type: "wake",
         id: $id,
@@ -331,6 +343,6 @@ wake_entry() {
         harness: $harness,
         headless: $headless,
         meta: $meta
-      }'"$model_fragment"
+      }'"$model_fragment""$os_user_fragment"
   fi
 }

--- a/test/harness_dispatch.bats
+++ b/test/harness_dispatch.bats
@@ -377,6 +377,12 @@ JSONL
   echo "$output" | jq -e '.model == "claude-opus-4-7"'
 }
 
+@test "wake_entry records .os_user when 10th arg is non-empty" {
+  run wake_entry w1 parent1 "2026-04-22T10:00:00.000Z" shellA ikma pi true "{}" "claude-opus-4-7" iris
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.os_user == "iris"'
+}
+
 @test "wake_entry omits .model when 9th arg is absent or empty" {
   # Both absent (no 9th arg) and explicit empty string must produce no
   # `.model` field. `sessions wake` requires a model; this low-level
@@ -396,11 +402,25 @@ JSONL
   done
 }
 
-@test "wake_entry includes both .meta and .model when both are non-empty" {
-  # Second jq branch (meta present) with fragment concatenation for model.
-  run wake_entry w1 parent1 "2026-04-22T10:00:00.000Z" shellA ikma pi true '{"by":"zeke"}' "claude-opus-4-7"
+@test "wake_entry omits .os_user when 10th arg is absent or empty" {
+  for arg in absent empty; do
+    if [ "$arg" = "absent" ]; then
+      run wake_entry w1 parent1 "2026-04-22T10:00:00.000Z" shellA ikma pi true "{}" "claude-opus-4-7"
+    else
+      run wake_entry w1 parent1 "2026-04-22T10:00:00.000Z" shellA ikma pi true "{}" "claude-opus-4-7" ""
+    fi
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'has("os_user") | not' >/dev/null || {
+      echo "case=$arg leaked an .os_user field: $output" >&2
+      return 1
+    }
+  done
+}
+
+@test "wake_entry includes .meta .model and .os_user when all are non-empty" {
+  run wake_entry w1 parent1 "2026-04-22T10:00:00.000Z" shellA ikma pi true '{"by":"zeke"}' "claude-opus-4-7" iris
   [ "$status" -eq 0 ]
-  echo "$output" | jq -e '.meta.by == "zeke" and .model == "claude-opus-4-7"'
+  echo "$output" | jq -e '.meta.by == "zeke" and .model == "claude-opus-4-7" and .os_user == "iris"'
 }
 
 # --- harness_entry builder ---

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -23,6 +23,50 @@ teardown() {
   teardown_test_sessions
 }
 
+stub_os_user_host() {
+  local user="${1:-iris}"
+  local bin="$BATS_TEST_TMPDIR/os-user-bin"
+  mkdir -p "$bin"
+  export PATH="$bin:$PATH"
+  export SESSIONS_RUN_AS_USER="$BATS_TEST_TMPDIR/run-as-user-stub"
+
+  cat > "$bin/id" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "-u" ] && [ "\${2:-}" = "$user" ]; then
+  echo 503
+  exit 0
+fi
+exit 1
+STUB
+  chmod +x "$bin/id"
+
+  cat > "$SESSIONS_RUN_AS_USER" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+[ "\${1:-}" = "--user" ]
+[ "\${2:-}" = "$user" ]
+[ "\${3:-}" = "--" ]
+shift 3
+if [ "\${WAKE_OS_USER_SMOKE_FAIL:-}" = "1" ]; then
+  exit 1
+fi
+exec "\$@"
+STUB
+  chmod +x "$SESSIONS_RUN_AS_USER"
+}
+
+stub_missing_os_user_host() {
+  local bin="$BATS_TEST_TMPDIR/missing-os-user-bin"
+  mkdir -p "$bin"
+  export PATH="$bin:$PATH"
+  cat > "$bin/id" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  chmod +x "$bin/id"
+}
+
 # --- Validation ---
 
 @test "wake errors on nonexistent session" {
@@ -35,6 +79,46 @@ teardown() {
   run sessions wake "$SESSION_1" --model "openai-codex/gpt-5.5" --context-file "/tmp/nonexistent-$$"
   [ "$status" -eq 1 ]
   echo "$output" | grep -q "not found"
+}
+
+@test "wake rejects invalid --os-user" {
+  run sessions wake "$SESSION_1" --model "openai-codex/gpt-5.5" --os-user "../bad"
+  [ "$status" -eq 2 ]
+  echo "$output" | grep -q "invalid --os-user"
+}
+
+@test "wake --os-user fails before recording wake when target user is missing" {
+  stub_missing_os_user_host
+  local src_file
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  local before
+  before=$(wc -l < "$src_file")
+
+  run sessions wake "$SESSION_1" --model "openai-codex/gpt-5.5" --os-user missingagent
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "target OS user 'missingagent' does not exist"
+
+  local after
+  after=$(wc -l < "$src_file")
+  [ "$after" = "$before" ]
+}
+
+@test "wake --os-user fails before recording wake when run-as-user preflight fails" {
+  stub_os_user_host iris
+  export WAKE_OS_USER_SMOKE_FAIL=1
+  local src_file
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  local before
+  before=$(wc -l < "$src_file")
+
+  run sessions wake "$SESSION_1" --model "openai-codex/gpt-5.5" --os-user iris
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "cannot run payload as OS user 'iris'"
+  echo "$output" | grep -q "host:doctor --os-user iris"
+
+  local after
+  after=$(wc -l < "$src_file")
+  [ "$after" = "$before" ]
 }
 
 # --- Background mode (shell/zmx) ---
@@ -144,6 +228,56 @@ STUB
   jq -e 'select(.type == "wake" and .harness == "pi" and .headless == false)' "$src_file"
 }
 
+@test "wake --os-user records os_user in wake event" {
+  stub_os_user_host iris
+  local stub_dir="$BATS_TEST_TMPDIR/stub-shell-os-user-record"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/shell" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$stub_dir/shell"
+
+  PATH="$stub_dir:$PATH" run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5" --os-user iris
+  [ "$status" -eq 0 ]
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  jq -e 'select(.type == "wake" and .os_user == "iris")' "$src_file"
+}
+
+@test "wake defaults os_user from SHIMMER_OS_USER" {
+  stub_os_user_host iris
+  local stub_dir="$BATS_TEST_TMPDIR/stub-shell-os-user-env"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/shell" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$stub_dir/shell"
+
+  export SHIMMER_OS_USER=iris
+  PATH="$stub_dir:$PATH" run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5"
+  [ "$status" -eq 0 ]
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  jq -e 'select(.type == "wake" and .os_user == "iris")' "$src_file"
+}
+
+@test "wake explicit --os-user overrides SHIMMER_OS_USER" {
+  stub_os_user_host iris
+  local stub_dir="$BATS_TEST_TMPDIR/stub-shell-os-user-override"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/shell" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$stub_dir/shell"
+
+  export SHIMMER_OS_USER=bob
+  PATH="$stub_dir:$PATH" run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5" --os-user iris
+  [ "$status" -eq 0 ]
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  jq -e 'select(.type == "wake" and .os_user == "iris")' "$src_file"
+}
+
 # --- Foreground mode ---
 # Foreground calls `exec sessions run` which requires the Elixir CLI.
 # We test that the wake event is recorded and the right command would be called
@@ -194,6 +328,37 @@ STUB
   run sessions wake "$SESSION_1" --background --model "gpt-5.5"
   [ "$status" -ne 0 ]
   echo "$output" | grep -q -- "--model must be provider-qualified"
+}
+
+@test "wake --os-user wraps only the sessions run payload" {
+  command -v shell >/dev/null 2>&1 || skip "shell not installed"
+  stub_os_user_host iris
+
+  local stub_dir="$BATS_TEST_TMPDIR/stub-shell-os-user-argv"
+  local capture="$BATS_TEST_TMPDIR/shell-argv-os-user"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/shell" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/shell"
+
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai-codex/gpt-5.5" --os-user iris
+  [ "$status" -eq 0 ]
+  [ -f "$capture" ]
+
+  [ "$(sed -n '1p' "$capture")" = "run" ]
+  [ "$(sed -n '3p' "$capture")" = "--cwd" ]
+
+  local run_as_line
+  run_as_line=$(grep -n '/libexec/run-as-user$' "$capture" | cut -d: -f1)
+  [ -n "$run_as_line" ]
+  [ "$(sed -n "$((run_as_line + 1))p" "$capture")" = "--user" ]
+  [ "$(sed -n "$((run_as_line + 2))p" "$capture")" = "iris" ]
+  [ "$(sed -n "$((run_as_line + 3))p" "$capture")" = "--" ]
+  [ "$(sed -n "$((run_as_line + 4))p" "$capture")" = "mise" ]
+  [ "$(sed -n "$((run_as_line + 5))p" "$capture")" = "-C" ]
 }
 
 @test "wake --model forwards --model to sessions run in RUN_CMD" {
@@ -369,4 +534,10 @@ STUB
   run sessions wake --help
   [ "$status" -eq 0 ]
   echo "$output" | grep -q -- "--model"
+}
+
+@test "wake --os-user is advertised in --help" {
+  run sessions wake --help
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q -- "--os-user"
 }

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -352,7 +352,7 @@ STUB
   [ "$(sed -n '3p' "$capture")" = "--cwd" ]
 
   local run_as_line
-  run_as_line=$(grep -n '/libexec/run-as-user$' "$capture" | cut -d: -f1)
+  run_as_line=$(grep -nFx "$SESSIONS_RUN_AS_USER" "$capture" | cut -d: -f1)
   [ -n "$run_as_line" ]
   [ "$(sed -n "$((run_as_line + 1))p" "$capture")" = "--user" ]
   [ "$(sed -n "$((run_as_line + 2))p" "$capture")" = "iris" ]


### PR DESCRIPTION
## Summary

Second implementation slice for #73.

- Add `sessions wake --os-user <user>`.
- Default `--os-user` from `$SHIMMER_OS_USER` when the flag is absent.
- Preflight target OS-user routing before mutating the session file:
  - target user must exist;
  - `libexec/run-as-user --user <user> -- true` must succeed.
- Record optional top-level `os_user` on wake events.
- Wrap only the `sessions run` payload with `libexec/run-as-user --user <user> -- ...`; the background `shell run` / zmx session remains caller-owned.
- Document the boundary in README.

## Boundary / non-goal

This PR intentionally does **not** define session-environment handoff. `run-as-user` still starts from its controlled target environment; caller secrets/auth/env are not copied into the target account.

That means the target OS user still needs its own tooling/auth/session environment before a full Iris agent wake can succeed. We should discuss and design that as a follow-up rather than smuggling in an ad hoc env allowlist.

## Validation

- `mise run test wake harness_dispatch` — 73/73
- `mise run test` — 232/232
- `CALLER_PWD="$PWD" readme build --check`
- configured codebase lints with explicit target path:
  - `mise-settings`
  - `gum-table`
  - `bats-test-helper`
  - `bats-test-task`
  - `mcr-scope`
  - `or-true`
  - `shellcheck`

## Review notes

I ran a self-review session before finalizing. It caught two issues: the ad hoc identity-env handoff I had added without design discussion, and missing no-mutation preflight for bad OS users. The final version removes env handoff from scope and keeps the preflight.
