### PR TITLE
sessions: bake system prompts at creation

### DIFF
--- a/.mise/tasks/new
+++ b/.mise/tasks/new
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
-#MISE description="Create a new session with optional injected context"
-#USAGE arg "[name]" help="Session name (human-readable label, also used for lookup)"
-#USAGE flag "--cwd <cwd>" help="Working directory for the session (default: current directory)"
-#USAGE flag "--context <context>" help="Initial context message to inject"
-#USAGE flag "--context-file <context_file>" help="File containing initial context message"
-#USAGE flag "--meta <meta>" var=#true help="Metadata key=value pairs (repeatable, supports dotted paths e.g. agent.name=ikma)"
-#USAGE flag "--harness <harness>" help="Harness adapter to use (default: pi, or value of SESSIONS_DEFAULT_HARNESS)"
+#MISE description="Create a new session with optional system prompt and injected context"
+#USAGE arg "[name]" default="" help="Session name (human-readable label, also used for lookup)"
+#USAGE flag "--cwd <cwd>" default="" help="Working directory for the session (default: current directory)"
+#USAGE flag "--system-prompt <prompt>" default="" help="System prompt content to bake into the session"
+#USAGE flag "--system-prompt-file <file>" default="" help="File containing system prompt content to bake into the session"
+#USAGE flag "--context <context>" default="" help="Initial context message to inject"
+#USAGE flag "--context-file <context_file>" default="" help="File containing context message"
+#USAGE flag "--meta <meta>" var=#true default="" help="Metadata key=value pairs (repeatable, supports dotted paths e.g. agent.name=ikma)"
+#USAGE flag "--harness <harness>" default="" help="Harness adapter to use (default: pi, or value of SESSIONS_DEFAULT_HARNESS)"
 
 set -euo pipefail
 
 NAME="${usage_name:-}"
 CWD="${usage_cwd:-}"
+SYSTEM_PROMPT="${usage_system_prompt:-}"
+SYSTEM_PROMPT_FILE="${usage_system_prompt_file:-}"
 CONTEXT="${usage_context:-}"
 CONTEXT_FILE="${usage_context_file:-}"
 META_RAW="${usage_meta:-}"
@@ -27,7 +31,17 @@ CWD_ABS=$(cd "$CWD" 2>/dev/null && pwd) || {
   exit 1
 }
 
-# Resolve context from file if provided
+# Resolve system prompt and context from files if provided. File flags mirror
+# the existing --context-file behavior: when both inline and file forms are
+# supplied, the file content wins.
+if [ -n "$SYSTEM_PROMPT_FILE" ]; then
+  if [ ! -f "$SYSTEM_PROMPT_FILE" ]; then
+    echo "Error: system prompt file not found: $SYSTEM_PROMPT_FILE" >&2
+    exit 1
+  fi
+  SYSTEM_PROMPT=$(cat "$SYSTEM_PROMPT_FILE")
+fi
+
 if [ -n "$CONTEXT_FILE" ]; then
   if [ ! -f "$CONTEXT_FILE" ]; then
     echo "Error: context file not found: $CONTEXT_FILE" >&2
@@ -99,10 +113,20 @@ harness_call "$HARNESS_NAME" header_entry "$SESSION_ID" "$NOW_ISO" "$CWD_ABS" "$
 HARNESS_ENTRY_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
 harness_entry "$HARNESS_ENTRY_ID" "$SESSION_ID" "$NOW_ISO" "$HARNESS_NAME" >> "$SESSION_FILE"
 
+LAST_ENTRY_ID="$HARNESS_ENTRY_ID"
+
+# Bake the system prompt into the session if provided. `sessions wake` does not
+# accept prompt flags; wake/run resolve this entry from the session file.
+if [ -n "$SYSTEM_PROMPT" ]; then
+  PROMPT_ENTRY_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
+  system_prompt_entry "$PROMPT_ENTRY_ID" "$LAST_ENTRY_ID" "$NOW_ISO" "$SYSTEM_PROMPT" >> "$SESSION_FILE"
+  LAST_ENTRY_ID="$PROMPT_ENTRY_ID"
+fi
+
 # Inject context as a user message if provided
 if [ -n "$CONTEXT" ]; then
   MSG_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
-  harness_call "$HARNESS_NAME" user_message_entry "$MSG_ID" "$HARNESS_ENTRY_ID" "$NOW_ISO" "$CONTEXT" >> "$SESSION_FILE"
+  harness_call "$HARNESS_NAME" user_message_entry "$MSG_ID" "$LAST_ENTRY_ID" "$NOW_ISO" "$CONTEXT" >> "$SESSION_FILE"
 fi
 
 # --- Output ---
@@ -114,6 +138,9 @@ else
   echo "Created session ${SESSION_ID:0:8}" >&2
 fi
 echo "cwd: $CWD_ABS" >&2
+if [ -n "$SYSTEM_PROMPT" ]; then
+  echo "System prompt: $(echo "$SYSTEM_PROMPT" | head -1 | cut -c1-80)..." >&2
+fi
 if [ -n "$CONTEXT" ]; then
   echo "Context: $(echo "$CONTEXT" | head -1 | cut -c1-80)..." >&2
 fi

--- a/.mise/tasks/new
+++ b/.mise/tasks/new
@@ -15,6 +15,8 @@ NAME="${usage_name:-}"
 CWD="${usage_cwd:-}"
 SYSTEM_PROMPT="${usage_system_prompt:-}"
 SYSTEM_PROMPT_FILE="${usage_system_prompt_file:-}"
+SYSTEM_PROMPT_PROVIDED=false
+[ -n "$SYSTEM_PROMPT" ] && SYSTEM_PROMPT_PROVIDED=true
 CONTEXT="${usage_context:-}"
 CONTEXT_FILE="${usage_context_file:-}"
 META_RAW="${usage_meta:-}"
