### PR TITLE
wake: allow interactive runs without an initial message

### DIFF
--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 #MISE description="Run an agent session with streaming output, timeout, and ABORT detection"
 #MISE quiet=true
-#USAGE arg "<message>" help="Message for the agent"
+#USAGE arg "[message]" help="Message for the agent (required for --headless, optional for interactive)"
 #USAGE flag "--system-prompt-file <file>" help="Path to system prompt file"
 #USAGE flag "--timeout <seconds>" help="Timeout in seconds (default: no timeout)"
 #USAGE flag "--model <model>" help="Model to use (required; provider-qualified, e.g. openai-codex/gpt-5.5)"
 #USAGE flag "--session <session>" help="Session file for conversation continuity"
 #USAGE flag "--cwd <cwd>" help="Working directory for pi"
 #USAGE flag "--headless" help="Non-interactive mode (appends headless context to system prompt)"
-#USAGE flag "--extensions" help="Enable pi extensions (default: disabled)"
-#USAGE flag "--skills" help="Enable pi skills (default: disabled)"
-#USAGE flag "--prompt-templates" help="Enable pi prompt templates (default: disabled)"
+#USAGE flag "--extensions" help="Enable pi extensions for print-mode runs (interactive no-message runs use pi defaults)"
+#USAGE flag "--skills" help="Enable pi skills for print-mode runs (interactive no-message runs use pi defaults)"
+#USAGE flag "--prompt-templates" help="Enable pi prompt templates for print-mode runs (interactive no-message runs use pi defaults)"
 
 set -euo pipefail
 
@@ -26,9 +26,12 @@ EXTENSIONS="${usage_extensions:-false}"
 SKILLS="${usage_skills:-false}"
 PROMPT_TEMPLATES="${usage_prompt_templates:-false}"
 
-if [ -z "$MESSAGE" ]; then
-  echo "Error: message required" >&2
-  echo "Usage: sessions run --system-prompt-file <path> --model <provider/model> [options] \"message\"" >&2
+# shellcheck source=../../lib/harness-env.sh
+source "$MISE_CONFIG_ROOT/lib/harness-env.sh"
+
+if [ "$HEADLESS" = "true" ] && [ -z "$MESSAGE" ]; then
+  echo "Error: --headless requires a message" >&2
+  echo "Usage: sessions run --headless --system-prompt-file <path> --model <provider/model> [options] \"message\"" >&2
   exit 1
 fi
 
@@ -68,6 +71,62 @@ if [ "$HEADLESS" = "true" ] && [ -n "$SYSTEM_PROMPT_FILE" ]; then
 ## Session Context
 This is a headless session. No human is present. You are running non-interactively — complete the task and exit.
 HEADLESS_EOF
+fi
+
+run_interactive_without_message() {
+  if [ -z "$SYSTEM_PROMPT_FILE" ]; then
+    echo "Error: --system-prompt-file is required" >&2
+    exit 1
+  fi
+
+  if [ ! -f "$SYSTEM_PROMPT_FILE" ]; then
+    echo "Error: System prompt file not found: $SYSTEM_PROMPT_FILE" >&2
+    exit 1
+  fi
+
+  # shellcheck source=../../lib/harness/dispatch.sh
+  source "$MISE_CONFIG_ROOT/lib/harness/dispatch.sh"
+
+  local harness_name
+  if [ -n "$SESSION" ]; then
+    harness_name=$(harness_resolve --session "$SESSION") || exit 1
+  else
+    harness_name=$(harness_resolve) || exit 1
+  fi
+
+  if [ "$harness_name" != "pi" ]; then
+    echo "sessions: '$harness_name' harness does not support interactive no-message run yet" >&2
+    exit "$HARNESS_UNSUPPORTED_EXIT"
+  fi
+
+  sessions_prepare_harness_env
+
+  if ! command -v pi >/dev/null 2>&1; then
+    echo "Error: pi not found on PATH" >&2
+    exit 1
+  fi
+
+  local pi_args=(--append-system-prompt "$SYSTEM_PROMPT_FILE" --model "$MODEL")
+  if [ -n "$SESSION" ]; then
+    pi_args+=(--session "$SESSION")
+  else
+    pi_args+=(--no-session)
+  fi
+  cd "$CWD"
+
+  if [ -n "$TIMEOUT" ]; then
+    if ! command -v timeout >/dev/null 2>&1; then
+      echo "Error: timeout command is required for --timeout" >&2
+      exit 1
+    fi
+    exec timeout "$TIMEOUT" pi "${pi_args[@]}"
+  fi
+
+  exec pi "${pi_args[@]}"
+}
+
+if [ -z "$MESSAGE" ]; then
+  run_interactive_without_message
 fi
 
 CLI_DIR="$MISE_CONFIG_ROOT/cli"

