### PR TITLE
fix(wake): execute smoke-tested run-as-user

### DIFF
--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -200,7 +200,7 @@ if [ -n "$MESSAGE" ]; then
 fi
 
 if [ -n "$OS_USER" ]; then
-  RUN_CMD=("$MISE_CONFIG_ROOT/libexec/run-as-user" --user "$OS_USER" -- "${RUN_CMD[@]}")
+  RUN_CMD=("$HOST_RUN_AS_USER" --user "$OS_USER" -- "${RUN_CMD[@]}")
 fi
 
 scrub_caller_pwd_env

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -352,7 +352,7 @@ STUB
   [ "$(sed -n '3p' "$capture")" = "--cwd" ]
 
   local run_as_line
-  run_as_line=$(grep -n '/libexec/run-as-user$' "$capture" | cut -d: -f1)
+  run_as_line=$(grep -nFx "$SESSIONS_RUN_AS_USER" "$capture" | cut -d: -f1)
   [ -n "$run_as_line" ]
   [ "$(sed -n "$((run_as_line + 1))p" "$capture")" = "--user" ]
   [ "$(sed -n "$((run_as_line + 2))p" "$capture")" = "iris" ]


### PR DESCRIPTION
Fix-it PR for #78.

`wake` preflights via `host_run_as_user_smoke`, which resolves `$HOST_RUN_AS_USER` from `SESSIONS_RUN_AS_USER` or the bundled default, but the payload wrapper was hard-coded to `$MISE_CONFIG_ROOT/libexec/run-as-user`. This makes the runtime command diverge from the binary that was just smoke-tested.

This switches the wrapper to `$HOST_RUN_AS_USER` and tightens the argv test to assert that exact path.

Validation:
- `env -u MISE_CONFIG_ROOT $(env | awk -F= '/^usage_/ {print "-u", $1}') mise run test wake harness_dispatch`\n- `env -u MISE_CONFIG_ROOT $(env | awk -F= '/^usage_/ {print "-u", $1}') mise run test`