### PR TITLE
Scrub stale mise install paths before launching harness

### DIFF
--- a/cli/lib/cli/engine.ex
+++ b/cli/lib/cli/engine.ex
@@ -61,7 +61,7 @@ defmodule Cli.Engine do
       :exit_status,
       :stderr_to_stdout,
       {:args, args},
-      {:env, caller_pwd_env_scrub()}
+      {:env, harness_env()}
     ]
 
     port_opts = if cwd, do: [{:cd, cwd} | port_opts], else: port_opts
@@ -89,11 +89,51 @@ defmodule Cli.Engine do
     status
   end
 
+  defp harness_env do
+    caller_pwd_env_scrub() ++ path_env()
+  end
+
   defp caller_pwd_env_scrub do
     System.get_env()
     |> Map.keys()
     |> Enum.filter(&(&1 == "CALLER_PWD" or String.ends_with?(&1, "_CALLER_PWD")))
     |> Enum.map(&{String.to_charlist(&1), false})
+  end
+
+  defp path_env do
+    case System.get_env("PATH") do
+      nil -> []
+      path -> [{~c"PATH", path |> sanitized_path() |> String.to_charlist()}]
+    end
+  end
+
+  defp sanitized_path(path) do
+    home = System.get_env("HOME")
+
+    mise_installs =
+      if home, do: Path.join([home, ".local", "share", "mise", "installs"]), else: nil
+
+    mise_shims = if home, do: Path.join([home, ".local", "share", "mise", "shims"]), else: nil
+
+    entries =
+      path
+      |> String.split(":", trim: false)
+      |> Enum.reject(&mise_install_path?(&1, mise_installs))
+
+    entries =
+      if mise_shims && mise_shims not in entries && File.dir?(mise_shims) do
+        [mise_shims | entries]
+      else
+        entries
+      end
+
+    Enum.join(entries, ":")
+  end
+
+  defp mise_install_path?(_entry, nil), do: false
+
+  defp mise_install_path?(entry, mise_installs) do
+    String.starts_with?(entry, mise_installs <> "/")
   end
 
   defp stream_output(port, %{buffer: buffer} = state) do

--- a/cli/lib/cli/engine.ex
+++ b/cli/lib/cli/engine.ex
@@ -108,12 +108,9 @@ defmodule Cli.Engine do
   end
 
   defp sanitized_path(path) do
-    home = System.get_env("HOME")
-
-    mise_installs =
-      if home, do: Path.join([home, ".local", "share", "mise", "installs"]), else: nil
-
-    mise_shims = if home, do: Path.join([home, ".local", "share", "mise", "shims"]), else: nil
+    mise_data_dir = mise_data_dir()
+    mise_installs = if mise_data_dir, do: Path.join(mise_data_dir, "installs"), else: nil
+    mise_shims = if mise_data_dir, do: Path.join(mise_data_dir, "shims"), else: nil
 
     entries =
       path
@@ -128,6 +125,30 @@ defmodule Cli.Engine do
       end
 
     Enum.join(entries, ":")
+  end
+
+  defp mise_data_dir do
+    cond do
+      data_dir = non_empty_env("MISE_DATA_DIR") ->
+        data_dir
+
+      xdg_data_home = non_empty_env("XDG_DATA_HOME") ->
+        Path.join(xdg_data_home, "mise")
+
+      home = non_empty_env("HOME") ->
+        Path.join([home, ".local", "share", "mise"])
+
+      true ->
+        nil
+    end
+  end
+
+  defp non_empty_env(name) do
+    case System.get_env(name) do
+      nil -> nil
+      "" -> nil
+      value -> value
+    end
   end
 
   defp mise_install_path?(_entry, nil), do: false

--- a/cli/test/engine_test.exs
+++ b/cli/test/engine_test.exs
@@ -91,7 +91,68 @@ defmodule Cli.EngineTest do
 
   defmodule EnvHarness do
     def build_command(_message, _model, _system_prompt_file, _session, _timeout, _opts) do
-      {"printf 'CALLER_PWD=%s\\n' \"${CALLER_PWD-}\"; printf 'SESSIONS_CALLER_PWD=%s\\n' \"${SESSIONS_CALLER_PWD-}\"; printf 'OTHER_CALLER_PWD=%s\\n' \"${OTHER_CALLER_PWD-}\"", []}
+      {"printf 'CALLER_PWD=%s\\n' \"${CALLER_PWD-}\"; printf 'SESSIONS_CALLER_PWD=%s\\n' \"${SESSIONS_CALLER_PWD-}\"; printf 'OTHER_CALLER_PWD=%s\\n' \"${OTHER_CALLER_PWD-}\"",
+       []}
+    end
+
+    def process_line(line, state) do
+      IO.puts(line)
+      state
+    end
+
+    def extract_partial_text(_partial), do: ""
+  end
+
+  test "sanitizes mise install paths from harness PATH" do
+    home = System.get_env("HOME") || System.tmp_dir!()
+
+    stale_codebase =
+      Path.join([home, ".local", "share", "mise", "installs", "shiv-codebase", "0.1.0", "bin"])
+
+    fresh_codebase =
+      Path.join([home, ".local", "share", "mise", "installs", "shiv-codebase", "0.2.0", "bin"])
+
+    mise_shims = Path.join([home, ".local", "share", "mise", "shims"])
+    non_mise = Path.join(System.tmp_dir!(), "sessions-non-mise-bin")
+
+    previous_path = System.get_env("PATH")
+
+    try do
+      System.put_env("PATH", Enum.join([stale_codebase, non_mise, fresh_codebase], ":"))
+
+      output =
+        capture_io(fn ->
+          exit_code =
+            Cli.Engine.run(
+              __MODULE__.PathHarness,
+              "ignored",
+              "/tmp/prompt.txt",
+              nil,
+              "test-model",
+              nil,
+              nil,
+              []
+            )
+
+          send(self(), {:exit_code, exit_code})
+        end)
+
+      assert_receive {:exit_code, 0}
+      refute output =~ stale_codebase
+      refute output =~ fresh_codebase
+      assert output =~ non_mise
+
+      if File.dir?(mise_shims) do
+        assert output =~ mise_shims
+      end
+    after
+      restore_env("PATH", previous_path)
+    end
+  end
+
+  defmodule PathHarness do
+    def build_command(_message, _model, _system_prompt_file, _session, _timeout, _opts) do
+      {"printf 'PATH=%s\\n' \"$PATH\"", []}
     end
 
     def process_line(line, state) do