--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 #MISE description="Run an agent session with streaming output, timeout, and ABORT detection"
 #MISE quiet=true
-#USAGE arg "[message]" help="Message for the agent (required for --headless, optional for interactive)"
-#USAGE flag "--system-prompt-file <file>" help="Path to system prompt file"
-#USAGE flag "--timeout <seconds>" help="Timeout in seconds (default: no timeout)"
-#USAGE flag "--model <model>" help="Model to use (required; provider-qualified, e.g. openai-codex/gpt-5.5)"
-#USAGE flag "--session <session>" help="Session file for conversation continuity"
-#USAGE flag "--cwd <cwd>" help="Working directory for pi"
-#USAGE flag "--headless" help="Non-interactive mode (appends headless context to system prompt)"
-#USAGE flag "--extensions" help="Enable pi extensions for print-mode runs (interactive no-message runs use pi defaults)"
-#USAGE flag "--skills" help="Enable pi skills for print-mode runs (interactive no-message runs use pi defaults)"
-#USAGE flag "--prompt-templates" help="Enable pi prompt templates for print-mode runs (interactive no-message runs use pi defaults)"
+#USAGE arg "[message]" default="" help="Message for the agent (required for --headless, optional for interactive)"
+#USAGE flag "--system-prompt-file <file>" default="" help="Path to system prompt file"
+#USAGE flag "--timeout <seconds>" default="" help="Timeout in seconds (default: no timeout)"
+#USAGE flag "--model <model>" default="" help="Model to use (required; provider-qualified, e.g. openai-codex/gpt-5.5)"
+#USAGE flag "--session <session>" default="" help="Session file for conversation continuity"
+#USAGE flag "--cwd <cwd>" default="" help="Working directory for pi"
+#USAGE flag "--headless" default=#false help="Non-interactive mode (appends headless context to system prompt)"
+#USAGE flag "--extensions" default=#false help="Enable pi extensions for print-mode runs (interactive no-message runs use pi defaults)"
+#USAGE flag "--skills" default=#false help="Enable pi skills for print-mode runs (interactive no-message runs use pi defaults)"
+#USAGE flag "--prompt-templates" default=#false help="Enable pi prompt templates for print-mode runs (interactive no-message runs use pi defaults)"
 
 set -euo pipefail
 

--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -3,7 +3,7 @@
 #USAGE arg "<session_id>" help="Session ID or name to wake into"
 #USAGE flag "--context <context>" help="Inject a context message into the session file before launching"
 #USAGE flag "--context-file <context_file>" help="File containing context message to inject"
-#USAGE flag "--message <message>" help="Message to pass to the agent"
+#USAGE flag "--message <message>" help="Message to pass to the agent (required for --headless, optional for interactive)"
 #USAGE flag "--model <model>" help="Model to use (required; provider-qualified, e.g. openai-codex/gpt-5.5)"
 #USAGE flag "--os-user <os_user>" help="Run the session payload as this local OS user (default: $SHIMMER_OS_USER)"
 #USAGE flag "--headless" help="No human present — agent completes task and exits"
