### PR TITLE
Fix unsupported no-message wake recording

### DIFF
--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -99,6 +99,11 @@ HARNESS_NAME=$(harness_resolve --session "$SESSION_FILE") || exit 1
 # shellcheck source=/dev/null
 source "$MISE_CONFIG_ROOT/lib/harness/$HARNESS_NAME.sh"
 
+if [ -z "$MESSAGE" ] && [ "$HARNESS_NAME" != "pi" ]; then
+  echo "sessions: '$HARNESS_NAME' harness does not support interactive no-message wake yet" >&2
+  exit "$HARNESS_UNSUPPORTED_EXIT"
+fi
+
 FULL_SESSION_ID=$(head -1 "$SESSION_FILE" | jq -r '.id // empty')
 if [ -z "$FULL_SESSION_ID" ]; then
   FULL_SESSION_ID="$SESSION_ID"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 238 passing](https://img.shields.io/badge/tests-238%20passing-brightgreen?style=flat)](test/)
+[![tests: 239 passing](https://img.shields.io/badge/tests-239%20passing-brightgreen?style=flat)](test/)
 ![commands: 14](https://img.shields.io/badge/commands-14-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -177,7 +177,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**238 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
+**239 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -207,7 +207,7 @@ sessions/
 │   ├── shell.sh        # Shell helpers
 │   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats          # 238 tests
+    └── *.bats          # 239 tests
 ```
 
 </details>

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -554,6 +554,21 @@ STUB
   [ "$after" = "$before" ]
 }
 
+@test "wake interactive without --message rejects unsupported harness before recording wake" {
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  local before
+  before=$(wc -l < "$src_file")
+  echo '{"type":"harness","id":"h-claude","parentId":"u4","timestamp":"2026-03-14T10:31:00.000Z","name":"claude"}' >> "$src_file"
+
+  run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5"
+  [ "$status" -eq 10 ]
+  echo "$output" | grep -q -- "claude.*does not support interactive no-message wake"
+
+  local after
+  after=$(wc -l < "$src_file")
+  [ "$after" = "$((before + 1))" ]
+}
+
 @test "wake interactive without --message records no synthetic message" {
   local stub_dir="$BATS_TEST_TMPDIR/stub-shell-no-message"
   local capture="$BATS_TEST_TMPDIR/shell-argv-no-message"


### PR DESCRIPTION
## Summary
- reject interactive no-message wakes for unsupported harnesses before appending a wake entry
- add a regression test using a claude-declared session
- update README test counts to 239

## Test
- env -u usage_* mise run test