### PR TITLE
fix(wake): launch with preflighted run-as-user helper

### DIFF
--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -200,7 +200,7 @@ if [ -n "$MESSAGE" ]; then
 fi
 
 if [ -n "$OS_USER" ]; then
-  RUN_CMD=("$MISE_CONFIG_ROOT/libexec/run-as-user" --user "$OS_USER" -- "${RUN_CMD[@]}")
+  RUN_CMD=("$HOST_RUN_AS_USER" --user "$OS_USER" -- "${RUN_CMD[@]}")
 fi
 
 scrub_caller_pwd_env

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -352,7 +352,7 @@ STUB
   [ "$(sed -n '3p' "$capture")" = "--cwd" ]
 
   local run_as_line
-  run_as_line=$(grep -n '/libexec/run-as-user$' "$capture" | cut -d: -f1)
+  run_as_line=$(grep -n -Fx "$SESSIONS_RUN_AS_USER" "$capture" | cut -d: -f1)
   [ -n "$run_as_line" ]
   [ "$(sed -n "$((run_as_line + 1))p" "$capture")" = "--user" ]
   [ "$(sed -n "$((run_as_line + 2))p" "$capture")" = "iris" ]


### PR DESCRIPTION
Fix-it for #78.\n\nThe wake OS-user preflight goes through `host_run_as_user_smoke`, which uses `HOST_RUN_AS_USER` and honors `SESSIONS_RUN_AS_USER`. The launch wrapper should use that same helper, rather than a separate hard-coded repo path, so a successful preflight validates the executable that actually runs the payload.\n\nValidation:\n- `git diff --check`\n- `bash -n .mise/tasks/wake test/wake.bats`\n\nI also attempted `mise run test wake harness_dispatch`, but this runner's BATS install failed before executing tests (`bats_readlinkf: command not found`, then missing `bats-exec-test`).