@@ -35,6 +37,7 @@ CWD_ABS=$(cd "$CWD" 2>/dev/null && pwd) || {
 # the existing --context-file behavior: when both inline and file forms are
 # supplied, the file content wins.
 if [ -n "$SYSTEM_PROMPT_FILE" ]; then
+  SYSTEM_PROMPT_PROVIDED=true
   if [ ! -f "$SYSTEM_PROMPT_FILE" ]; then
     echo "Error: system prompt file not found: $SYSTEM_PROMPT_FILE" >&2
     exit 1
@@ -117,7 +120,7 @@ LAST_ENTRY_ID="$HARNESS_ENTRY_ID"
 
 # Bake the system prompt into the session if provided. `sessions wake` does not
 # accept prompt flags; wake/run resolve this entry from the session file.
-if [ -n "$SYSTEM_PROMPT" ]; then
+if [ "$SYSTEM_PROMPT_PROVIDED" = "true" ]; then
   PROMPT_ENTRY_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
   system_prompt_entry "$PROMPT_ENTRY_ID" "$LAST_ENTRY_ID" "$NOW_ISO" "$SYSTEM_PROMPT" >> "$SESSION_FILE"
   LAST_ENTRY_ID="$PROMPT_ENTRY_ID"
@@ -138,7 +141,7 @@ else
   echo "Created session ${SESSION_ID:0:8}" >&2
 fi
 echo "cwd: $CWD_ABS" >&2
-if [ -n "$SYSTEM_PROMPT" ]; then
+if [ "$SYSTEM_PROMPT_PROVIDED" = "true" ]; then
   echo "System prompt: $(echo "$SYSTEM_PROMPT" | head -1 | cut -c1-80)..." >&2
 fi
 if [ -n "$CONTEXT" ]; then

--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -29,6 +29,35 @@ PROMPT_TEMPLATES="${usage_prompt_templates:-false}"
 # shellcheck source=../../lib/harness-env.sh
 source "$MISE_CONFIG_ROOT/lib/harness-env.sh"
 
+PROMPT_TEMP_FILE=""
+# shellcheck disable=SC2329  # Invoked by EXIT trap below.
+cleanup_prompt_temp() {
+  if [ -n "$PROMPT_TEMP_FILE" ]; then
+    rm -f "$PROMPT_TEMP_FILE"
+  fi
+}
+trap cleanup_prompt_temp EXIT
+
+latest_session_system_prompt() {
+  local session_file="$1"
+  [ -f "$session_file" ] || return 0
+  jq -s -r '[.[] | select(.type == "system_prompt") | .content] | last // empty' "$session_file"
+}
+
+write_prompt_temp() {
+  PROMPT_TEMP_FILE=$(mktemp)
+  printf '%s\n' "$1" > "$PROMPT_TEMP_FILE"
+  SYSTEM_PROMPT_FILE="$PROMPT_TEMP_FILE"
+}
+
+run_and_exit() {
+  set +e
+  "$@"
+  local rc=$?
+  set -e
+  exit "$rc"
+}
+
 if [ "$HEADLESS" = "true" ] && [ -z "$MESSAGE" ]; then
   echo "Error: --headless requires a message" >&2
   echo "Usage: sessions run --headless --system-prompt-file <path> --model <provider/model> [options] \"message\"" >&2
@@ -46,12 +75,25 @@ if [[ "$MODEL" != */* ]]; then
   exit 1
 fi
 
-# If no system prompt file provided but AGENT_IDENTITY is in env, write it to a temp file
-if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "${AGENT_IDENTITY:-}" ]; then
-  SYSTEM_PROMPT_FILE=$(mktemp)
-  echo "$AGENT_IDENTITY" > "$SYSTEM_PROMPT_FILE"
+# Prompt resolution order:
+#   1. Explicit --system-prompt-file
+#   2. Latest system_prompt entry baked into --session by `sessions new`
+#   3. Legacy AGENT_IDENTITY environment fallback
+if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "$SESSION" ]; then
+  SESSION_SYSTEM_PROMPT=$(latest_session_system_prompt "$SESSION")
+  if [ -n "$SESSION_SYSTEM_PROMPT" ]; then
+    write_prompt_temp "$SESSION_SYSTEM_PROMPT"
+  fi
+  unset SESSION_SYSTEM_PROMPT
+fi
 
-  trap 'rm -f "$SYSTEM_PROMPT_FILE"' EXIT
+if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "${AGENT_IDENTITY:-}" ]; then
+  write_prompt_temp "$AGENT_IDENTITY"
+fi
+
+if [ -z "$SYSTEM_PROMPT_FILE" ]; then
+  echo "Error: system prompt required (--system-prompt-file, session system_prompt, or AGENT_IDENTITY)" >&2
+  exit 1
 fi
 
 # Append dispatch context (outside the conditional — applies to any prompt file)
@@ -74,11 +116,6 @@ HEADLESS_EOF
 fi
 
 run_interactive_without_message() {
-  if [ -z "$SYSTEM_PROMPT_FILE" ]; then
-    echo "Error: --system-prompt-file is required" >&2
-    exit 1
-  fi
-
   if [ ! -f "$SYSTEM_PROMPT_FILE" ]; then
     echo "Error: System prompt file not found: $SYSTEM_PROMPT_FILE" >&2
     exit 1
@@ -119,10 +156,10 @@ run_interactive_without_message() {
       echo "Error: timeout command is required for --timeout" >&2
       exit 1
     fi
-    exec timeout "$TIMEOUT" pi "${pi_args[@]}"
+    run_and_exit timeout "$TIMEOUT" pi "${pi_args[@]}"
   fi
 
-  exec pi "${pi_args[@]}"
+  run_and_exit pi "${pi_args[@]}"
 }
 
 if [ -z "$MESSAGE" ]; then
@@ -149,4 +186,4 @@ source "$MISE_CONFIG_ROOT/lib/ensure-deps.sh"
 ensure_cli_deps "$CLI_DIR"
 
 cd "$CLI_DIR"
-exec mix sessions "${CLI_ARGS[@]}" "$MESSAGE"
+run_and_exit mix sessions "${CLI_ARGS[@]}" "$MESSAGE"

--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -41,8 +41,8 @@ trap cleanup_prompt_temp EXIT
 
 latest_session_system_prompt() {
   local session_file="$1"
-  [ -f "$session_file" ] || return 0
-  jq -s -r '[.[] | select(.type == "system_prompt") | .content] | last // empty' "$session_file"
+  [ -f "$session_file" ] || return 1
+  jq -s -e -r '[.[] | select(.type == "system_prompt") | .content] | if length == 0 then empty else last end' "$session_file"
 }
 
 write_prompt_temp() {
@@ -53,8 +53,37 @@ write_prompt_temp() {
 
 run_and_exit() {
   set +e
-  "$@"
+  (
+    trap - INT TERM HUP QUIT
+    exec "$@"
+  ) <&0 &
+  local child_pid=$!
+
+  # shellcheck disable=SC2329  # Invoked by signal traps below.
+  forward_child_signal() {
+    local sig="$1"
+    local sig_num
+    trap - INT TERM HUP QUIT
+    if ! kill -s "$sig" "$child_pid" 2>/dev/null; then
+      :
+    fi
+    wait "$child_pid"
+    local rc=$?
+    if [ "$rc" -eq 127 ]; then
+      sig_num=$(kill -l "$sig" 2>/dev/null || echo 0)
+      rc=$((128 + sig_num))
+    fi
+    exit "$rc"
+  }
+
+  trap 'forward_child_signal INT' INT
+  trap 'forward_child_signal TERM' TERM
+  trap 'forward_child_signal HUP' HUP
+  trap 'forward_child_signal QUIT' QUIT
+
+  wait "$child_pid"
   local rc=$?
+  trap - INT TERM HUP QUIT
   set -e
   exit "$rc"
 }
@@ -81,8 +110,7 @@ fi
 #   2. Latest system_prompt entry baked into --session by `sessions new`
 #   3. Legacy AGENT_IDENTITY environment fallback
 if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "$SESSION" ]; then
-  SESSION_SYSTEM_PROMPT=$(latest_session_system_prompt "$SESSION")
-  if [ -n "$SESSION_SYSTEM_PROMPT" ]; then
+  if SESSION_SYSTEM_PROMPT=$(latest_session_system_prompt "$SESSION"); then
     write_prompt_temp "$SESSION_SYSTEM_PROMPT"
   fi
   unset SESSION_SYSTEM_PROMPT

--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-#MISE description="Run an agent session with streaming output, timeout, and ABORT detection"
+#MISE description="Internal executor for sessions wake (advanced/compatibility)"
 #MISE quiet=true
+#MISE hide=true
 #USAGE arg "[message]" default="" help="Message for the agent (required for --headless, optional for interactive)"
 #USAGE flag "--system-prompt-file <file>" default="" help="Path to system prompt file"
 #USAGE flag "--timeout <seconds>" default="" help="Timeout in seconds (default: no timeout)"

--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -41,8 +41,28 @@ trap cleanup_prompt_temp EXIT
 
 latest_session_system_prompt() {
   local session_file="$1"
-  [ -f "$session_file" ] || return 1
-  jq -s -e -r '[.[] | select(.type == "system_prompt") | .content] | if length == 0 then empty else last end' "$session_file"
+  local jq_output
+  local jq_status
+
+  if [ ! -f "$session_file" ]; then
+    echo "Error: session file not found: $session_file" >&2
+    return 2
+  fi
+
+  if jq_output=$(jq -s -e -r '[.[] | select(.type == "system_prompt") | .content] | if length == 0 then empty else last end' "$session_file" 2>&1); then
+    printf '%s' "$jq_output"
+    return 0
+  else
+    jq_status=$?
+  fi
+
+  if [ "$jq_status" -eq 4 ]; then
+    return 1
+  fi
+
+  echo "Error: failed to read session system prompt from $session_file" >&2
+  printf '%s\n' "$jq_output" >&2
+  return 2
 }
 
 write_prompt_temp() {
@@ -112,8 +132,13 @@ fi
 if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "$SESSION" ]; then
   if SESSION_SYSTEM_PROMPT=$(latest_session_system_prompt "$SESSION"); then
     write_prompt_temp "$SESSION_SYSTEM_PROMPT"
+  else
+    SESSION_PROMPT_STATUS=$?
+    if [ "$SESSION_PROMPT_STATUS" -ne 1 ]; then
+      exit "$SESSION_PROMPT_STATUS"
+    fi
   fi
-  unset SESSION_SYSTEM_PROMPT
+  unset SESSION_SYSTEM_PROMPT SESSION_PROMPT_STATUS
 fi
 
 if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "${AGENT_IDENTITY:-}" ]; then

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 239 passing](https://img.shields.io/badge/tests-239%20passing-brightgreen?style=flat)](test/)
+[![tests: 247 passing](https://img.shields.io/badge/tests-247%20passing-brightgreen?style=flat)](test/)
 ![commands: 14](https://img.shields.io/badge/commands-14-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
 </div>
 
 ```
-$ sessions new review/pr-50 --cwd ~/agents/ikma/den --meta agent.name=ikma
+$ sessions new review/pr-50 --cwd ~/agents/ikma/den --system-prompt-file /tmp/review-profile.md --meta agent.name=ikma
 e96bd43a
 
 $ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "review PR #50"
@@ -55,7 +55,7 @@ sessions inspect e96bd43a
 Sessions aren't just transcript files agents leave behind — they're managed artifacts with structure. A session starts with `new`, gets woken into with `wake`, and every event is recorded in the JSONL stream.
 
 ```
-  sessions new              create session with metadata + context
+  sessions new              create session with prompt + metadata + context
   sessions wake             wake an agent into it via shell
     └─ shell run            persistent zmx session (caller-owned)
          └─ run-as-user     optional --os-user payload boundary
@@ -68,13 +68,14 @@ Sessions aren't just transcript files agents leave behind — they're managed ar
 Each wake event is a first-class entry in the session file — timestamped, attributed, with its own metadata. A session that's been woken three times has three `wake` entries you can filter on. The full conversation history carries forward, so the agent sees everything that happened before.
 
 ```bash
-# Create a named session with metadata and context
+# Create a named session with a baked system prompt, metadata, and context
 sessions new review/pr-50 --cwd ~/agents/ikma/den \
+  --system-prompt-file /tmp/review-profile.md \
   --meta agent.name=ikma \
   --meta purpose=review \
   --context "Background: this PR refactors the auth module"
 
-# Wake an agent into it (by name). Model is required at wake time.
+# Wake the existing session. Model is required at wake time.
 sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "Review PR #50"
 
 # Watch what it does
@@ -84,7 +85,9 @@ sessions read review/pr-50 --last 5
 sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed the edge case in line 42"
 ```
 
-The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for persistent zmx sessions. `sessions wake` calls `sessions run` directly for execution — identity (AGENT_IDENTITY, etc.) must already be in the environment, typically set upstream via `eval $(shimmer as <agent>)`.
+The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for persistent zmx sessions. `sessions wake` calls `sessions run` as its low-level executor. For normal use, prefer `new` + `wake`: bake identity or profile instructions into the session with `--system-prompt-file` at creation, then wake it with task messages.
+
+`sessions run` still accepts an explicit `--system-prompt-file` and keeps the legacy `AGENT_IDENTITY` fallback, but sessions created with a system prompt no longer need identity in the environment at wake time.
 
 `--model` on `sessions wake` is required and is not remembered across wakes — pass a provider-qualified model (for example `openai-codex/gpt-5.5`) on each wake.
 
@@ -177,7 +180,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**239 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
+**247 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -185,7 +188,7 @@ mise run test
 ```
 sessions/
 ├── .mise/tasks/
-│   ├── new          # Create sessions with metadata + context
+│   ├── new          # Create sessions with prompt + metadata + context
 │   ├── wake         # Wake agents into sessions via shell
 │   ├── meta         # Read session header metadata
 │   ├── list         # List + filter sessions (Rich tables)
@@ -207,7 +210,7 @@ sessions/
 │   ├── shell.sh        # Shell helpers
 │   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats          # 239 tests
+    └── *.bats          # 247 tests
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ sessions read review/pr-50 --last 5
 sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed the edge case in line 42"
 ```
 
-The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for persistent zmx sessions. `sessions wake` calls `sessions run` as its low-level executor. For normal use, prefer `new` + `wake`: bake identity or profile instructions into the session with `--system-prompt-file` at creation, then wake it with task messages.
+The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for persistent zmx sessions. `sessions wake` calls `sessions run` as its hidden low-level executor. For normal use, prefer `new` + `wake`: bake identity or profile instructions into the session with `--system-prompt-file` at creation, then wake it with task messages.
 
-`sessions run` still accepts an explicit `--system-prompt-file` and keeps the legacy `AGENT_IDENTITY` fallback, but sessions created with a system prompt no longer need identity in the environment at wake time.
+`sessions run` remains available as an advanced/compatibility command. It accepts an explicit `--system-prompt-file` and keeps the legacy `AGENT_IDENTITY` fallback, but sessions created with a system prompt no longer need identity in the environment at wake time.
 
 `--model` on `sessions wake` is required and is not remembered across wakes — pass a provider-qualified model (for example `openai-codex/gpt-5.5`) on each wake.
 
@@ -197,7 +197,7 @@ sessions/
 │   ├── inspect      # Forensic metadata (duration, tools, model)
 │   ├── copy         # Duplicate sessions for handoff
 │   ├── remove       # Remove sessions (kill shell + delete file)
-│   ├── run          # Execute agent sessions (wraps Elixir CLI)
+│   ├── run          # Hidden low-level executor used by wake
 │   ├── cli/build    # Build Elixir CLI dependencies
 │   ├── export       # Portable bundles (JSONL + metadata)
 │   └── import       # Import exported sessions

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 251 passing](https://img.shields.io/badge/tests-251%20passing-brightgreen?style=flat)](test/)
+[![tests: 252 passing](https://img.shields.io/badge/tests-252%20passing-brightgreen?style=flat)](test/)
 ![commands: 14](https://img.shields.io/badge/commands-14-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -180,7 +180,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**251 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
+**252 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -210,7 +210,7 @@ sessions/
 │   ├── shell.sh        # Shell helpers
 │   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats          # 251 tests
+    └── *.bats          # 252 tests
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 247 passing](https://img.shields.io/badge/tests-247%20passing-brightgreen?style=flat)](test/)
+[![tests: 251 passing](https://img.shields.io/badge/tests-251%20passing-brightgreen?style=flat)](test/)
 ![commands: 14](https://img.shields.io/badge/commands-14-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -180,7 +180,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**247 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
+**251 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -210,7 +210,7 @@ sessions/
 │   ├── shell.sh        # Shell helpers
 │   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats          # 247 tests
+    └── *.bats          # 251 tests
 ```
 
 </details>

--- a/README.tsx
+++ b/README.tsx
@@ -46,7 +46,7 @@ const libLines = libFiles.reduce(
 // ── Visual hook ──────────────────────────────────────────────
 
 const lifecycle = [
-  "$ sessions new review/pr-50 --cwd ~/agents/ikma/den --meta agent.name=ikma",
+  "$ sessions new review/pr-50 --cwd ~/agents/ikma/den --system-prompt-file /tmp/review-profile.md --meta agent.name=ikma",
   "e96bd43a",
   "",
   "$ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message \"review PR #50\"",
@@ -63,7 +63,7 @@ const lifecycle = [
 // ── Spawning stack ───────────────────────────────────────────
 
 const stack = [
-  "  sessions new              create session with metadata + context",
+  "  sessions new              create session with prompt + metadata + context",
   "  sessions wake             wake an agent into it via shell",
   "    └─ shell run            persistent zmx session (caller-owned)",
   "         └─ run-as-user     optional --os-user payload boundary",
@@ -156,13 +156,14 @@ sessions inspect e96bd43a`}</CodeBlock>
         {" entries you can filter on. The full conversation history carries forward, so the agent sees everything that happened before."}
       </Paragraph>
 
-      <CodeBlock lang="bash">{`# Create a named session with metadata and context
+      <CodeBlock lang="bash">{`# Create a named session with a baked system prompt, metadata, and context
 sessions new review/pr-50 --cwd ~/agents/ikma/den \\
+  --system-prompt-file /tmp/review-profile.md \\
   --meta agent.name=ikma \\
   --meta purpose=review \\
   --context "Background: this PR refactors the auth module"
 
-# Wake an agent into it (by name). Model is required at wake time.
+# Wake the existing session. Model is required at wake time.
 sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "Review PR #50"
 
 # Watch what it does
@@ -178,9 +179,22 @@ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed th
         <Code>sessions wake</Code>
         {" calls "}
         <Code>sessions run</Code>
-        {" directly for execution \u2014 identity (AGENT_IDENTITY, etc.) must already be in the environment, typically set upstream via "}
-        <Code>{"eval $(shimmer as <agent>)"}</Code>
-        {"."}
+        {" as its low-level executor. For normal use, prefer "}
+        <Code>new</Code>
+        {" + "}
+        <Code>wake</Code>
+        {": bake identity or profile instructions into the session with "}
+        <Code>--system-prompt-file</Code>
+        {" at creation, then wake it with task messages."}
+      </Paragraph>
+
+      <Paragraph>
+        <Code>sessions run</Code>
+        {" still accepts an explicit "}
+        <Code>--system-prompt-file</Code>
+        {" and keeps the legacy "}
+        <Code>AGENT_IDENTITY</Code>
+        {" fallback, but sessions created with a system prompt no longer need identity in the environment at wake time."}
       </Paragraph>
 
       <Paragraph>
@@ -308,7 +322,7 @@ mise run test`}</CodeBlock>
       <Details summary="Project structure">
         <CodeBlock>{`sessions/
 ├── .mise/tasks/
-│   ├── new          # Create sessions with metadata + context
+│   ├── new          # Create sessions with prompt + metadata + context
 │   ├── wake         # Wake agents into sessions via shell
 │   ├── meta         # Read session header metadata
 │   ├── list         # List + filter sessions (Rich tables)

--- a/README.tsx
+++ b/README.tsx
@@ -179,7 +179,7 @@ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed th
         <Code>sessions wake</Code>
         {" calls "}
         <Code>sessions run</Code>
-        {" as its low-level executor. For normal use, prefer "}
+        {" as its hidden low-level executor. For normal use, prefer "}
         <Code>new</Code>
         {" + "}
         <Code>wake</Code>
@@ -190,7 +190,7 @@ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed th
 
       <Paragraph>
         <Code>sessions run</Code>
-        {" still accepts an explicit "}
+        {" remains available as an advanced/compatibility command. It accepts an explicit "}
         <Code>--system-prompt-file</Code>
         {" and keeps the legacy "}
         <Code>AGENT_IDENTITY</Code>
@@ -331,7 +331,7 @@ mise run test`}</CodeBlock>
 │   ├── inspect      # Forensic metadata (duration, tools, model)
 │   ├── copy         # Duplicate sessions for handoff
 │   ├── remove       # Remove sessions (kill shell + delete file)
-│   ├── run          # Execute agent sessions (wraps Elixir CLI)
+│   ├── run          # Hidden low-level executor used by wake
 │   ├── cli/build    # Build Elixir CLI dependencies
 │   ├── export       # Portable bundles (JSONL + metadata)
 │   └── import       # Import exported sessions

--- a/lib/harness/dispatch.sh
+++ b/lib/harness/dispatch.sh
@@ -235,6 +235,31 @@ harness_entry() {
     }'
 }
 
+# Session system-prompt entry — records the prompt baked into this managed
+# session. Harness binaries ignore this entry type; `sessions run --session`
+# resolves the latest one when no explicit `--system-prompt-file` is supplied.
+#
+#   $1 entry_id, $2 parent_id, $3 timestamp_iso, $4 content
+system_prompt_entry() {
+  local entry_id="$1"
+  local parent_id="$2"
+  local ts="$3"
+  local content="$4"
+
+  jq -nc \
+    --arg id "$entry_id" \
+    --arg parent_id "$parent_id" \
+    --arg ts "$ts" \
+    --arg content "$content" \
+    '{
+      type: "system_prompt",
+      id: $id,
+      parentId: $parent_id,
+      timestamp: $ts,
+      content: $content
+    }'
+}
+
 # Wake event entry — records that an agent was woken into a session.
 # Shape is uniform across harnesses: the harness binaries don't read
 # this entry type; we own the schema.

--- a/mise.toml
+++ b/mise.toml
@@ -13,6 +13,7 @@ usage = "latest"
 uv = "latest"
 bats = "1.13.0"
 "shiv:codebase" = "0.2.0"                  # Codebase linting + migrations
+"shiv:readme" = "0.1"                      # README generation/checks
 "shiv:shell" = "0.1.0"                     # Persistent terminal sessions (used by wake)
 erlang = "28.4.1"
 elixir = "1.19.5-otp-27"

--- a/test/new.bats
+++ b/test/new.bats
@@ -139,6 +139,16 @@ EOF
   jq -r 'select(.type == "system_prompt") | .content' "$new_file" | grep -q "Keep output concise"
 }
 
+@test "new --system-prompt-file stores empty file as an explicit baked prompt" {
+  : > "$BATS_TEST_TMPDIR/empty-prompt.md"
+
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt-file "$BATS_TEST_TMPDIR/empty-prompt.md"
+  [ "$status" -eq 0 ]
+  new_id=$(echo "$output" | head -1)
+  new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
+  jq -e 'select(.type == "system_prompt" and .content == "")' "$new_file"
+}
+
 @test "new errors with nonexistent system prompt file" {
   run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt-file "/tmp/nonexistent-$$"
   [ "$status" -eq 1 ]

--- a/test/new.bats
+++ b/test/new.bats
@@ -118,6 +118,42 @@ teardown() { teardown_test_sessions; }
   ! jq -e 'select(.type == "model_change")' "$new_file"
 }
 
+@test "new --system-prompt stores baked system prompt entry" {
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt "You are a stateless drone"
+  [ "$status" -eq 0 ]
+  new_id=$(echo "$output" | head -1)
+  new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
+  sed -n '3p' "$new_file" | jq -e '.type == "system_prompt" and .content == "You are a stateless drone"'
+}
+
+@test "new --system-prompt-file stores file content" {
+  cat > "$BATS_TEST_TMPDIR/prompt.md" <<'EOF'
+You are a profile-backed worker.
+Keep output concise.
+EOF
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt-file "$BATS_TEST_TMPDIR/prompt.md"
+  [ "$status" -eq 0 ]
+  new_id=$(echo "$output" | head -1)
+  new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
+  jq -r 'select(.type == "system_prompt") | .content' "$new_file" | grep -q "profile-backed worker"
+  jq -r 'select(.type == "system_prompt") | .content' "$new_file" | grep -q "Keep output concise"
+}
+
+@test "new errors with nonexistent system prompt file" {
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt-file "/tmp/nonexistent-$$"
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "system prompt file not found"
+}
+
+@test "new with system prompt and context links context after prompt" {
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt "system" --context "context"
+  [ "$status" -eq 0 ]
+  new_id=$(echo "$output" | head -1)
+  new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
+  prompt_id=$(jq -r 'select(.type == "system_prompt") | .id' "$new_file")
+  jq -e --arg prompt_id "$prompt_id" 'select(.type == "message") | .parentId == $prompt_id' "$new_file"
+}
+
 @test "new rejects --model" {
   run sessions new --cwd "$BATS_TEST_TMPDIR" --model "openai-codex/gpt-5.5"
   [ "$status" -ne 0 ]

--- a/test/run.bats
+++ b/test/run.bats
@@ -55,6 +55,133 @@ teardown() {
   ! grep -qx '' "$argv_capture"
 }
 
+@test "run interactive without message uses baked session system prompt" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-baked-prompt"
+  local argv_capture="$BATS_TEST_TMPDIR/pi-argv-baked-prompt"
+  local prompt_capture="$BATS_TEST_TMPDIR/pi-prompt-baked-prompt"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/pi" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$@" > "$argv_capture"
+prompt_file=""
+while [ "\$#" -gt 0 ]; do
+  if [ "\$1" = "--append-system-prompt" ]; then
+    prompt_file="\$2"
+    break
+  fi
+  shift
+done
+[ -n "\$prompt_file" ]
+cat "\$prompt_file" > "$prompt_capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/pi"
+
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt "baked prompt from session"
+  [ "$status" -eq 0 ]
+  new_id=$(echo "$output" | head -1)
+  session_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
+
+  unset AGENT_IDENTITY
+  PATH="$stub_dir:$PATH" run sessions run \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5" \
+    --session "$session_file"
+  [ "$status" -eq 0 ]
+  [ -f "$argv_capture" ]
+  [ -f "$prompt_capture" ]
+
+  grep -qx -- "--append-system-prompt" "$argv_capture"
+  grep -q "baked prompt from session" "$prompt_capture"
+  prompt_path=$(awk '/^--append-system-prompt$/ { getline; print; exit }' "$argv_capture")
+  [ -n "$prompt_path" ]
+  [ ! -e "$prompt_path" ]
+}
+
+@test "run headless with message uses baked session system prompt" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-mix-baked-prompt"
+  local argv_capture="$BATS_TEST_TMPDIR/mix-argv-baked-prompt"
+  local prompt_capture="$BATS_TEST_TMPDIR/mix-prompt-baked-prompt"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/mix" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$@" > "$argv_capture"
+prompt_file=""
+while [ "\$#" -gt 0 ]; do
+  if [ "\$1" = "--system-prompt-file" ]; then
+    prompt_file="\$2"
+    break
+  fi
+  shift
+done
+[ -n "\$prompt_file" ]
+cat "\$prompt_file" > "$prompt_capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/mix"
+
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt "headless baked prompt"
+  [ "$status" -eq 0 ]
+  new_id=$(echo "$output" | head -1)
+  session_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
+
+  unset AGENT_IDENTITY
+  PATH="$stub_dir:$PATH" run sessions run \
+    --headless \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5" \
+    --session "$session_file" \
+    "do work"
+  [ "$status" -eq 0 ]
+  [ -f "$argv_capture" ]
+  [ -f "$prompt_capture" ]
+
+  grep -q "headless baked prompt" "$prompt_capture"
+  grep -q "This is a headless session" "$prompt_capture"
+  prompt_path=$(awk '/^--system-prompt-file$/ { getline; print; exit }' "$argv_capture")
+  [ -n "$prompt_path" ]
+  [ ! -e "$prompt_path" ]
+}
+
+@test "run interactive without message prefers explicit prompt file over baked prompt" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-explicit-prompt"
+  local prompt_capture="$BATS_TEST_TMPDIR/pi-prompt-explicit-prompt"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/pi" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+prompt_file=""
+while [ "\$#" -gt 0 ]; do
+  if [ "\$1" = "--append-system-prompt" ]; then
+    prompt_file="\$2"
+    break
+  fi
+  shift
+done
+[ -n "\$prompt_file" ]
+cat "\$prompt_file" > "$prompt_capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/pi"
+
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt "baked prompt"
+  [ "$status" -eq 0 ]
+  new_id=$(echo "$output" | head -1)
+  session_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
+  echo "explicit prompt" > "$BATS_TEST_TMPDIR/explicit.md"
+
+  PATH="$stub_dir:$PATH" run sessions run \
+    --system-prompt-file "$BATS_TEST_TMPDIR/explicit.md" \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5" \
+    --session "$session_file"
+  [ "$status" -eq 0 ]
+  grep -q "explicit prompt" "$prompt_capture"
+  ! grep -q "baked prompt" "$prompt_capture"
+}
+
 @test "run interactive without message scrubs stale harness environment" {
   local mise_data="${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}"
   local stale_bin="$mise_data/installs/sessions-test-stale/bin"

--- a/test/run.bats
+++ b/test/run.bats
@@ -55,6 +55,35 @@ teardown() {
   ! grep -qx '' "$argv_capture"
 }
 
+@test "run interactive without message preserves stdin for pi" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-stdin"
+  local stdin_capture="$BATS_TEST_TMPDIR/pi-stdin-capture"
+  local prompt="$BATS_TEST_TMPDIR/prompt.md"
+  mkdir -p "$stub_dir"
+  echo "test prompt" > "$prompt"
+  cat > "$stub_dir/pi" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+if read -r line; then
+  printf '%s' "\$line" > "$stdin_capture"
+else
+  printf 'stdin closed' > "$stdin_capture"
+  exit 1
+fi
+STUB
+  chmod +x "$stub_dir/pi"
+
+  run bash -c 'printf "%s\n" "typed input" | PATH="$1" PI_DIR="$2" mise -C "$3" run -q run --system-prompt-file "$4" --cwd "$5" --model "openai-codex/gpt-5.5"' \
+    bash \
+    "$stub_dir:$PATH" \
+    "$PI_DIR" \
+    "$REPO_DIR" \
+    "$prompt" \
+    "$BATS_TEST_TMPDIR"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$stdin_capture")" = "typed input" ]
+}
+
 @test "run interactive without message uses baked session system prompt" {
   local stub_dir="$BATS_TEST_TMPDIR/stub-pi-baked-prompt"
   local argv_capture="$BATS_TEST_TMPDIR/pi-argv-baked-prompt"
@@ -180,6 +209,110 @@ STUB
   [ "$status" -eq 0 ]
   grep -q "explicit prompt" "$prompt_capture"
   ! grep -q "baked prompt" "$prompt_capture"
+}
+
+@test "run interactive without message treats an empty baked prompt as present" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-empty-baked-prompt"
+  local prompt_capture="$BATS_TEST_TMPDIR/pi-prompt-empty-baked-prompt"
+  local prompt_path_capture="$BATS_TEST_TMPDIR/pi-prompt-path-empty-baked-prompt"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/pi" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+prompt_file=""
+while [ "\$#" -gt 0 ]; do
+  if [ "\$1" = "--append-system-prompt" ]; then
+    prompt_file="\$2"
+    break
+  fi
+  shift
+done
+[ -n "\$prompt_file" ]
+printf '%s\n' "\$prompt_file" > "$prompt_path_capture"
+cat "\$prompt_file" > "$prompt_capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/pi"
+
+  : > "$BATS_TEST_TMPDIR/empty-prompt.md"
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt-file "$BATS_TEST_TMPDIR/empty-prompt.md"
+  [ "$status" -eq 0 ]
+  new_id=$(echo "$output" | head -1)
+  session_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
+
+  export AGENT_IDENTITY="stale legacy identity"
+  PATH="$stub_dir:$PATH" run sessions run \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5" \
+    --session "$session_file"
+  [ "$status" -eq 0 ]
+  [ -f "$prompt_capture" ]
+  [ -f "$prompt_path_capture" ]
+  ! grep -q "stale legacy identity" "$prompt_capture"
+  [ ! -e "$(cat "$prompt_path_capture")" ]
+}
+
+@test "run forwards SIGTERM to child before cleaning generated prompt" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-sigterm"
+  local pid_capture="$BATS_TEST_TMPDIR/pi-sigterm-pid"
+  local term_capture="$BATS_TEST_TMPDIR/pi-sigterm-seen"
+  local prompt_path_capture="$BATS_TEST_TMPDIR/pi-sigterm-prompt-path"
+  local stdout_capture="$BATS_TEST_TMPDIR/run-sigterm-stdout"
+  local stderr_capture="$BATS_TEST_TMPDIR/run-sigterm-stderr"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/pi" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+prompt_file=""
+while [ "\$#" -gt 0 ]; do
+  if [ "\$1" = "--append-system-prompt" ]; then
+    prompt_file="\$2"
+    break
+  fi
+  shift
+done
+[ -n "\$prompt_file" ]
+printf '%s\n' "\$prompt_file" > "$prompt_path_capture"
+printf '%s\n' "\$\$" > "$pid_capture"
+trap 'printf term > "$term_capture"; exit 143' TERM
+while :; do sleep 1; done
+STUB
+  chmod +x "$stub_dir/pi"
+
+  PATH="$stub_dir:$PATH" AGENT_IDENTITY="generated prompt" PI_DIR="$PI_DIR" \
+    mise -C "$REPO_DIR" run -q run --cwd "$BATS_TEST_TMPDIR" --model "openai-codex/gpt-5.5" \
+    >"$stdout_capture" 2>"$stderr_capture" &
+  local mise_pid=$!
+
+  for _ in $(seq 1 50); do
+    [ -s "$pid_capture" ] && [ -s "$prompt_path_capture" ] && break
+    sleep 0.1
+  done
+  [ -s "$pid_capture" ]
+  [ -s "$prompt_path_capture" ]
+
+  local child_pid
+  child_pid=$(cat "$pid_capture")
+  local runner_pid
+  runner_pid=$(ps -o ppid= -p "$child_pid" | tr -d ' ')
+  [ -n "$runner_pid" ]
+  local prompt_path
+  prompt_path=$(cat "$prompt_path_capture")
+  [ -e "$prompt_path" ]
+
+  kill -TERM "$runner_pid"
+  set +e
+  wait "$mise_pid"
+  local rc=$?
+  set -e
+
+  [ "$rc" -eq 143 ]
+  [ -f "$term_capture" ]
+  if kill -0 "$child_pid" 2>/dev/null; then
+    kill "$child_pid" 2>/dev/null || true
+    return 1
+  fi
+  [ ! -e "$prompt_path" ]
 }
 
 @test "run interactive without message scrubs stale harness environment" {

--- a/test/run.bats
+++ b/test/run.bats
@@ -252,6 +252,30 @@ STUB
   [ ! -e "$(cat "$prompt_path_capture")" ]
 }
 
+@test "run with malformed session does not fall back to stale AGENT_IDENTITY" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-malformed-session"
+  local invoked_capture="$BATS_TEST_TMPDIR/pi-malformed-session-invoked"
+  local bad_session="$BATS_TEST_TMPDIR/malformed-session.jsonl"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/pi" <<STUB
+#!/usr/bin/env bash
+printf invoked > "$invoked_capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/pi"
+  printf '{"type":"session"\n' > "$bad_session"
+
+  export AGENT_IDENTITY="stale legacy identity"
+  PATH="$stub_dir:$PATH" run sessions run \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5" \
+    --session "$bad_session"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "failed to read session system prompt"
+  echo "$output" | grep -q "parse error"
+  [ ! -e "$invoked_capture" ]
+}
+
 @test "run forwards SIGTERM to child before cleaning generated prompt" {
   local stub_dir="$BATS_TEST_TMPDIR/stub-pi-sigterm"
   local pid_capture="$BATS_TEST_TMPDIR/pi-sigterm-pid"

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -639,6 +639,45 @@ STUB
   ! grep -qx '' "$pi_argv_capture"
 }
 
+@test "wake interactive without --message uses baked session system prompt" {
+  local session_cwd="$BATS_TEST_TMPDIR/wake-baked-cwd"
+  mkdir -p "$session_cwd"
+
+  run sessions new wake-baked-prompt --cwd "$session_cwd" --system-prompt "wake baked prompt"
+  [ "$status" -eq 0 ]
+  new_id=$(echo "$output" | head -1)
+
+  local stub_dir="$BATS_TEST_TMPDIR/stub-shell-pi-baked-prompt"
+  local shell_capture="$BATS_TEST_TMPDIR/shell-argv-baked-prompt"
+  local prompt_capture="$BATS_TEST_TMPDIR/pi-prompt-baked-prompt"
+  stub_shell_exec_payload "$stub_dir" "$shell_capture"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/pi" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+prompt_file=""
+while [ "\$#" -gt 0 ]; do
+  if [ "\$1" = "--append-system-prompt" ]; then
+    prompt_file="\$2"
+    break
+  fi
+  shift
+done
+[ -n "\$prompt_file" ]
+cat "\$prompt_file" > "$prompt_capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/pi"
+
+  unset AGENT_IDENTITY
+  PATH="$stub_dir:$PATH" run sessions wake wake-baked-prompt --background --model "openai-codex/gpt-5.5"
+  [ "$status" -eq 0 ]
+  [ -f "$shell_capture" ]
+  [ -f "$prompt_capture" ]
+  grep -q "wake baked prompt" "$prompt_capture"
+  jq -e 'select(.type == "wake" and .headless == false)' "$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")"
+}
+
 @test "wake --model is advertised in --help" {
   run sessions wake --help
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

- add `sessions new --system-prompt` and `--system-prompt-file`
- record baked prompts as sessions-owned `system_prompt` JSONL entries
- teach `sessions run --session <file>` to resolve prompts as explicit file → baked session prompt → legacy `AGENT_IDENTITY`
- keep `sessions wake` prompt-free; it reuses the session prompt through the existing run path
- document `new + wake` as the normal user path and `run` as the low-level executor

## Notes

Self-review requested one fix: temp prompt files leaked because `sessions run` used `exec`, so EXIT traps did not fire. Addressed by running child processes normally and exiting with their status; tests now assert generated temp prompts are removed.

## Verification

- `mise run test` — 247/247
- `readme build --check`
- `cd cli && mix test` — 121 tests + 4 doctests
- codebase lints with absolute target:
  - `lint:mise-settings`
  - `lint:gum-table`
  - `lint:bats-test-helper`
  - `lint:bats-test-task`
  - `lint:mcr-scope`
  - `lint:or-true`
  - `lint:shellcheck`
- `git diff --check`
