### PR TITLE
Fix stale mise usage env in wake/run no-message paths

### DIFF
--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -14,17 +14,92 @@
 
 set -euo pipefail
 
-MESSAGE="${usage_message:-}"
-SYSTEM_PROMPT_FILE="${usage_system_prompt_file:-}"
-TIMEOUT="${usage_timeout:-}"
-MODEL="${usage_model:-}"
-SESSION="${usage_session:-}"
-CWD="${usage_cwd:-${SESSIONS_CALLER_PWD:-${CALLER_PWD:-.}}}"
-HEADLESS="${usage_headless:-false}"
+MESSAGE=""
+SYSTEM_PROMPT_FILE=""
+TIMEOUT=""
+MODEL=""
+SESSION=""
+CWD="${SESSIONS_CALLER_PWD:-${CALLER_PWD:-.}}"
+HEADLESS="false"
 # Extensions disabled by default (determinism for CI). Pass --extensions etc. to enable.
-EXTENSIONS="${usage_extensions:-false}"
-SKILLS="${usage_skills:-false}"
-PROMPT_TEMPLATES="${usage_prompt_templates:-false}"
+EXTENSIONS="false"
+SKILLS="false"
+PROMPT_TEMPLATES="false"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --system-prompt-file)
+      SYSTEM_PROMPT_FILE="${2:-}"
+      shift 2
+      ;;
+    --system-prompt-file=*)
+      SYSTEM_PROMPT_FILE="${1#*=}"
+      shift
+      ;;
+    --timeout)
+      TIMEOUT="${2:-}"
+      shift 2
+      ;;
+    --timeout=*)
+      TIMEOUT="${1#*=}"
+      shift
+      ;;
+    --model)
+      MODEL="${2:-}"
+      shift 2
+      ;;
+    --model=*)
+      MODEL="${1#*=}"
+      shift
+      ;;
+    --session)
+      SESSION="${2:-}"
+      shift 2
+      ;;
+    --session=*)
+      SESSION="${1#*=}"
+      shift
+      ;;
+    --cwd)
+      CWD="${2:-}"
+      shift 2
+      ;;
+    --cwd=*)
+      CWD="${1#*=}"
+      shift
+      ;;
+    --headless)
+      HEADLESS="true"
+      shift
+      ;;
+    --extensions)
+      EXTENSIONS="true"
+      shift
+      ;;
+    --skills)
+      SKILLS="true"
+      shift
+      ;;
+    --prompt-templates)
+      PROMPT_TEMPLATES="true"
+      shift
+      ;;
+    --)
+      shift
+      if [ "$#" -gt 0 ]; then
+        MESSAGE="$1"
+      fi
+      break
+      ;;
+    --*)
+      shift
+      ;;
+    *)
+      MESSAGE="$1"
+      shift
+      ;;
+  esac
+done
 
 # shellcheck source=../../lib/harness-env.sh
 source "$MISE_CONFIG_ROOT/lib/harness-env.sh"

--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -12,15 +12,97 @@
 
 set -euo pipefail
 
-SESSION_ID="${usage_session_id:-}"
-CONTEXT="${usage_context:-}"
-WAKE_META_RAW="${usage_meta:-}"
-CONTEXT_FILE="${usage_context_file:-}"
-MESSAGE="${usage_message:-}"
-MODEL="${usage_model:-}"
-OS_USER="${usage_os_user:-}"
-HEADLESS="${usage_headless:-false}"
-BACKGROUND="${usage_background:-false}"
+SESSION_ID=""
+CONTEXT=""
+WAKE_META_RAW=""
+CONTEXT_FILE=""
+MESSAGE=""
+MODEL=""
+OS_USER=""
+HEADLESS="false"
+BACKGROUND="false"
+WAKE_META_VALUES=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --context)
+      CONTEXT="${2:-}"
+      shift 2
+      ;;
+    --context=*)
+      CONTEXT="${1#*=}"
+      shift
+      ;;
+    --context-file)
+      CONTEXT_FILE="${2:-}"
+      shift 2
+      ;;
+    --context-file=*)
+      CONTEXT_FILE="${1#*=}"
+      shift
+      ;;
+    --message)
+      MESSAGE="${2:-}"
+      shift 2
+      ;;
+    --message=*)
+      MESSAGE="${1#*=}"
+      shift
+      ;;
+    --model)
+      MODEL="${2:-}"
+      shift 2
+      ;;
+    --model=*)
+      MODEL="${1#*=}"
+      shift
+      ;;
+    --os-user)
+      OS_USER="${2:-}"
+      shift 2
+      ;;
+    --os-user=*)
+      OS_USER="${1#*=}"
+      shift
+      ;;
+    --meta)
+      WAKE_META_VALUES+=("${2:-}")
+      shift 2
+      ;;
+    --meta=*)
+      WAKE_META_VALUES+=("${1#*=}")
+      shift
+      ;;
+    --headless)
+      HEADLESS="true"
+      shift
+      ;;
+    --background)
+      BACKGROUND="true"
+      shift
+      ;;
+    --)
+      shift
+      if [ "$#" -gt 0 ] && [ -z "$SESSION_ID" ]; then
+        SESSION_ID="$1"
+      fi
+      break
+      ;;
+    --*)
+      shift
+      ;;
+    *)
+      if [ -z "$SESSION_ID" ]; then
+        SESSION_ID="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ "${#WAKE_META_VALUES[@]}" -gt 0 ]; then
+  WAKE_META_RAW=$(printf '%s\n' "${WAKE_META_VALUES[@]}")
+fi
 
 scrub_caller_pwd_env() {
   local name

--- a/test/run.bats
+++ b/test/run.bats
@@ -27,6 +27,9 @@ teardown() {
   local session_file
   session_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
 
+  export usage_message="stale inherited message"
+  export usage_headless=true
+
   PATH="$stub_dir:$PATH" run sessions run \
     --system-prompt-file "$prompt" \
     --cwd "$run_cwd" \

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -569,6 +569,9 @@ STUB
   local before_messages
   before_messages=$(jq -s '[.[] | select(.type == "message")] | length' "$src_file")
 
+  export usage_message="stale inherited message"
+  export usage_headless=true
+
   PATH="$stub_dir:$PATH" run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   [ -f "$capture" ]
@@ -579,6 +582,8 @@ STUB
   jq -e 'select(.type == "wake" and .headless == false)' "$src_file"
 
   [ "$(tail -1 "$capture")" = "openai-codex/gpt-5.5" ]
+  ! grep -qx 'stale inherited message' "$capture"
+  ! grep -qx -- '--headless' "$capture"
   ! grep -qx '' "$capture"
 }
 


### PR DESCRIPTION
Fix-it for PR #89.

The no-message paths were still reading ambient `usage_*` variables produced by the parent sessions wake/run invocation. In an agent-dispatched environment, `sessions run` without a message could inherit the dispatch message plus `usage_headless=true`, so it entered pi print mode instead of interactive mode.

Changes:
- Parse wake/run arguments from the actual task argv instead of inherited `usage_*` env.
- Add regression coverage with stale `usage_message` / `usage_headless` exported.

Verified:
- `bats test/run.bats test/wake.bats`
- `env $(env | awk -F= '/^usage_/ {print "-u", $1}') mise run test`
