### PR TITLE
Fix baked prompt edge cases

### DIFF
--- a/.mise/tasks/new
+++ b/.mise/tasks/new
@@ -15,6 +15,8 @@ NAME="${usage_name:-}"
 CWD="${usage_cwd:-}"
 SYSTEM_PROMPT="${usage_system_prompt:-}"
 SYSTEM_PROMPT_FILE="${usage_system_prompt_file:-}"
+SYSTEM_PROMPT_PROVIDED=false
+[ -n "$SYSTEM_PROMPT" ] && SYSTEM_PROMPT_PROVIDED=true
 CONTEXT="${usage_context:-}"
 CONTEXT_FILE="${usage_context_file:-}"
 META_RAW="${usage_meta:-}"
@@ -35,6 +37,7 @@ CWD_ABS=$(cd "$CWD" 2>/dev/null && pwd) || {
 # the existing --context-file behavior: when both inline and file forms are
 # supplied, the file content wins.
 if [ -n "$SYSTEM_PROMPT_FILE" ]; then
+  SYSTEM_PROMPT_PROVIDED=true
   if [ ! -f "$SYSTEM_PROMPT_FILE" ]; then
     echo "Error: system prompt file not found: $SYSTEM_PROMPT_FILE" >&2
     exit 1
@@ -117,7 +120,7 @@ LAST_ENTRY_ID="$HARNESS_ENTRY_ID"
 
 # Bake the system prompt into the session if provided. `sessions wake` does not
 # accept prompt flags; wake/run resolve this entry from the session file.
-if [ -n "$SYSTEM_PROMPT" ]; then
+if [ "$SYSTEM_PROMPT_PROVIDED" = "true" ]; then
   PROMPT_ENTRY_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
   system_prompt_entry "$PROMPT_ENTRY_ID" "$LAST_ENTRY_ID" "$NOW_ISO" "$SYSTEM_PROMPT" >> "$SESSION_FILE"
   LAST_ENTRY_ID="$PROMPT_ENTRY_ID"
@@ -138,7 +141,7 @@ else
   echo "Created session ${SESSION_ID:0:8}" >&2
 fi
 echo "cwd: $CWD_ABS" >&2
-if [ -n "$SYSTEM_PROMPT" ]; then
+if [ "$SYSTEM_PROMPT_PROVIDED" = "true" ]; then
   echo "System prompt: $(echo "$SYSTEM_PROMPT" | head -1 | cut -c1-80)..." >&2
 fi
 if [ -n "$CONTEXT" ]; then

--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -41,8 +41,8 @@ trap cleanup_prompt_temp EXIT
 
 latest_session_system_prompt() {
   local session_file="$1"
-  [ -f "$session_file" ] || return 0
-  jq -s -r '[.[] | select(.type == "system_prompt") | .content] | last // empty' "$session_file"
+  [ -f "$session_file" ] || return 1
+  jq -s -e -r '[.[] | select(.type == "system_prompt") | .content] | if length == 0 then empty else last end' "$session_file"
 }
 
 write_prompt_temp() {
@@ -53,8 +53,37 @@ write_prompt_temp() {
 
 run_and_exit() {
   set +e
-  "$@"
+  (
+    trap - INT TERM HUP QUIT
+    exec "$@"
+  ) <&0 &
+  local child_pid=$!
+
+  # shellcheck disable=SC2329  # Invoked by signal traps below.
+  forward_child_signal() {
+    local sig="$1"
+    local sig_num
+    trap - INT TERM HUP QUIT
+    if ! kill -s "$sig" "$child_pid" 2>/dev/null; then
+      :
+    fi
+    wait "$child_pid"
+    local rc=$?
+    if [ "$rc" -eq 127 ]; then
+      sig_num=$(kill -l "$sig" 2>/dev/null || echo 0)
+      rc=$((128 + sig_num))
+    fi
+    exit "$rc"
+  }
+
+  trap 'forward_child_signal INT' INT
+  trap 'forward_child_signal TERM' TERM
+  trap 'forward_child_signal HUP' HUP
+  trap 'forward_child_signal QUIT' QUIT
+
+  wait "$child_pid"
   local rc=$?
+  trap - INT TERM HUP QUIT
   set -e
   exit "$rc"
 }
@@ -81,8 +110,7 @@ fi
 #   2. Latest system_prompt entry baked into --session by `sessions new`
 #   3. Legacy AGENT_IDENTITY environment fallback
 if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "$SESSION" ]; then
-  SESSION_SYSTEM_PROMPT=$(latest_session_system_prompt "$SESSION")
-  if [ -n "$SESSION_SYSTEM_PROMPT" ]; then
+  if SESSION_SYSTEM_PROMPT=$(latest_session_system_prompt "$SESSION"); then
     write_prompt_temp "$SESSION_SYSTEM_PROMPT"
   fi
   unset SESSION_SYSTEM_PROMPT

--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -41,8 +41,28 @@ trap cleanup_prompt_temp EXIT
 
 latest_session_system_prompt() {
   local session_file="$1"
-  [ -f "$session_file" ] || return 1
-  jq -s -e -r '[.[] | select(.type == "system_prompt") | .content] | if length == 0 then empty else last end' "$session_file"
+  local jq_output
+  local jq_status
+
+  if [ ! -f "$session_file" ]; then
+    echo "Error: session file not found: $session_file" >&2
+    return 2
+  fi
+
+  if jq_output=$(jq -s -e -r '[.[] | select(.type == "system_prompt") | .content] | if length == 0 then empty else last end' "$session_file" 2>&1); then
+    printf '%s' "$jq_output"
+    return 0
+  else
+    jq_status=$?
+  fi
+
+  if [ "$jq_status" -eq 4 ]; then
+    return 1
+  fi
+
+  echo "Error: failed to read session system prompt from $session_file" >&2
+  printf '%s\n' "$jq_output" >&2
+  return 2
 }
 
 write_prompt_temp() {
@@ -112,8 +132,13 @@ fi
 if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "$SESSION" ]; then
   if SESSION_SYSTEM_PROMPT=$(latest_session_system_prompt "$SESSION"); then
     write_prompt_temp "$SESSION_SYSTEM_PROMPT"
+  else
+    SESSION_PROMPT_STATUS=$?
+    if [ "$SESSION_PROMPT_STATUS" -ne 1 ]; then
+      exit "$SESSION_PROMPT_STATUS"
+    fi
   fi
-  unset SESSION_SYSTEM_PROMPT
+  unset SESSION_SYSTEM_PROMPT SESSION_PROMPT_STATUS
 fi
 
 if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "${AGENT_IDENTITY:-}" ]; then

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 251 passing](https://img.shields.io/badge/tests-251%20passing-brightgreen?style=flat)](test/)
+[![tests: 252 passing](https://img.shields.io/badge/tests-252%20passing-brightgreen?style=flat)](test/)
 ![commands: 14](https://img.shields.io/badge/commands-14-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -180,7 +180,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**251 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
+**252 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -210,7 +210,7 @@ sessions/
 │   ├── shell.sh        # Shell helpers
 │   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats          # 251 tests
+    └── *.bats          # 252 tests
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 247 passing](https://img.shields.io/badge/tests-247%20passing-brightgreen?style=flat)](test/)
+[![tests: 251 passing](https://img.shields.io/badge/tests-251%20passing-brightgreen?style=flat)](test/)
 ![commands: 14](https://img.shields.io/badge/commands-14-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -180,7 +180,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**247 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
+**251 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -210,7 +210,7 @@ sessions/
 │   ├── shell.sh        # Shell helpers
 │   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats          # 247 tests
+    └── *.bats          # 251 tests
 ```
 
 </details>

--- a/mise.toml
+++ b/mise.toml
@@ -13,6 +13,7 @@ usage = "latest"
 uv = "latest"
 bats = "1.13.0"
 "shiv:codebase" = "0.2.0"                  # Codebase linting + migrations
+"shiv:readme" = "0.1"                      # README generation/checks
 "shiv:shell" = "0.1.0"                     # Persistent terminal sessions (used by wake)
 erlang = "28.4.1"
 elixir = "1.19.5-otp-27"

--- a/test/new.bats
+++ b/test/new.bats
@@ -139,6 +139,16 @@ EOF
   jq -r 'select(.type == "system_prompt") | .content' "$new_file" | grep -q "Keep output concise"
 }
 
+@test "new --system-prompt-file stores empty file as an explicit baked prompt" {
+  : > "$BATS_TEST_TMPDIR/empty-prompt.md"
+
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt-file "$BATS_TEST_TMPDIR/empty-prompt.md"
+  [ "$status" -eq 0 ]
+  new_id=$(echo "$output" | head -1)
+  new_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
+  jq -e 'select(.type == "system_prompt" and .content == "")' "$new_file"
+}
+
 @test "new errors with nonexistent system prompt file" {
   run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt-file "/tmp/nonexistent-$$"
   [ "$status" -eq 1 ]

--- a/test/run.bats
+++ b/test/run.bats
@@ -55,6 +55,35 @@ teardown() {
   ! grep -qx '' "$argv_capture"
 }
 
+@test "run interactive without message preserves stdin for pi" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-stdin"
+  local stdin_capture="$BATS_TEST_TMPDIR/pi-stdin-capture"
+  local prompt="$BATS_TEST_TMPDIR/prompt.md"
+  mkdir -p "$stub_dir"
+  echo "test prompt" > "$prompt"
+  cat > "$stub_dir/pi" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+if read -r line; then
+  printf '%s' "\$line" > "$stdin_capture"
+else
+  printf 'stdin closed' > "$stdin_capture"
+  exit 1
+fi
+STUB
+  chmod +x "$stub_dir/pi"
+
+  run bash -c 'printf "%s\n" "typed input" | PATH="$1" PI_DIR="$2" mise -C "$3" run -q run --system-prompt-file "$4" --cwd "$5" --model "openai-codex/gpt-5.5"' \
+    bash \
+    "$stub_dir:$PATH" \
+    "$PI_DIR" \
+    "$REPO_DIR" \
+    "$prompt" \
+    "$BATS_TEST_TMPDIR"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$stdin_capture")" = "typed input" ]
+}
+
 @test "run interactive without message uses baked session system prompt" {
   local stub_dir="$BATS_TEST_TMPDIR/stub-pi-baked-prompt"
   local argv_capture="$BATS_TEST_TMPDIR/pi-argv-baked-prompt"
@@ -180,6 +209,110 @@ STUB
   [ "$status" -eq 0 ]
   grep -q "explicit prompt" "$prompt_capture"
   ! grep -q "baked prompt" "$prompt_capture"
+}
+
+@test "run interactive without message treats an empty baked prompt as present" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-empty-baked-prompt"
+  local prompt_capture="$BATS_TEST_TMPDIR/pi-prompt-empty-baked-prompt"
+  local prompt_path_capture="$BATS_TEST_TMPDIR/pi-prompt-path-empty-baked-prompt"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/pi" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+prompt_file=""
+while [ "\$#" -gt 0 ]; do
+  if [ "\$1" = "--append-system-prompt" ]; then
+    prompt_file="\$2"
+    break
+  fi
+  shift
+done
+[ -n "\$prompt_file" ]
+printf '%s\n' "\$prompt_file" > "$prompt_path_capture"
+cat "\$prompt_file" > "$prompt_capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/pi"
+
+  : > "$BATS_TEST_TMPDIR/empty-prompt.md"
+  run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt-file "$BATS_TEST_TMPDIR/empty-prompt.md"
+  [ "$status" -eq 0 ]
+  new_id=$(echo "$output" | head -1)
+  session_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
+
+  export AGENT_IDENTITY="stale legacy identity"
+  PATH="$stub_dir:$PATH" run sessions run \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5" \
+    --session "$session_file"
+  [ "$status" -eq 0 ]
+  [ -f "$prompt_capture" ]
+  [ -f "$prompt_path_capture" ]
+  ! grep -q "stale legacy identity" "$prompt_capture"
+  [ ! -e "$(cat "$prompt_path_capture")" ]
+}
+
+@test "run forwards SIGTERM to child before cleaning generated prompt" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-sigterm"
+  local pid_capture="$BATS_TEST_TMPDIR/pi-sigterm-pid"
+  local term_capture="$BATS_TEST_TMPDIR/pi-sigterm-seen"
+  local prompt_path_capture="$BATS_TEST_TMPDIR/pi-sigterm-prompt-path"
+  local stdout_capture="$BATS_TEST_TMPDIR/run-sigterm-stdout"
+  local stderr_capture="$BATS_TEST_TMPDIR/run-sigterm-stderr"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/pi" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+prompt_file=""
+while [ "\$#" -gt 0 ]; do
+  if [ "\$1" = "--append-system-prompt" ]; then
+    prompt_file="\$2"
+    break
+  fi
+  shift
+done
+[ -n "\$prompt_file" ]
+printf '%s\n' "\$prompt_file" > "$prompt_path_capture"
+printf '%s\n' "\$\$" > "$pid_capture"
+trap 'printf term > "$term_capture"; exit 143' TERM
+while :; do sleep 1; done
+STUB
+  chmod +x "$stub_dir/pi"
+
+  PATH="$stub_dir:$PATH" AGENT_IDENTITY="generated prompt" PI_DIR="$PI_DIR" \
+    mise -C "$REPO_DIR" run -q run --cwd "$BATS_TEST_TMPDIR" --model "openai-codex/gpt-5.5" \
+    >"$stdout_capture" 2>"$stderr_capture" &
+  local mise_pid=$!
+
+  for _ in $(seq 1 50); do
+    [ -s "$pid_capture" ] && [ -s "$prompt_path_capture" ] && break
+    sleep 0.1
+  done
+  [ -s "$pid_capture" ]
+  [ -s "$prompt_path_capture" ]
+
+  local child_pid
+  child_pid=$(cat "$pid_capture")
+  local runner_pid
+  runner_pid=$(ps -o ppid= -p "$child_pid" | tr -d ' ')
+  [ -n "$runner_pid" ]
+  local prompt_path
+  prompt_path=$(cat "$prompt_path_capture")
+  [ -e "$prompt_path" ]
+
+  kill -TERM "$runner_pid"
+  set +e
+  wait "$mise_pid"
+  local rc=$?
+  set -e
+
+  [ "$rc" -eq 143 ]
+  [ -f "$term_capture" ]
+  if kill -0 "$child_pid" 2>/dev/null; then
+    kill "$child_pid" 2>/dev/null || true
+    return 1
+  fi
+  [ ! -e "$prompt_path" ]
 }
 
 @test "run interactive without message scrubs stale harness environment" {

--- a/test/run.bats
+++ b/test/run.bats
@@ -252,6 +252,30 @@ STUB
   [ ! -e "$(cat "$prompt_path_capture")" ]
 }
 
+@test "run with malformed session does not fall back to stale AGENT_IDENTITY" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-malformed-session"
+  local invoked_capture="$BATS_TEST_TMPDIR/pi-malformed-session-invoked"
+  local bad_session="$BATS_TEST_TMPDIR/malformed-session.jsonl"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/pi" <<STUB
+#!/usr/bin/env bash
+printf invoked > "$invoked_capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/pi"
+  printf '{"type":"session"\n' > "$bad_session"
+
+  export AGENT_IDENTITY="stale legacy identity"
+  PATH="$stub_dir:$PATH" run sessions run \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5" \
+    --session "$bad_session"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "failed to read session system prompt"
+  echo "$output" | grep -q "parse error"
+  [ ! -e "$invoked_capture" ]
+}
+
 @test "run forwards SIGTERM to child before cleaning generated prompt" {
   local stub_dir="$BATS_TEST_TMPDIR/stub-pi-sigterm"
   local pid_capture="$BATS_TEST_TMPDIR/pi-sigterm-pid"


### PR DESCRIPTION
Follow-up fix-it for #92 adversarial review.

Changes:
- Preserve explicit empty `--system-prompt-file` prompts as baked `system_prompt` entries, and make empty baked prompts win over stale `AGENT_IDENTITY`.
- Replace the temp-prompt cleanup wrapper with signal forwarding so killing `sessions run` still terminates the child before the EXIT cleanup removes the generated prompt file.
- Add regression coverage for empty prompts, stdin preservation, SIGTERM forwarding, and temp cleanup.

Verification:
- `bash -n .mise/tasks/new .mise/tasks/run .mise/tasks/wake lib/harness/dispatch.sh`
- `git diff --check`
- `mise run test new`
- `mise run test run`
- `mise run test wake`
- `readme build --check`
- `cd cli && mix test`
- codebase lints with absolute target:
  - `lint:mise-settings`
  - `lint:gum-table`
  - `lint:bats-test-helper`
  - `lint:bats-test-task`
  - `lint:mcr-scope`
  - `lint:or-true`
  - `lint:shellcheck`
- Full `mise run test` still fails in existing `test/search.bats` cases; reproduced on `origin/main` via a clean worktree (`mise run test search`).