### PR TITLE
fix(wake): use preflighted run-as-user helper

### DIFF
--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -200,7 +200,7 @@ if [ -n "$MESSAGE" ]; then
 fi
 
 if [ -n "$OS_USER" ]; then
-  RUN_CMD=("$MISE_CONFIG_ROOT/libexec/run-as-user" --user "$OS_USER" -- "${RUN_CMD[@]}")
+  RUN_CMD=("$HOST_RUN_AS_USER" --user "$OS_USER" -- "${RUN_CMD[@]}")
 fi
 
 scrub_caller_pwd_env

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -352,7 +352,7 @@ STUB
   [ "$(sed -n '3p' "$capture")" = "--cwd" ]
 
   local run_as_line
-  run_as_line=$(grep -n '/libexec/run-as-user$' "$capture" | cut -d: -f1)
+  run_as_line=$(grep -nFx "$SESSIONS_RUN_AS_USER" "$capture" | cut -d: -f1)
   [ -n "$run_as_line" ]
   [ "$(sed -n "$((run_as_line + 1))p" "$capture")" = "--user" ]
   [ "$(sed -n "$((run_as_line + 2))p" "$capture")" = "iris" ]


### PR DESCRIPTION
Fix-it for #78.\n\nThe wake preflight honors the shared host helper path (including SESSIONS_RUN_AS_USER overrides), but launch was hardcoding libexec/run-as-user. This makes the preflight and payload wrapper use the same helper and updates the argv test accordingly.\n\nValidation:\n- git diff --check\n- bash -n .mise/tasks/wake test/wake.bats\n\nNote: mise run test and mise run test test/wake.bats both failed in this checkout before executing tests because the local bats install could not find bats_readlinkf / bats-exec-test.