--- a/cli/test/engine_test.exs
+++ b/cli/test/engine_test.exs
@@ -105,14 +105,48 @@ defmodule Cli.EngineTest do
 
   test "sanitizes mise install paths from harness PATH" do
     home = System.get_env("HOME") || System.tmp_dir!()
+    mise_data_dir = Path.join([home, ".local", "share", "mise"])
 
-    stale_codebase =
-      Path.join([home, ".local", "share", "mise", "installs", "shiv-codebase", "0.1.0", "bin"])
+    with_env(%{"MISE_DATA_DIR" => nil, "XDG_DATA_HOME" => nil}, fn ->
+      assert_sanitized_path(mise_data_dir)
+    end)
+  end
 
-    fresh_codebase =
-      Path.join([home, ".local", "share", "mise", "installs", "shiv-codebase", "0.2.0", "bin"])
+  test "sanitizes mise install paths from MISE_DATA_DIR" do
+    tmp =
+      Path.join(System.tmp_dir!(), "sessions-mise-data-dir-#{System.unique_integer([:positive])}")
 
-    mise_shims = Path.join([home, ".local", "share", "mise", "shims"])
+    File.mkdir_p!(Path.join(tmp, "shims"))
+
+    try do
+      with_env(%{"MISE_DATA_DIR" => tmp, "XDG_DATA_HOME" => nil}, fn ->
+        assert_sanitized_path(tmp)
+      end)
+    after
+      File.rm_rf!(tmp)
+    end
+  end
+
+  test "sanitizes mise install paths from XDG_DATA_HOME" do
+    xdg_data_home =
+      Path.join(System.tmp_dir!(), "sessions-xdg-data-home-#{System.unique_integer([:positive])}")
+
+    mise_data_dir = Path.join(xdg_data_home, "mise")
+    File.mkdir_p!(Path.join(mise_data_dir, "shims"))
+
+    try do
+      with_env(%{"MISE_DATA_DIR" => nil, "XDG_DATA_HOME" => xdg_data_home}, fn ->
+        assert_sanitized_path(mise_data_dir)
+      end)
+    after
+      File.rm_rf!(xdg_data_home)
+    end
+  end
+
+  defp assert_sanitized_path(mise_data_dir) do
+    stale_codebase = Path.join([mise_data_dir, "installs", "shiv-codebase", "0.1.0", "bin"])
+    fresh_codebase = Path.join([mise_data_dir, "installs", "shiv-codebase", "0.2.0", "bin"])
+    mise_shims = Path.join(mise_data_dir, "shims")
     non_mise = Path.join(System.tmp_dir!(), "sessions-non-mise-bin")
 
     previous_path = System.get_env("PATH")
@@ -161,6 +195,21 @@ defmodule Cli.EngineTest do
     end
 
     def extract_partial_text(_partial), do: ""
+  end
+
+  defp with_env(env, fun) do
+    previous = Map.new(env, fn {name, _value} -> {name, System.get_env(name)} end)
+
+    try do
+      Enum.each(env, fn
+        {name, nil} -> System.delete_env(name)
+        {name, value} -> System.put_env(name, value)
+      end)
+
+      fun.()
+    after
+      Enum.each(previous, fn {name, value} -> restore_env(name, value) end)
+    end
   end
 
   defp restore_env(name, nil), do: System.delete_env(name)


### PR DESCRIPTION
## Summary
- scrub `~/.local/share/mise/installs/...` entries from the PATH inherited by the harness process
- keep non-mise PATH entries and ensure the mise shims directory is present when available
- add an engine regression proving stale/fresh direct install bins are removed before the agent harness runs

## Why
During Brownie's CI review of KnickKnackLabs/wallpapers#55, a bare `codebase ...` from `~/agents/brownie/wallpapers` resolved to fold's `shiv-codebase@0.1.0` direct install, even though wallpapers declared `shiv:codebase=latest` and `mise.lock` resolved `0.2.0`.

Root cause: the agent process is launched from nested mise/shiv tasks, so it inherits direct install bin paths from the launcher repo (`fold` pins codebase 0.1.0). Later `cd` into another repo does not reorder those already-prepended direct install entries, so bare commands can beat the mise shims and ignore the target repo's lockfile.

Long-lived agent sessions should inherit shims, not fixed-version launcher install bins. This keeps bare commands repo-sensitive from the agent's perspective.

## Verification
- `cd cli && mix test test/engine_test.exs`
- `cd cli && mix test`
- `git diff --check`

Note: `mise run test` currently has unrelated failures in existing BATS around meta/search/wake state; I did not treat that as verification for this PR.
