### PR TITLE
Honor configured mise data dir in harness PATH scrub

### DIFF
--- a/cli/lib/cli/engine.ex
+++ b/cli/lib/cli/engine.ex
@@ -108,12 +108,9 @@ defmodule Cli.Engine do
   end
 
   defp sanitized_path(path) do
-    home = System.get_env("HOME")
-
-    mise_installs =
-      if home, do: Path.join([home, ".local", "share", "mise", "installs"]), else: nil
-
-    mise_shims = if home, do: Path.join([home, ".local", "share", "mise", "shims"]), else: nil
+    mise_data_dir = mise_data_dir()
+    mise_installs = if mise_data_dir, do: Path.join(mise_data_dir, "installs"), else: nil
+    mise_shims = if mise_data_dir, do: Path.join(mise_data_dir, "shims"), else: nil
 
     entries =
       path
@@ -128,6 +125,30 @@ defmodule Cli.Engine do
       end
 
     Enum.join(entries, ":")
+  end
+
+  defp mise_data_dir do
+    cond do
+      data_dir = non_empty_env("MISE_DATA_DIR") ->
+        data_dir
+
+      xdg_data_home = non_empty_env("XDG_DATA_HOME") ->
+        Path.join(xdg_data_home, "mise")
+
+      home = non_empty_env("HOME") ->
+        Path.join([home, ".local", "share", "mise"])
+
+      true ->
+        nil
+    end
+  end
+
+  defp non_empty_env(name) do
+    case System.get_env(name) do
+      nil -> nil
+      "" -> nil
+      value -> value
+    end
   end
 
   defp mise_install_path?(_entry, nil), do: false

--- a/cli/test/engine_test.exs
+++ b/cli/test/engine_test.exs
@@ -105,14 +105,48 @@ defmodule Cli.EngineTest do
 
   test "sanitizes mise install paths from harness PATH" do
     home = System.get_env("HOME") || System.tmp_dir!()
+    mise_data_dir = Path.join([home, ".local", "share", "mise"])
 
-    stale_codebase =
-      Path.join([home, ".local", "share", "mise", "installs", "shiv-codebase", "0.1.0", "bin"])
+    with_env(%{"MISE_DATA_DIR" => nil, "XDG_DATA_HOME" => nil}, fn ->
+      assert_sanitized_path(mise_data_dir)
+    end)
+  end
 
-    fresh_codebase =
-      Path.join([home, ".local", "share", "mise", "installs", "shiv-codebase", "0.2.0", "bin"])
+  test "sanitizes mise install paths from MISE_DATA_DIR" do
+    tmp =
+      Path.join(System.tmp_dir!(), "sessions-mise-data-dir-#{System.unique_integer([:positive])}")
 
-    mise_shims = Path.join([home, ".local", "share", "mise", "shims"])
+    File.mkdir_p!(Path.join(tmp, "shims"))
+
+    try do
+      with_env(%{"MISE_DATA_DIR" => tmp, "XDG_DATA_HOME" => nil}, fn ->
+        assert_sanitized_path(tmp)
+      end)
+    after
+      File.rm_rf!(tmp)
+    end
+  end
+
+  test "sanitizes mise install paths from XDG_DATA_HOME" do
+    xdg_data_home =
+      Path.join(System.tmp_dir!(), "sessions-xdg-data-home-#{System.unique_integer([:positive])}")
+
+    mise_data_dir = Path.join(xdg_data_home, "mise")
+    File.mkdir_p!(Path.join(mise_data_dir, "shims"))
+
+    try do
+      with_env(%{"MISE_DATA_DIR" => nil, "XDG_DATA_HOME" => xdg_data_home}, fn ->
+        assert_sanitized_path(mise_data_dir)
+      end)
+    after
+      File.rm_rf!(xdg_data_home)
+    end
+  end
+
+  defp assert_sanitized_path(mise_data_dir) do
+    stale_codebase = Path.join([mise_data_dir, "installs", "shiv-codebase", "0.1.0", "bin"])
+    fresh_codebase = Path.join([mise_data_dir, "installs", "shiv-codebase", "0.2.0", "bin"])
+    mise_shims = Path.join(mise_data_dir, "shims")
     non_mise = Path.join(System.tmp_dir!(), "sessions-non-mise-bin")
 
     previous_path = System.get_env("PATH")
@@ -161,6 +195,21 @@ defmodule Cli.EngineTest do
     end
 
     def extract_partial_text(_partial), do: ""
+  end
+
+  defp with_env(env, fun) do
+    previous = Map.new(env, fn {name, _value} -> {name, System.get_env(name)} end)
+
+    try do
+      Enum.each(env, fn
+        {name, nil} -> System.delete_env(name)
+        {name, value} -> System.put_env(name, value)
+      end)
+
+      fun.()
+    after
+      Enum.each(previous, fn {name, value} -> restore_env(name, value) end)
+    end
   end
 
   defp restore_env(name, nil), do: System.delete_env(name)


### PR DESCRIPTION
## Summary
- derive mise's data dir from `MISE_DATA_DIR`, then `XDG_DATA_HOME`, then the default `~/.local/share/mise`
- scrub direct install bins and add shims from the configured data dir
- add engine regressions for both `MISE_DATA_DIR` and `XDG_DATA_HOME`

## Verification
- `cd cli && mix format --check-formatted lib/cli/engine.ex test/engine_test.exs`
- `cd cli && mix test test/engine_test.exs`
- `cd cli && mix test`
- `git diff --check`