@@ -45,6 +45,12 @@ fi
 
 if [[ "$MODEL" != */* ]]; then
   echo "Error: --model must be provider-qualified (for example: openai-codex/gpt-5.5)" >&2
+  exit 1
+fi
+
+if [ "$HEADLESS" = "true" ] && [ -z "$MESSAGE" ]; then
+  echo "Error: --headless requires --message" >&2
+  echo "Usage: sessions wake <name-or-id> --headless --model <provider/model> --message '...'" >&2
   exit 1
 fi
 

--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 #MISE description="Wake an agent into a session"
 #USAGE arg "<session_id>" help="Session ID or name to wake into"
-#USAGE flag "--context <context>" help="Inject a context message into the session file before launching"
-#USAGE flag "--context-file <context_file>" help="File containing context message to inject"
-#USAGE flag "--message <message>" help="Message to pass to the agent (required for --headless, optional for interactive)"
-#USAGE flag "--model <model>" help="Model to use (required; provider-qualified, e.g. openai-codex/gpt-5.5)"
-#USAGE flag "--os-user <os_user>" help="Run the session payload as this local OS user (default: $SHIMMER_OS_USER)"
-#USAGE flag "--headless" help="No human present — agent completes task and exits"
-#USAGE flag "--background" help="Launch in background via shell/zmx (default: foreground, blocks until done)"
-#USAGE flag "--meta <meta>" var=#true help="Metadata for the wake event (repeatable, dotted paths or jq expressions)"
+#USAGE flag "--context <context>" default="" help="Inject a context message into the session file before launching"
+#USAGE flag "--context-file <context_file>" default="" help="File containing context message to inject"
+#USAGE flag "--message <message>" default="" help="Message to pass to the agent (required for --headless, optional for interactive)"
+#USAGE flag "--model <model>" default="" help="Model to use (required; provider-qualified, e.g. openai-codex/gpt-5.5)"
+#USAGE flag "--os-user <os_user>" default="" help="Run the session payload as this local OS user (default: $SHIMMER_OS_USER)"
+#USAGE flag "--headless" default=#false help="No human present — agent completes task and exits"
+#USAGE flag "--background" default=#false help="Launch in background via shell/zmx (default: foreground, blocks until done)"
+#USAGE flag "--meta <meta>" var=#true default="" help="Metadata for the wake event (repeatable, dotted paths or jq expressions)"
 
 set -euo pipefail
 
@@ -98,6 +98,11 @@ SESSION_FILE=$(find_session_file "$SESSION_ID") || exit 1
 HARNESS_NAME=$(harness_resolve --session "$SESSION_FILE") || exit 1
 # shellcheck source=/dev/null
 source "$MISE_CONFIG_ROOT/lib/harness/$HARNESS_NAME.sh"
+
+if [ -z "$MESSAGE" ] && [ "$HARNESS_NAME" != "pi" ]; then
+  echo "sessions: '$HARNESS_NAME' harness does not support interactive no-message wake yet" >&2
+  exit "$HARNESS_UNSUPPORTED_EXIT"
+fi
 
 FULL_SESSION_ID=$(head -1 "$SESSION_FILE" | jq -r '.id // empty')
 if [ -z "$FULL_SESSION_ID" ]; then

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 238 passing](https://img.shields.io/badge/tests-238%20passing-brightgreen?style=flat)](test/)
+[![tests: 239 passing](https://img.shields.io/badge/tests-239%20passing-brightgreen?style=flat)](test/)
 ![commands: 14](https://img.shields.io/badge/commands-14-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -177,7 +177,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**238 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
+**239 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -207,7 +207,7 @@ sessions/
 │   ├── shell.sh        # Shell helpers
 │   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats          # 238 tests
+    └── *.bats          # 239 tests
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 232 passing](https://img.shields.io/badge/tests-232%20passing-brightgreen?style=flat)](test/)
+[![tests: 238 passing](https://img.shields.io/badge/tests-238%20passing-brightgreen?style=flat)](test/)
 ![commands: 14](https://img.shields.io/badge/commands-14-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -60,7 +60,7 @@ Sessions aren't just transcript files agents leave behind — they're managed ar
     └─ shell run            persistent zmx session (caller-owned)
          └─ run-as-user     optional --os-user payload boundary
               └─ sessions run
-                   └─ pi    harness — processes message, exits
+                   └─ pi    harness — processes message or opens interactively
   sessions read             observe the transcript
   sessions wake (again)     re-enter with corrections
 ```
@@ -87,6 +87,8 @@ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed th
 The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for persistent zmx sessions. `sessions wake` calls `sessions run` directly for execution — identity (AGENT_IDENTITY, etc.) must already be in the environment, typically set upstream via `eval $(shimmer as <agent>)`.
 
 `--model` on `sessions wake` is required and is not remembered across wakes — pass a provider-qualified model (for example `openai-codex/gpt-5.5`) on each wake.
+
+`--message` is optional for interactive wakes/runs; omit it to open the harness and let the human start the conversation. `--headless` still requires `--message`.
 
 To run only the payload process as a local agent OS user, pass `--os-user` or set `SHIMMER_OS_USER`. The shell/zmx session remains owned by the caller. This does not copy caller environment, secrets, or auth into the target account; the target user's session environment is a separate setup step.
 
@@ -175,7 +177,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**232 tests** across 15 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
+**238 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -205,7 +207,7 @@ sessions/
 │   ├── shell.sh        # Shell helpers
 │   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats          # 232 tests
+    └── *.bats          # 238 tests
 ```
 
 </details>

--- a/README.tsx
+++ b/README.tsx
@@ -68,7 +68,7 @@ const stack = [
   "    └─ shell run            persistent zmx session (caller-owned)",
   "         └─ run-as-user     optional --os-user payload boundary",
   "              └─ sessions run",
-  "                   └─ pi    harness — processes message, exits",
+  "                   └─ pi    harness — processes message or opens interactively",
   "  sessions read             observe the transcript",
   "  sessions wake (again)     re-enter with corrections",
 ].join("\n");
@@ -190,6 +190,15 @@ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed th
         {" is required and is not remembered across wakes — pass a provider-qualified model (for example "}
         <Code>openai-codex/gpt-5.5</Code>
         {") on each wake."}
+      </Paragraph>
+
+      <Paragraph>
+        <Code>--message</Code>
+        {" is optional for interactive wakes/runs; omit it to open the harness and let the human start the conversation. "}
+        <Code>--headless</Code>
+        {" still requires "}
+        <Code>--message</Code>
+        {"."}
       </Paragraph>
 
       <Paragraph>

--- a/lib/harness-env.sh
+++ b/lib/harness-env.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Shared environment preparation for launching an interactive harness
+# directly from Bash tasks.
+
+sessions_scrub_caller_pwd_env() {
+  local name
+  while IFS= read -r name; do
+    case "$name" in
+      CALLER_PWD|*_CALLER_PWD) unset "$name" ;;
+    esac
+  done < <(compgen -e)
+}
+
+sessions_mise_data_dir() {
+  if [ -n "${MISE_DATA_DIR:-}" ]; then
+    echo "$MISE_DATA_DIR"
+  elif [ -n "${XDG_DATA_HOME:-}" ]; then
+    echo "$XDG_DATA_HOME/mise"
+  elif [ -n "${HOME:-}" ]; then
+    echo "$HOME/.local/share/mise"
+  fi
+}
+
+sessions_sanitize_harness_path() {
+  local data_dir
+  data_dir=$(sessions_mise_data_dir)
+  [ -n "$data_dir" ] || return 0
+
+  local installs="$data_dir/installs"
+  local shims="$data_dir/shims"
+  local path_rest="${PATH:-}:"
+  local entry new_path="" have_entry=false
+
+  while [ -n "$path_rest" ]; do
+    entry="${path_rest%%:*}"
+    path_rest="${path_rest#*:}"
+
+    case "$entry" in
+      "$installs"/*) continue ;;
+    esac
+
+    if [ "$have_entry" = false ]; then
+      new_path="$entry"
+      have_entry=true
+    else
+      new_path="$new_path:$entry"
+    fi
+  done
+
+  if [ -d "$shims" ]; then
+    case ":$new_path:" in
+      *":$shims:"*) ;;
+      *)
+        if [ "$have_entry" = true ]; then
+          new_path="$shims:$new_path"
+        else
+          new_path="$shims"
+        fi
+        ;;
+    esac
+  fi
+
+  export PATH="$new_path"
+}
+
+sessions_prepare_harness_env() {
+  sessions_scrub_caller_pwd_env
+  sessions_sanitize_harness_path
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -28,6 +28,100 @@ sessions() {
 }
 export -f sessions
 
+stub_pi_capture_argv_cwd() {
+  local stub_dir="$1"
+  local argv_capture="$2"
+  local cwd_capture="$3"
+
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/pi" <<STUB
+#!/usr/bin/env bash
+pwd -P > "$cwd_capture"
+printf '%s\n' "\$@" > "$argv_capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/pi"
+}
+
+stub_pi_capture_env() {
+  local stub_dir="$1"
+  local env_capture="$2"
+
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/pi" <<STUB
+#!/usr/bin/env bash
+printf 'CALLER_PWD=%s\n' "\${CALLER_PWD-}" > "$env_capture"
+printf 'SESSIONS_CALLER_PWD=%s\n' "\${SESSIONS_CALLER_PWD-}" >> "$env_capture"
+printf 'OTHER_CALLER_PWD=%s\n' "\${OTHER_CALLER_PWD-}" >> "$env_capture"
+printf 'PATH=%s\n' "\$PATH" >> "$env_capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/pi"
+}
+
+stub_shell_exec_payload() {
+  local stub_dir="$1"
+  local argv_capture="$2"
+
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/shell" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$@" > "$argv_capture"
+[ "\${1:-}" = "run" ]
+shift
+shell_name="\${1:-}"
+[ -n "\$shell_name" ]
+shift
+cwd=""
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    --cwd)
+      cwd="\$2"
+      shift 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+[ -n "\$cwd" ]
+cd "\$cwd"
+exec "\$@"
+STUB
+  chmod +x "$stub_dir/shell"
+}
+
+stub_shell_recording() {
+  local stub_dir="$1"
+  local argv_capture="$2"
+  local names_capture="$3"
+
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/shell" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+case "\${1:-}" in
+  run)
+    printf '%s\n' "\$@" > "$argv_capture"
+    if [ "\$#" -ge 2 ]; then
+      printf '%s\n' "\$2" >> "$names_capture"
+    fi
+    ;;
+  list)
+    [ -f "$names_capture" ] && cat "$names_capture"
+    ;;
+  kill|status|wait|history|send)
+    ;;
+  *)
+    printf 'unexpected shell stub command: %s\n' "\${1:-}" >&2
+    exit 2
+    ;;
+esac
+STUB
+  chmod +x "$stub_dir/shell"
+}
+
 # Fixed UUIDs for reproducible tests
 SESSION_1="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 SESSION_2="11111111-2222-3333-4444-555555555555"

--- a/test/run.bats
+++ b/test/run.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+
+load helpers
+
+setup() {
+  setup_test_sessions
+}
+
+teardown() {
+  teardown_test_sessions
+}
+
+@test "run interactive without message execs pi without print mode" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi"
+  local argv_capture="$BATS_TEST_TMPDIR/pi-argv"
+  local cwd_capture="$BATS_TEST_TMPDIR/pi-cwd"
+  stub_pi_capture_argv_cwd "$stub_dir" "$argv_capture" "$cwd_capture"
+
+  local prompt="$BATS_TEST_TMPDIR/prompt.md"
+  echo "test prompt" > "$prompt"
+
+  local run_cwd="$BATS_TEST_TMPDIR/run-cwd"
+  mkdir -p "$run_cwd"
+  local expected_cwd
+  expected_cwd=$(cd "$run_cwd" && pwd -P)
+
+  local session_file
+  session_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+
+  PATH="$stub_dir:$PATH" run sessions run \
+    --system-prompt-file "$prompt" \
+    --cwd "$run_cwd" \
+    --model "openai-codex/gpt-5.5" \
+    --session "$session_file"
+  [ "$status" -eq 0 ]
+  [ -f "$argv_capture" ]
+  [ -f "$cwd_capture" ]
+
+  [ "$(cat "$cwd_capture")" = "$expected_cwd" ]
+  grep -qx -- "--append-system-prompt" "$argv_capture"
+  grep -qx -- "$prompt" "$argv_capture"
+  grep -qx -- "--model" "$argv_capture"
+  [ "$(awk '/^--model$/ { getline; print; exit }' "$argv_capture")" = "openai-codex/gpt-5.5" ]
+  grep -qx -- "--session" "$argv_capture"
+  [ "$(awk '/^--session$/ { getline; print; exit }' "$argv_capture")" = "$session_file" ]
+
+  ! grep -qx -- "-p" "$argv_capture"
+  ! grep -qx -- "--print" "$argv_capture"
+  ! grep -qx -- "--no-extensions" "$argv_capture"
+  ! grep -qx -- "--no-skills" "$argv_capture"
+  ! grep -qx -- "--no-prompt-templates" "$argv_capture"
+  ! grep -qx '' "$argv_capture"
+}
+
+@test "run interactive without message scrubs stale harness environment" {
+  local mise_data="${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}"
+  local stale_bin="$mise_data/installs/sessions-test-stale/bin"
+  local fresh_bin="$mise_data/installs/sessions-test-fresh/bin"
+  local shim_bin="$mise_data/shims"
+  local pi_bin="$BATS_TEST_TMPDIR/pi-bin"
+  local env_capture="$BATS_TEST_TMPDIR/pi-env"
+  stub_pi_capture_env "$pi_bin" "$env_capture"
+
+  local prompt="$BATS_TEST_TMPDIR/prompt.md"
+  echo "test prompt" > "$prompt"
+
+  export CALLER_PWD="/stale/caller"
+  export SESSIONS_CALLER_PWD="/stale/sessions"
+  export OTHER_CALLER_PWD="/stale/other"
+
+  PATH="$stale_bin:$pi_bin:$shim_bin:$fresh_bin:$PATH" run sessions run \
+    --system-prompt-file "$prompt" \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5"
+  [ "$status" -eq 0 ]
+  [ -f "$env_capture" ]
+
+  grep -q '^CALLER_PWD=$' "$env_capture"
+  grep -q '^SESSIONS_CALLER_PWD=$' "$env_capture"
+  grep -q '^OTHER_CALLER_PWD=$' "$env_capture"
+  grep -q "$shim_bin" "$env_capture"
+  grep -q "$pi_bin" "$env_capture"
+  ! grep -q "$stale_bin" "$env_capture"
+  ! grep -q "$fresh_bin" "$env_capture"
+}
+
+@test "run --headless requires a message" {
+  local prompt="$BATS_TEST_TMPDIR/prompt.md"
+  echo "test prompt" > "$prompt"
+
+  run sessions run --headless --system-prompt-file "$prompt" --model "openai-codex/gpt-5.5"
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q -- "--headless requires a message"
+}

--- a/test/run.bats
+++ b/test/run.bats
@@ -27,6 +27,9 @@ teardown() {
   local session_file
   session_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
 
+  export usage_message="stale inherited message"
+  export usage_headless=true
+
   PATH="$stub_dir:$PATH" run sessions run \
     --system-prompt-file "$prompt" \
     --cwd "$run_cwd" \

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -7,6 +7,16 @@ setup() {
   # Isolate zmx sessions per-test to prevent bats FD hangs.
   export ZMX_DIR="/tmp/swk-$$"
   mkdir -p "$ZMX_DIR"
+
+  # Most wake tests care about the argv passed to shell, not about opening
+  # a real persistent zmx + pi process. Default to a recording shell stub;
+  # individual tests that need a different shell behavior prepend their own.
+  local shell_stub_dir="$BATS_TEST_TMPDIR/default-shell-stub"
+  stub_shell_recording \
+    "$shell_stub_dir" \
+    "$BATS_TEST_TMPDIR/default-shell-argv" \
+    "$BATS_TEST_TMPDIR/default-shell-names"
+  export PATH="$shell_stub_dir:$PATH"
 }
 teardown() {
   # Clean up shell sessions in our isolated dir
@@ -214,7 +224,7 @@ STUB
 
 @test "wake --headless records harness=pi and headless=true" {
   command -v shell >/dev/null 2>&1 || skip "shell not installed"
-  run sessions wake "$SESSION_1" --headless --background --model "openai-codex/gpt-5.5"
+  run sessions wake "$SESSION_1" --headless --background --model "openai-codex/gpt-5.5" --message "review this"
   [ "$status" -eq 0 ]
   src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
   jq -e 'select(.type == "wake" and .harness == "pi" and .headless == true)' "$src_file"
@@ -528,6 +538,85 @@ STUB
     after_session && /^--cwd$/ { getline; print; exit }
   ' "$capture")
   [ "$run_cwd" = "$expected_cwd" ]
+}
+
+@test "wake --headless requires --message before recording wake" {
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  local before
+  before=$(wc -l < "$src_file")
+
+  run sessions wake "$SESSION_1" --headless --model "openai-codex/gpt-5.5"
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q -- "--headless requires --message"
+
+  local after
+  after=$(wc -l < "$src_file")
+  [ "$after" = "$before" ]
+}
+
+@test "wake interactive without --message records no synthetic message" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-shell-no-message"
+  local capture="$BATS_TEST_TMPDIR/shell-argv-no-message"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/shell" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/shell"
+
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  local before_messages
+  before_messages=$(jq -s '[.[] | select(.type == "message")] | length' "$src_file")
+
+  PATH="$stub_dir:$PATH" run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5"
+  [ "$status" -eq 0 ]
+  [ -f "$capture" ]
+
+  local after_messages
+  after_messages=$(jq -s '[.[] | select(.type == "message")] | length' "$src_file")
+  [ "$after_messages" = "$before_messages" ]
+  jq -e 'select(.type == "wake" and .headless == false)' "$src_file"
+
+  [ "$(tail -1 "$capture")" = "openai-codex/gpt-5.5" ]
+  ! grep -qx '' "$capture"
+}
+
+@test "wake interactive without --message executes nested run without print mode" {
+  local session_cwd="$BATS_TEST_TMPDIR/wake-session-cwd"
+  local expected_cwd
+  mkdir -p "$session_cwd"
+  expected_cwd=$(cd "$session_cwd" && pwd -P)
+
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  local updated_file="$BATS_TEST_TMPDIR/session-cwd-for-nested-run.jsonl"
+  jq -c --arg cwd "$session_cwd" 'if .type == "session" then .cwd = $cwd else . end' "$src_file" > "$updated_file"
+  mv "$updated_file" "$src_file"
+
+  local stub_dir="$BATS_TEST_TMPDIR/stub-shell-pi-no-message"
+  local shell_capture="$BATS_TEST_TMPDIR/shell-argv-nested-no-message"
+  local pi_argv_capture="$BATS_TEST_TMPDIR/pi-argv-nested-no-message"
+  local pi_cwd_capture="$BATS_TEST_TMPDIR/pi-cwd-nested-no-message"
+  stub_shell_exec_payload "$stub_dir" "$shell_capture"
+  stub_pi_capture_argv_cwd "$stub_dir" "$pi_argv_capture" "$pi_cwd_capture"
+
+  export AGENT_IDENTITY="test identity"
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai-codex/gpt-5.5"
+  [ "$status" -eq 0 ]
+  [ -f "$shell_capture" ]
+  [ -f "$pi_argv_capture" ]
+  [ -f "$pi_cwd_capture" ]
+
+  [ "$(cat "$pi_cwd_capture")" = "$expected_cwd" ]
+  grep -qx -- "--append-system-prompt" "$pi_argv_capture"
+  grep -qx -- "--model" "$pi_argv_capture"
+  [ "$(awk '/^--model$/ { getline; print; exit }' "$pi_argv_capture")" = "openai-codex/gpt-5.5" ]
+  grep -qx -- "--session" "$pi_argv_capture"
+  [ "$(awk '/^--session$/ { getline; print; exit }' "$pi_argv_capture")" = "$src_file" ]
+
+  ! grep -qx -- "-p" "$pi_argv_capture"
+  ! grep -qx -- "--print" "$pi_argv_capture"
+  ! grep -qx '' "$pi_argv_capture"
 }
 
 @test "wake --model is advertised in --help" {

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -554,6 +554,21 @@ STUB
   [ "$after" = "$before" ]
 }
 
+@test "wake interactive without --message rejects unsupported harness before recording wake" {
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  local before
+  before=$(wc -l < "$src_file" | tr -d ' ')
+  echo '{"type":"harness","id":"h-claude","parentId":"u4","timestamp":"2026-03-14T10:31:00.000Z","name":"claude"}' >> "$src_file"
+
+  run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5"
+  [ "$status" -eq 10 ]
+  echo "$output" | grep -q -- "claude.*does not support interactive no-message wake"
+
+  local after
+  after=$(wc -l < "$src_file" | tr -d ' ')
+  [ "$after" = "$((before + 1))" ]
+}
+
 @test "wake interactive without --message records no synthetic message" {
   local stub_dir="$BATS_TEST_TMPDIR/stub-shell-no-message"
   local capture="$BATS_TEST_TMPDIR/shell-argv-no-message"
@@ -569,6 +584,9 @@ STUB
   local before_messages
   before_messages=$(jq -s '[.[] | select(.type == "message")] | length' "$src_file")
 
+  export usage_message="stale inherited message"
+  export usage_headless=true
+
   PATH="$stub_dir:$PATH" run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   [ -f "$capture" ]
@@ -579,6 +597,8 @@ STUB
   jq -e 'select(.type == "wake" and .headless == false)' "$src_file"
 
   [ "$(tail -1 "$capture")" = "openai-codex/gpt-5.5" ]
+  ! grep -qx 'stale inherited message' "$capture"
+  ! grep -qx -- '--headless' "$capture"
   ! grep -qx '' "$capture"
 }
 


### PR DESCRIPTION
## Summary

Closes #88.

Allows interactive `sessions wake` / `sessions run` to omit an initial message so launchers can open the harness and let the human start the conversation. `--headless` still requires a message.

## Changes

- `sessions wake`: reject `--headless` without `--message` before recording a wake event.
- `sessions run`: when no message is provided in interactive mode, exec `pi` directly without `-p` / print mode and without a synthetic message.
- Add `lib/harness-env.sh` so direct interactive launches get the same caller-cwd and stale mise-install PATH cleanup expected at harness boundaries.
- Stub `shell`/`pi` in wake/run tests so no-message interactive coverage does not spawn real zmx/pi processes.
- Update README generated test counts.

## Verification

- `MISE_TASK_RUN_AUTO_INSTALL=false mise run test` — 238/238 BATS passing
- `cd cli && mix test` — 121 tests + 4 doctests passing
- `CALLER_PWD=$PWD readme build --check`
- `codebase lint:shellcheck "$PWD"`
- `codebase lint:bats-test-helper "$PWD"`
- `codebase lint:bats-test-task "$PWD"`
- `codebase lint:mcr-scope "$PWD"`
- `codebase lint:or-true "$PWD"`
- `codebase lint:mise-settings "$PWD"`
- `git diff --check`

Note: plain `mise run test` attempted to auto-install a missing `shiv:shell@0.1.0` and hit unauthenticated GitHub API rate limits; verification was run with mise task auto-install disabled against the existing toolchain.
