### PR TITLE
Add sessions wait for transcript deltas

### DIFF
--- a/.mise/tasks/read
+++ b/.mise/tasks/read
@@ -1,12 +1,12 @@
 #!/usr/bin/env -S uv run --script
 #MISE description="Read a session transcript (replaces show + tail)"
 #USAGE arg "<session_id>" help="Session ID (prefix match supported)"
-#USAGE flag "--from <n>" help="Start at message N (1-indexed, negative counts from end)"
-#USAGE flag "--to <n>" help="End at message N (inclusive, negative counts from end)"
-#USAGE flag "--last <n>" help="Show only the last N messages"
-#USAGE flag "--tools" help="Include tool_use/tool_result blocks (hidden by default)"
-#USAGE flag "--user-only" help="Show only user messages"
-#USAGE flag "--json" help="Output as JSON"
+#USAGE flag "--from <n>" default="" help="Start at message N (1-indexed, negative counts from end)"
+#USAGE flag "--to <n>" default="" help="End at message N (inclusive, negative counts from end)"
+#USAGE flag "--last <n>" default="" help="Show only the last N messages"
+#USAGE flag "--tools" default=#false help="Include tool_use/tool_result blocks (hidden by default)"
+#USAGE flag "--user-only" default=#false help="Show only user messages"
+#USAGE flag "--json" default=#false help="Output as JSON"
 # /// script
 # requires-python = ">=3.10"
 # dependencies = ["rich"]
@@ -30,6 +30,7 @@ from format import (
     format_time,
 )
 
+from messages import filter_text_messages, split_message
 from rich.text import Text
 
 session_id = os.environ.get("usage_session_id", "")
@@ -53,48 +54,13 @@ meta = session.metadata()
 messages = session.text_messages()
 
 
-def is_tool_line(line: str) -> bool:
-    """Check if a line is a tool_use or tool_result marker."""
-    stripped = line.strip()
-    return stripped.startswith("[tool_use:") or stripped.startswith("[tool_result:")
-
-
-def filter_message(text: str) -> str:
-    """Strip tool lines from message text. Returns empty string if nothing left."""
-    lines = text.split("\n")
-    lines = [l for l in lines if not is_tool_line(l)]
-    return "\n".join(lines).strip()
-
-
-def split_message(text: str) -> tuple[list[str], list[str]]:
-    """Split message text into (content_lines, tool_lines)."""
-    content = []
-    tools = []
-    for line in text.split("\n"):
-        if is_tool_line(line):
-            tools.append(line.strip())
-        else:
-            content.append(line)
-    return content, tools
-
-
 # --- Filter messages ---
 
-filtered = []
-for idx, role, ts, text in messages:
-    if user_only and role != "user":
-        continue
-
-    if include_tools:
-        # Keep everything, we'll style tool lines differently
-        if not text.strip():
-            continue
-        filtered.append((idx, role, ts, text))
-    else:
-        cleaned = filter_message(text)
-        if not cleaned:
-            continue
-        filtered.append((idx, role, ts, cleaned))
+filtered = filter_text_messages(
+    messages,
+    include_tools=include_tools,
+    user_only=user_only,
+)
 
 # --- Apply windowing (--from, --to, --last) ---
 

