### PR TITLE
fix(wake): launch with preflighted run-as-user helper

### DIFF
--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -200,7 +200,7 @@ if [ -n "$MESSAGE" ]; then
 fi
 
 if [ -n "$OS_USER" ]; then
-  RUN_CMD=("$MISE_CONFIG_ROOT/libexec/run-as-user" --user "$OS_USER" -- "${RUN_CMD[@]}")
+  RUN_CMD=("$HOST_RUN_AS_USER" --user "$OS_USER" -- "${RUN_CMD[@]}")
 fi
 
 scrub_caller_pwd_env

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -352,7 +352,7 @@ STUB
   [ "$(sed -n '3p' "$capture")" = "--cwd" ]
 
   local run_as_line
-  run_as_line=$(grep -n '/libexec/run-as-user$' "$capture" | cut -d: -f1)
+  run_as_line=$(grep -nFx "$SESSIONS_RUN_AS_USER" "$capture" | cut -d: -f1)
   [ -n "$run_as_line" ]
   [ "$(sed -n "$((run_as_line + 1))p" "$capture")" = "--user" ]
   [ "$(sed -n "$((run_as_line + 2))p" "$capture")" = "iris" ]


### PR DESCRIPTION
Fix-it for #78.\n\nThe wake task preflights through HOST_RUN_AS_USER (honoring SESSIONS_RUN_AS_USER), but the launch path was hardcoding libexec/run-as-user. This makes the launched payload use the same helper that was preflighted and tightens the argv regression test accordingly.\n\nValidation:\n- git diff --check origin/ikma/wake-os-user-routing...HEAD\n- bash -n .mise/tasks/wake test/wake.bats\n\nNote: I also attempted `mise run test wake harness_dispatch`, but this runner's BATS install failed before executing tests with `bats_readlinkf: command not found` / missing `bats-exec-test`.