--- a/.mise/tasks/wait
+++ b/.mise/tasks/wait
@@ -1,0 +1,198 @@
+#!/usr/bin/env -S uv run --script
+#MISE description="Wait for new messages in a session transcript"
+#USAGE arg "<session_id>" help="Session ID (prefix match supported)"
+#USAGE flag "--count <n>" default="1" help="Number of new matching messages to wait for (default: 1)"
+#USAGE flag "--timeout <seconds>" default="0" help="Maximum seconds to wait; 0 means no timeout"
+#USAGE flag "--interval <seconds>" default="1" help="Polling interval in seconds (default: 1)"
+#USAGE flag "--tools" default=#false help="Include tool_use/tool_result blocks (hidden by default)"
+#USAGE flag "--user-only" default=#false help="Wait only for user messages"
+#USAGE flag "--assistant-only" default=#false help="Wait only for assistant messages"
+#USAGE flag "--match <regex>" default="" help="Wait only for messages matching a regex"
+#USAGE flag "--json" default=#false help="Output as JSON"
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["rich"]
+# ///
+
+import json
+import os
+import re
+import sys
+import time
+
+sys.path.insert(0, os.environ["MISE_CONFIG_ROOT"] + "/lib")
+import parse
+from format import (
+    STYLE_DIM,
+    STYLE_ID,
+    STYLE_ROLE_ASSISTANT,
+    STYLE_ROLE_USER,
+    STYLE_TOOL,
+    console,
+    format_time,
+)
+from messages import filter_text_messages, split_message
+from rich.text import Text
+
+session_id = os.environ.get("usage_session_id", "")
+if not session_id:
+    print("Usage: sessions wait <session_id>", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    target_count = int(os.environ.get("usage_count", "1"))
+except ValueError:
+    print("Error: --count must be an integer", file=sys.stderr)
+    sys.exit(1)
+if target_count < 1:
+    print("Error: --count must be at least 1", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    timeout_seconds = float(os.environ.get("usage_timeout", "0"))
+except ValueError:
+    print("Error: --timeout must be a number", file=sys.stderr)
+    sys.exit(1)
+if timeout_seconds < 0:
+    print("Error: --timeout must be non-negative", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    interval_seconds = float(os.environ.get("usage_interval", "1"))
+except ValueError:
+    print("Error: --interval must be a number", file=sys.stderr)
+    sys.exit(1)
+if interval_seconds <= 0:
+    print("Error: --interval must be greater than 0", file=sys.stderr)
+    sys.exit(1)
+
+include_tools = os.environ.get("usage_tools", "") == "true"
+user_only = os.environ.get("usage_user_only", "") == "true"
+assistant_only = os.environ.get("usage_assistant_only", "") == "true"
+match_raw = os.environ.get("usage_match", "")
+output_json = os.environ.get("usage_json", "") == "true"
+
+if user_only and assistant_only:
+    print("Error: --user-only and --assistant-only are mutually exclusive", file=sys.stderr)
+    sys.exit(1)
+
+pattern = None
+if match_raw:
+    try:
+        pattern = re.compile(match_raw, re.IGNORECASE)
+    except re.error as e:
+        print(f"Invalid regex: {e}", file=sys.stderr)
+        sys.exit(1)
+
+filepath = parse.find_session(session_id)
+
+
+def load_text_messages():
+    return parse.load(filepath).text_messages()
+
+
+def latest_index(messages):
+    if not messages:
+        return -1
+    return max(idx for idx, _role, _ts, _text in messages)
+
+
+def filter_new_messages(messages, cursor):
+    new_messages = [m for m in messages if m[0] > cursor]
+    return filter_text_messages(
+        new_messages,
+        include_tools=include_tools,
+        user_only=user_only,
+        assistant_only=assistant_only,
+        pattern=pattern,
+    )
+
+
+def message_to_dict(message):
+    idx, role, ts, text = message
+    return {
+        "index": idx,
+        "role": role,
+        "timestamp": ts,
+        "text": text,
+    }
+
+
+def print_json(messages):
+    print(json.dumps({
+        "session_id": session_id_full,
+        "messages": [message_to_dict(m) for m in messages],
+    }, indent=2))
+
+
+def print_text(messages):
+    title = Text()
+    title.append(session_id_full[:8], style=STYLE_ID)
+    title.append(f"  waited for {len(messages)} new message", style=STYLE_DIM)
+    if len(messages) != 1:
+        title.append("s", style=STYLE_DIM)
+
+    console.print()
+    console.print(title)
+    console.rule(style="dim")
+    console.print()
+
+    for i, (_idx, role, ts, text) in enumerate(messages):
+        time_str = format_time(ts)
+        header = Text()
+        if role == "user":
+            header.append("👤 ", style=STYLE_ROLE_USER)
+            header.append("User", style=f"bold {STYLE_ROLE_USER}")
+        else:
+            header.append("🤖 ", style=STYLE_ROLE_ASSISTANT)
+            header.append("Assistant", style=f"bold {STYLE_ROLE_ASSISTANT}")
+        header.append(f"  {time_str}", style=STYLE_DIM)
+        console.print(header)
+
+        if include_tools:
+            content_lines, tool_lines = split_message(text)
+            content_text = "\n".join(content_lines).strip()
+            if content_text:
+                console.print(content_text, soft_wrap=True)
+            for tool_line in tool_lines:
+                console.print(Text(tool_line, style=STYLE_TOOL))
+        else:
+            console.print(text, soft_wrap=True)
+
+        if i < len(messages) - 1:
+            console.print()
+
+
+initial_messages = load_text_messages()
+cursor = latest_index(initial_messages)
+session_id_full = parse.load(filepath).session_id
+matched = []
+deadline = time.monotonic() + timeout_seconds if timeout_seconds > 0 else None
+
+while len(matched) < target_count:
+    sleep_for = interval_seconds
+    if deadline is not None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            print(
+                f"Timed out waiting for {target_count} new matching message(s) in {session_id_full[:8]}",
+                file=sys.stderr,
+            )
+            sys.exit(124)
+        sleep_for = min(interval_seconds, remaining)
+
+    time.sleep(sleep_for)
+
+    messages = load_text_messages()
+    new_matches = filter_new_messages(messages, cursor)
+    if messages:
+        cursor = max(cursor, latest_index(messages))
+
+    if new_matches:
+        remaining = target_count - len(matched)
+        matched.extend(new_matches[:remaining])
+
+if output_json:
+    print_json(matched)
+else:
+    print_text(matched)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 252 passing](https://img.shields.io/badge/tests-252%20passing-brightgreen?style=flat)](test/)
-![commands: 14](https://img.shields.io/badge/commands-14-blue?style=flat)
+[![tests: 262 passing](https://img.shields.io/badge/tests-262%20passing-brightgreen?style=flat)](test/)
+![commands: 15](https://img.shields.io/badge/commands-15-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
 </div>
@@ -24,6 +24,9 @@ Woke session 'review/pr-50'
 $ sessions read review/pr-50 --last 3
 ┃ assistant  Found 3 issues in error handling.
 ┃ assistant  Posted review to #scout-report.
+
+$ sessions wait review/pr-50 --assistant-only --timeout 120
+┃ assistant  Re-ran CI; all checks are green.
 
 $ sessions list --filter session.meta.agent.name=ikma
   e96bd43a  review/pr-50   12m   3m ago   claude-sonnet-4   8
@@ -42,6 +45,9 @@ sessions list
 
 # Read a transcript (by name or ID prefix)
 sessions read review/pr-50
+
+# Wait for the next assistant message
+sessions wait review/pr-50 --assistant-only --timeout 120
 
 # Search across all sessions
 sessions search "error handling"
@@ -62,6 +68,7 @@ Sessions aren't just transcript files agents leave behind — they're managed ar
               └─ sessions run
                    └─ pi    harness — processes message or opens interactively
   sessions read             observe the transcript
+  sessions wait             block until new transcript messages arrive
   sessions wake (again)     re-enter with corrections
 ```
 
@@ -166,6 +173,17 @@ sessions read e96bd43a --from -5           # last 5 messages
 sessions read e96bd43a --tools             # include tool calls
 ```
 
+`sessions wait` snapshots the current transcript and blocks until new matching messages arrive. It is useful for supervising long-running or parallel sessions without hand-written sleep loops.
+
+```bash
+sessions wait e96bd43a                         # next non-tool message
+sessions wait e96bd43a --count 10              # wait for 10 messages
+sessions wait e96bd43a --assistant-only        # ignore user/operator messages
+sessions wait e96bd43a --match "done|failed"   # wait for a regex match
+sessions wait e96bd43a --tools                 # include tool calls/results
+sessions wait e96bd43a --timeout 120 --json
+```
+
 For existing sessions you want to work with elsewhere, `copy` duplicates a session with its full conversation history plus a fork notice. The copy gets a new ID and can be woken independently — useful for handing off context between agents.
 
 ```bash
@@ -180,7 +198,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**252 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
+**262 tests** across 17 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, inspect, search). The JSONL parsing library is 558 lines of Python in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -193,6 +211,7 @@ sessions/
 │   ├── meta         # Read session header metadata
 │   ├── list         # List + filter sessions (Rich tables)
 │   ├── read         # Windowed transcript reader
+│   ├── wait         # Wait for new transcript messages
 │   ├── search       # Full-text regex across transcripts
 │   ├── inspect      # Forensic metadata (duration, tools, model)
 │   ├── copy         # Duplicate sessions for handoff
@@ -210,7 +229,7 @@ sessions/
 │   ├── shell.sh        # Shell helpers
 │   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats          # 252 tests
+    └── *.bats          # 262 tests
 ```
 
 </details>

--- a/README.tsx
+++ b/README.tsx
@@ -56,6 +56,9 @@ const lifecycle = [
   "┃ assistant  Found 3 issues in error handling.",
   "┃ assistant  Posted review to #scout-report.",
   "",
+  "$ sessions wait review/pr-50 --assistant-only --timeout 120",
+  "┃ assistant  Re-ran CI; all checks are green.",
+  "",
   "$ sessions list --filter session.meta.agent.name=ikma",
   "  e96bd43a  review/pr-50   12m   3m ago   claude-sonnet-4   8",
 ].join("\n");
@@ -70,6 +73,7 @@ const stack = [
   "              └─ sessions run",
   "                   └─ pi    harness — processes message or opens interactively",
   "  sessions read             observe the transcript",
+  "  sessions wait             block until new transcript messages arrive",
   "  sessions wake (again)     re-enter with corrections",
 ].join("\n");
 
@@ -131,6 +135,9 @@ sessions list
 
 # Read a transcript (by name or ID prefix)
 sessions read review/pr-50
+
+# Wait for the next assistant message
+sessions wait review/pr-50 --assistant-only --timeout 120
 
 # Search across all sessions
 sessions search "error handling"
@@ -295,6 +302,18 @@ sessions read e96bd43a --from -5           # last 5 messages
 sessions read e96bd43a --tools             # include tool calls`}</CodeBlock>
 
       <Paragraph>
+        <Code>sessions wait</Code>
+        {" snapshots the current transcript and blocks until new matching messages arrive. It is useful for supervising long-running or parallel sessions without hand-written sleep loops."}
+      </Paragraph>
+
+      <CodeBlock lang="bash">{`sessions wait e96bd43a                         # next non-tool message
+sessions wait e96bd43a --count 10              # wait for 10 messages
+sessions wait e96bd43a --assistant-only        # ignore user/operator messages
+sessions wait e96bd43a --match "done|failed"   # wait for a regex match
+sessions wait e96bd43a --tools                 # include tool calls/results
+sessions wait e96bd43a --timeout 120 --json`}</CodeBlock>
+
+      <Paragraph>
         {"For existing sessions you want to work with elsewhere, "}
         <Code>copy</Code>
         {" duplicates a session with its full conversation history plus a fork notice. The copy gets a new ID and can be woken independently — useful for handing off context between agents."}
@@ -314,7 +333,7 @@ mise run test`}</CodeBlock>
         <Link href="https://github.com/bats-core/bats-core">{`BATS ${batsVersion}`}</Link>
         {`. Tasks are bash scripts (session creation, wake, metadata) and Python scripts with `}
         <Link href="https://github.com/Textualize/rich">Rich</Link>
-        {` output (list, read, inspect, search). The JSONL parsing library is ${libLines} lines of Python in `}
+        {` output (list, read, wait, inspect, search). The JSONL parsing library is ${libLines} lines of Python in `}
         <Code>lib/</Code>
         {"."}
       </Paragraph>
@@ -327,6 +346,7 @@ mise run test`}</CodeBlock>
 │   ├── meta         # Read session header metadata
 │   ├── list         # List + filter sessions (Rich tables)
 │   ├── read         # Windowed transcript reader
+│   ├── wait         # Wait for new transcript messages
 │   ├── search       # Full-text regex across transcripts
 │   ├── inspect      # Forensic metadata (duration, tools, model)
 │   ├── copy         # Duplicate sessions for handoff

--- a/lib/messages.py
+++ b/lib/messages.py
@@ -1,0 +1,72 @@
+"""Shared transcript message filtering helpers.
+
+The parser returns rendered text messages as ``(index, role, timestamp, text)``
+tuples. These helpers keep command-level semantics consistent for tool-block
+filtering, role filtering, and regex matching.
+"""
+
+
+def is_tool_line(line: str) -> bool:
+    """Check if a rendered line is a tool_use or tool_result marker."""
+    stripped = line.strip()
+    return stripped.startswith("[tool_use:") or stripped.startswith("[tool_result:")
+
+
+def strip_tool_lines(text: str) -> str:
+    """Strip rendered tool lines from message text."""
+    lines = text.split("\n")
+    lines = [line for line in lines if not is_tool_line(line)]
+    return "\n".join(lines).strip()
+
+
+def split_message(text: str) -> tuple[list[str], list[str]]:
+    """Split rendered message text into (content_lines, tool_lines)."""
+    content = []
+    tools = []
+    for line in text.split("\n"):
+        if is_tool_line(line):
+            tools.append(line.strip())
+        else:
+            content.append(line)
+    return content, tools
+
+
+def filter_text_messages(
+    messages: list,
+    *,
+    include_tools: bool = False,
+    user_only: bool = False,
+    assistant_only: bool = False,
+    pattern=None,
+) -> list:
+    """Filter rendered text messages for display/waiting.
+
+    Args:
+        messages: Iterable of ``(index, role, timestamp, text)`` tuples.
+        include_tools: Keep rendered tool_use/tool_result lines.
+        user_only: Keep only user-role messages.
+        assistant_only: Keep only assistant-role messages.
+        pattern: Optional compiled regex matched against the rendered text.
+
+    Empty messages after filtering are dropped. ``pattern`` is evaluated after
+    tool and role filtering, so default matching ignores tool-only content.
+    """
+    if user_only and assistant_only:
+        raise ValueError("--user-only and --assistant-only are mutually exclusive")
+
+    filtered = []
+    for idx, role, ts, text in messages:
+        if user_only and role != "user":
+            continue
+        if assistant_only and role != "assistant":
+            continue
+
+        rendered = text if include_tools else strip_tool_lines(text)
+        if not rendered.strip():
+            continue
+        if pattern is not None and not pattern.search(rendered):
+            continue
+
+        filtered.append((idx, role, ts, rendered))
+
+    return filtered

--- a/test/read.bats
+++ b/test/read.bats
@@ -46,6 +46,21 @@ teardown() { teardown_test_sessions; }
   ! echo "$output" | grep -q "\[tool_result:"
 }
 
+@test "read clears inherited optional usage defaults" {
+  run env \
+    usage_tools=true \
+    usage_user_only=true \
+    usage_json=true \
+    usage_last=1 \
+    bash -c 'sessions read "$1"' _ "$SESSION_1"
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Assistant"
+  echo "$output" | grep -q "hello.*help"
+  ! echo "$output" | grep -q "\[tool_use:"
+  ! echo "$output" | python3 -m json.tool >/dev/null 2>&1
+}
+
 @test "read --tools shows tool blocks" {
   run sessions read "$SESSION_1" --tools
   [ "$status" -eq 0 ]

--- a/test/wait.bats
+++ b/test/wait.bats
@@ -1,0 +1,190 @@
+#!/usr/bin/env bats
+
+load helpers
+
+setup() { setup_test_sessions; }
+teardown() { teardown_test_sessions; }
+
+session_path() {
+  printf '%s\n' "$PROJECT_DIR"*"_$1.jsonl"
+}
+
+append_assistant_text() {
+  local file="$1"
+  local id="$2"
+  local text="$3"
+  cat >> "$file" <<JSONL
+{"type":"message","id":"$id","parentId":"wait-test","timestamp":"2026-03-14T10:31:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"$text"}],"model":"claude-opus-4-6","provider":"anthropic","stopReason":"stop","timestamp":1710405060000}}
+JSONL
+}
+
+append_user_text() {
+  local file="$1"
+  local id="$2"
+  local text="$3"
+  cat >> "$file" <<JSONL
+{"type":"message","id":"$id","parentId":"wait-test","timestamp":"2026-03-14T10:31:00.000Z","message":{"role":"user","content":[{"type":"text","text":"$text"}],"timestamp":1710405060000}}
+JSONL
+}
+
+append_assistant_tool_only() {
+  local file="$1"
+  local id="$2"
+  local command="$3"
+  cat >> "$file" <<JSONL
+{"type":"message","id":"$id","parentId":"wait-test","timestamp":"2026-03-14T10:31:00.000Z","message":{"role":"assistant","content":[{"type":"toolCall","id":"tc-$id","name":"bash","arguments":{"command":"$command"}}],"model":"claude-opus-4-6","provider":"anthropic","stopReason":"toolUse","timestamp":1710405060000}}
+JSONL
+}
+
+@test "wait returns the next appended rendered message" {
+  file=$(session_path "$SESSION_1")
+  (
+    sleep 1
+    append_assistant_text "$file" "a-wait-1" "new wait message ready"
+  ) &
+  appender=$!
+
+  run sessions wait "$SESSION_1" --timeout 5 --interval 0.1
+  wait "$appender"
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "new wait message ready"
+  ! echo "$output" | grep -q "hello.*help"
+}
+
+@test "wait times out when no matching message appears" {
+  run sessions wait "$SESSION_1" --timeout 0.3 --interval 0.05
+
+  [ "$status" -eq 124 ]
+  echo "$output" | grep -q "Timed out waiting"
+}
+
+@test "wait clears inherited optional usage defaults" {
+  file=$(session_path "$SESSION_1")
+  (
+    sleep 1
+    append_assistant_text "$file" "a-wait-clear-usage" "usage defaults cleared"
+  ) &
+  appender=$!
+
+  run env \
+    usage_count=2 \
+    usage_tools=true \
+    usage_user_only=true \
+    usage_assistant_only=true \
+    usage_match=never \
+    usage_json=true \
+    bash -c 'sessions wait "$1" --timeout 5 --interval 0.1' _ "$SESSION_1"
+  wait "$appender"
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Assistant"
+  echo "$output" | grep -q "usage defaults cleared"
+  ! echo "$output" | python3 -m json.tool >/dev/null 2>&1
+}
+
+@test "wait ignores tool-only messages by default" {
+  file=$(session_path "$SESSION_1")
+  (
+    sleep 1
+    append_assistant_tool_only "$file" "a-wait-tool-default" "echo hidden-tool"
+  ) &
+  appender=$!
+
+  run sessions wait "$SESSION_1" --timeout 2 --interval 0.1
+  wait "$appender"
+
+  [ "$status" -eq 124 ]
+  echo "$output" | grep -q "Timed out waiting"
+}
+
+@test "wait --tools can match tool-only messages" {
+  file=$(session_path "$SESSION_1")
+  (
+    sleep 1
+    append_assistant_tool_only "$file" "a-wait-tool-visible" "echo visible-tool"
+  ) &
+  appender=$!
+
+  run sessions wait "$SESSION_1" --tools --timeout 5 --interval 0.1
+  wait "$appender"
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "\[tool_use:.*bash"
+  echo "$output" | grep -q "visible-tool"
+}
+
+@test "wait --assistant-only ignores new user messages" {
+  file=$(session_path "$SESSION_1")
+  (
+    sleep 1
+    append_user_text "$file" "u-wait-ignored" "human/operator note"
+    sleep 0.5
+    append_assistant_text "$file" "a-wait-assistant" "assistant follow-up"
+  ) &
+  appender=$!
+
+  run sessions wait "$SESSION_1" --assistant-only --timeout 5 --interval 0.1
+  wait "$appender"
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "assistant follow-up"
+  ! echo "$output" | grep -q "human/operator note"
+}
+
+@test "wait --match waits for a matching new message" {
+  file=$(session_path "$SESSION_1")
+  (
+    sleep 1
+    append_assistant_text "$file" "a-wait-unmatched" "still working"
+    sleep 0.5
+    append_assistant_text "$file" "a-wait-matched" "Done with the requested work"
+  ) &
+  appender=$!
+
+  run sessions wait "$SESSION_1" --match "done with" --timeout 5 --interval 0.1
+  wait "$appender"
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Done with the requested work"
+  ! echo "$output" | grep -q "still working"
+}
+
+@test "wait --count collects multiple new matching messages" {
+  file=$(session_path "$SESSION_1")
+  (
+    sleep 1
+    append_assistant_text "$file" "a-wait-count-1" "first counted wait message"
+    sleep 0.5
+    append_assistant_text "$file" "a-wait-count-2" "second counted wait message"
+  ) &
+  appender=$!
+
+  run sessions wait "$SESSION_1" --count 2 --timeout 5 --interval 0.1
+  wait "$appender"
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "first counted wait message"
+  echo "$output" | grep -q "second counted wait message"
+}
+
+@test "wait --json returns matching messages as JSON" {
+  file=$(session_path "$SESSION_1")
+  (
+    sleep 1
+    append_assistant_text "$file" "a-wait-json" "json wait message"
+  ) &
+  appender=$!
+
+  run sessions wait "$SESSION_1" --json --timeout 5 --interval 0.1
+  wait "$appender"
+
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+assert data['session_id'] == '$SESSION_1'
+assert len(data['messages']) == 1
+assert data['messages'][0]['text'] == 'json wait message'
+"
+}


### PR DESCRIPTION
## Summary

Adds `sessions wait <session_id>` for blocking until new transcript messages arrive without hand-written sleep loops.

Behavior:
- snapshots the current transcript cursor at startup
- waits for new rendered messages after that cursor
- hides tool-only content by default, matching `sessions read`
- supports `--count`, `--timeout`, `--interval`, `--tools`, `--user-only`, `--assistant-only`, `--match`, and `--json`
- exits `124` on timeout

Also extracts shared rendered-message filtering from `read` into `lib/messages.py` so `read` and `wait` use the same tool-stripping semantics.

## Validation

- `mise run test`
- `mise run test wait read`
- `python3 -m py_compile lib/messages.py .mise/tasks/read .mise/tasks/wait`
- `readme build --check`
- `git diff --check`
