### PR TITLE
Fix usage filter limit ordering

### DIFF
--- a/.mise/tasks/usage
+++ b/.mise/tasks/usage
@@ -1,0 +1,304 @@
+#!/usr/bin/env -S uv run --script
+#MISE description="Show recorded token usage and cost for sessions"
+#USAGE arg "[session_id]" default="" help="Session ID/name (optional; omit for aggregate view)"
+#USAGE flag "--today" default=#false help="Aggregate records from today (UTC)"
+#USAGE flag "--after <date>" default="" help="Only include usage records on/after YYYY-MM-DD"
+#USAGE flag "--before <date>" default="" help="Only include usage records on/before YYYY-MM-DD"
+#USAGE flag "--limit <n>" default="" help="Max sessions to scan in aggregate mode (default: 20 unless date filters/--all)"
+#USAGE flag "--project <filter>" default="" help="Filter aggregate sessions by project directory substring"
+#USAGE flag "--filter <filter>" var=#true default="" help="Filter sessions (same syntax as sessions list --filter)"
+#USAGE flag "--all" default=#false help="Scan all sessions in aggregate mode"
+#USAGE flag "--turns" default=#false help="Show per-turn usage records"
+#USAGE flag "--json" default=#false help="Output as JSON"
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["rich"]
+# ///
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.environ["MISE_CONFIG_ROOT"] + "/lib")
+import harness
+import parse
+from format import STYLE_DIM, STYLE_ID, console, format_duration, make_table
+from usage import (
+    aggregate,
+    aggregate_by_model,
+    avg,
+    filter_records_by_date,
+    format_cost,
+    format_tokens,
+)
+
+session_query = os.environ.get("usage_session_id", "")
+today = os.environ.get("usage_today", "false") == "true"
+after = os.environ.get("usage_after", "")
+before = os.environ.get("usage_before", "")
+limit_raw = os.environ.get("usage_limit", "")
+project_filter = os.environ.get("usage_project", "")
+filter_raw = os.environ.get("usage_filter", "")
+scan_all = os.environ.get("usage_all", "false") == "true"
+show_turns = os.environ.get("usage_turns", "false") == "true"
+output_json = os.environ.get("usage_json", "false") == "true"
+
+if today:
+    after = before = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+try:
+    limit = int(limit_raw) if limit_raw else None
+except ValueError:
+    print("Error: --limit must be an integer", file=sys.stderr)
+    sys.exit(1)
+if limit is not None and limit < 1:
+    print("Error: --limit must be at least 1", file=sys.stderr)
+    sys.exit(1)
+
+filters = parse.parse_filters(filter_raw) if filter_raw else []
+
+
+def records_for_session(session, *, exit_on_unsupported=True):
+    try:
+        records = session.usage_records()
+    except harness.Unsupported as e:
+        if exit_on_unsupported:
+            harness.exit_unsupported(e.harness or "unknown", e.op)
+        return None
+    return filter_records_by_date(records, after=after, before=before)
+
+
+def session_summary(session, records):
+    meta = session.metadata()
+    totals = aggregate(records)
+    by_model = aggregate_by_model(records)
+    return {
+        "session_id": meta["session_id"],
+        "name": meta.get("name", ""),
+        "project": meta.get("project", ""),
+        "first_timestamp": meta.get("first_timestamp", ""),
+        "last_timestamp": meta.get("last_timestamp", ""),
+        "duration": format_duration(meta.get("first_timestamp", ""), meta.get("last_timestamp", "")),
+        "totals": totals,
+        "by_model": by_model,
+        "turns": records if show_turns else [],
+    }
+
+
+def usage_files():
+    files = []
+    for harness_name in harness.available():
+        adapter = harness.adapter(harness_name)
+        try:
+            root = adapter.sessions_dir()
+        except harness.Unsupported:
+            continue
+        if not os.path.isdir(root):
+            continue
+        for project_dir in os.listdir(root):
+            project_path = os.path.join(root, project_dir)
+            if not os.path.isdir(project_path):
+                continue
+            if project_filter and project_filter not in project_dir:
+                continue
+            for fname in os.listdir(project_path):
+                if not fname.endswith(".jsonl"):
+                    continue
+                if fname.startswith("agent-") and not scan_all:
+                    continue
+                filepath = os.path.join(project_path, fname)
+                files.append((os.path.getmtime(filepath), filepath))
+    files.sort(key=lambda item: -item[0])
+
+    if session_query or scan_all or today or after or before:
+        return [path for _mtime, path in files]
+    bounded = limit if limit is not None else 20
+    return [path for _mtime, path in files[:bounded]]
+
+
+def aggregate_summaries():
+    summaries = []
+    for filepath in usage_files():
+        try:
+            session = parse.load(filepath)
+            if filters and not parse.session_matches_filters(session, filters):
+                continue
+            records = records_for_session(session, exit_on_unsupported=False)
+            if not records:
+                continue
+            summaries.append(session_summary(session, records))
+        except harness.Unsupported:
+            continue
+        except Exception:
+            continue
+        if limit is not None and len(summaries) >= limit:
+            break
+    return summaries
+
+
+def combine_summaries(summaries):
+    combined = aggregate([])
+    combined_by_model = {}
+    for summary in summaries:
+        totals = summary["totals"]
+        combined["calls"] += totals["calls"]
+        for key in ("input", "output", "cacheRead", "cacheWrite", "totalTokens"):
+            combined[key] += totals[key]
+        for key, value in totals["cost"].items():
+            combined["cost"][key] += value
+
+        for key, group in summary["by_model"].items():
+            if key not in combined_by_model:
+                combined_by_model[key] = aggregate([])
+                combined_by_model[key]["model"] = group.get("model", "unknown")
+                combined_by_model[key]["provider"] = group.get("provider", "")
+            dest = combined_by_model[key]
+            dest["calls"] += group["calls"]
+            for token_key in ("input", "output", "cacheRead", "cacheWrite", "totalTokens"):
+                dest[token_key] += group[token_key]
+            for cost_key, value in group["cost"].items():
+                dest["cost"][cost_key] += value
+    return combined, combined_by_model
+
+
+def print_totals_table(totals):
+    table = make_table()
+    table.add_column("Metric", style="bold")
+    table.add_column("Value", justify="right")
+    table.add_row("Calls", format_tokens(totals["calls"]))
+    table.add_row("Input", format_tokens(totals["input"]))
+    table.add_row("Output", format_tokens(totals["output"]))
+    table.add_row("Cache read", format_tokens(totals["cacheRead"]))
+    table.add_row("Cache write", format_tokens(totals["cacheWrite"]))
+    table.add_row("Total tokens", format_tokens(totals["totalTokens"]))
+    table.add_row("Cost input", format_cost(totals["cost"]["input"]))
+    table.add_row("Cost output", format_cost(totals["cost"]["output"]))
+    table.add_row("Cost cache read", format_cost(totals["cost"]["cacheRead"]))
+    table.add_row("Cost cache write", format_cost(totals["cost"]["cacheWrite"]))
+    table.add_row("Cost total", format_cost(totals["cost"]["total"]))
+    if totals["calls"]:
+        table.add_row("Avg tokens/call", format_tokens(round(avg(totals["totalTokens"], totals["calls"]))))
+        table.add_row("Avg cost/call", format_cost(avg(totals["cost"]["total"], totals["calls"])))
+    console.print(table)
+
+
+def print_model_table(by_model):
+    if not by_model:
+        return
+    table = make_table()
+    table.add_column("Model", style="cyan")
+    table.add_column("Calls", justify="right")
+    table.add_column("Input", justify="right")
+    table.add_column("Output", justify="right")
+    table.add_column("Cache read", justify="right")
+    table.add_column("Total", justify="right")
+    table.add_column("Cost", justify="right")
+    for key, totals in sorted(by_model.items(), key=lambda item: -item[1]["cost"]["total"]):
+        table.add_row(
+            key,
+            format_tokens(totals["calls"]),
+            format_tokens(totals["input"]),
+            format_tokens(totals["output"]),
+            format_tokens(totals["cacheRead"]),
+            format_tokens(totals["totalTokens"]),
+            format_cost(totals["cost"]["total"]),
+        )
+    console.print(table)
+
+
+def print_turns_table(records):
+    if not records:
+        return
+    table = make_table()
+    table.add_column("Time", no_wrap=True)
+    table.add_column("Model", style="cyan")
+    table.add_column("Input", justify="right")
+    table.add_column("Output", justify="right")
+    table.add_column("Cache read", justify="right")
+    table.add_column("Total", justify="right")
+    table.add_column("Cost", justify="right")
+    for record in records:
+        provider = record.get("provider") or ""
+        model = record.get("model") or "unknown"
+        label = f"{provider}/{model}" if provider else model
+        table.add_row(
+            (record.get("timestamp") or "")[:19],
+            label,
+            format_tokens(record.get("input", 0)),
+            format_tokens(record.get("output", 0)),
+            format_tokens(record.get("cacheRead", 0)),
+            format_tokens(record.get("totalTokens", 0)),
+            format_cost((record.get("cost") or {}).get("total", 0.0)),
+        )
+    console.print(table)
+
+
+def print_session(summary):
+    console.print()
+    title = f"{summary['session_id'][:8]}  {summary['project']}"
+    console.print(title, style=STYLE_ID)
+    console.print(f"{summary['duration']}  ·  {summary['totals']['calls']} model calls", style=STYLE_DIM)
+    if not summary["totals"]["calls"]:
+        console.print("No recorded usage.", style=STYLE_DIM)
+        return
+    console.print("\nTotals", style="bold")
+    print_totals_table(summary["totals"])
+    console.print("\nBy model", style="bold")
+    print_model_table(summary["by_model"])
+    if show_turns:
+        console.print("\nTurns", style="bold")
+        print_turns_table(summary["turns"])
+
+
+def print_aggregate(summaries):
+    console.print()
+    console.print(f"Usage across {len(summaries)} session(s)", style=STYLE_ID)
+    if not summaries:
+        console.print("No recorded usage.", style=STYLE_DIM)
+        return
+
+    table = make_table()
+    table.add_column("ID", style="cyan", no_wrap=True)
+    table.add_column("Project")
+    table.add_column("Calls", justify="right")
+    table.add_column("Input", justify="right")
+    table.add_column("Output", justify="right")
+    table.add_column("Cache read", justify="right")
+    table.add_column("Total", justify="right")
+    table.add_column("Cost", justify="right")
+    for summary in summaries:
+        totals = summary["totals"]
+        table.add_row(
+            summary["session_id"][:8],
+            summary["project"],
+            format_tokens(totals["calls"]),
+            format_tokens(totals["input"]),
+            format_tokens(totals["output"]),
+            format_tokens(totals["cacheRead"]),
+            format_tokens(totals["totalTokens"]),
+            format_cost(totals["cost"]["total"]),
+        )
+    console.print(table)
+
+    totals, by_model = combine_summaries(summaries)
+    console.print("\nTotals", style="bold")
+    print_totals_table(totals)
+    console.print("\nBy model", style="bold")
+    print_model_table(by_model)
+
+
+if session_query:
+    session = parse.load(parse.find_session(session_query))
+    summary = session_summary(session, records_for_session(session))
+    if output_json:
+        print(json.dumps(summary, indent=2))
+    else:
+        print_session(summary)
+else:
+    summaries = aggregate_summaries()
+    if output_json:
+        totals, by_model = combine_summaries(summaries)
+        print(json.dumps({"sessions": summaries, "totals": totals, "by_model": by_model}, indent=2))
+    else:
+        print_aggregate(summaries)

--- a/.mise/tasks/usage
+++ b/.mise/tasks/usage
@@ -111,7 +111,7 @@ def usage_files():
                 files.append((os.path.getmtime(filepath), filepath))
     files.sort(key=lambda item: -item[0])
 
-    if session_query or scan_all or today or after or before:
+    if session_query or scan_all or today or after or before or filters:
         return [path for _mtime, path in files]
     bounded = limit if limit is not None else 20
     return [path for _mtime, path in files[:bounded]]

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 252 passing](https://img.shields.io/badge/tests-252%20passing-brightgreen?style=flat)](test/)
-![commands: 14](https://img.shields.io/badge/commands-14-blue?style=flat)
+[![tests: 259 passing](https://img.shields.io/badge/tests-259%20passing-brightgreen?style=flat)](test/)
+![commands: 15](https://img.shields.io/badge/commands-15-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
 </div>
@@ -24,6 +24,9 @@ Woke session 'review/pr-50'
 $ sessions read review/pr-50 --last 3
 ┃ assistant  Found 3 issues in error handling.
 ┃ assistant  Posted review to #scout-report.
+
+$ sessions usage review/pr-50
+┃ total  1.2M tokens  $0.84
 
 $ sessions list --filter session.meta.agent.name=ikma
   e96bd43a  review/pr-50   12m   3m ago   claude-sonnet-4   8
@@ -46,6 +49,9 @@ sessions read review/pr-50
 # Search across all sessions
 sessions search "error handling"
 
+# Show recorded token usage and cost
+sessions usage review/pr-50
+
 # Inspect forensic metadata
 sessions inspect e96bd43a
 ```
@@ -62,6 +68,7 @@ Sessions aren't just transcript files agents leave behind — they're managed ar
               └─ sessions run
                    └─ pi    harness — processes message or opens interactively
   sessions read             observe the transcript
+  sessions usage            inspect recorded tokens + costs
   sessions wake (again)     re-enter with corrections
 ```
 
@@ -166,6 +173,15 @@ sessions read e96bd43a --from -5           # last 5 messages
 sessions read e96bd43a --tools             # include tool calls
 ```
 
+`sessions usage` reports recorded token usage and cost. It works for one session, or across recent/date-filtered sessions, and attributes usage by the model active at each turn so model switches are visible.
+
+```bash
+sessions usage e96bd43a                  # one session summary
+sessions usage e96bd43a --turns          # per-turn records
+sessions usage --today                   # aggregate today's recorded usage
+sessions usage --after 2026-06-01 --json # machine-readable aggregate
+```
+
 For existing sessions you want to work with elsewhere, `copy` duplicates a session with its full conversation history plus a fork notice. The copy gets a new ID and can be woken independently — useful for handing off context between agents.
 
 ```bash
@@ -180,7 +196,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**252 tests** across 16 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, inspect, search). The JSONL parsing library is 485 lines of Python in `lib/`.
+**259 tests** across 17 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, usage, inspect, search). The JSONL parsing library is 559 lines of Python in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -193,6 +209,7 @@ sessions/
 │   ├── meta         # Read session header metadata
 │   ├── list         # List + filter sessions (Rich tables)
 │   ├── read         # Windowed transcript reader
+│   ├── usage        # Recorded token/cost aggregation
 │   ├── search       # Full-text regex across transcripts
 │   ├── inspect      # Forensic metadata (duration, tools, model)
 │   ├── copy         # Duplicate sessions for handoff
@@ -210,7 +227,7 @@ sessions/
 │   ├── shell.sh        # Shell helpers
 │   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats          # 252 tests
+    └── *.bats          # 259 tests
 ```
 
 </details>

--- a/README.tsx
+++ b/README.tsx
@@ -56,6 +56,9 @@ const lifecycle = [
   "┃ assistant  Found 3 issues in error handling.",
   "┃ assistant  Posted review to #scout-report.",
   "",
+  "$ sessions usage review/pr-50",
+  "┃ total  1.2M tokens  $0.84",
+  "",
   "$ sessions list --filter session.meta.agent.name=ikma",
   "  e96bd43a  review/pr-50   12m   3m ago   claude-sonnet-4   8",
 ].join("\n");
@@ -70,6 +73,7 @@ const stack = [
   "              └─ sessions run",
   "                   └─ pi    harness — processes message or opens interactively",
   "  sessions read             observe the transcript",
+  "  sessions usage            inspect recorded tokens + costs",
   "  sessions wake (again)     re-enter with corrections",
 ].join("\n");
 
@@ -134,6 +138,9 @@ sessions read review/pr-50
 
 # Search across all sessions
 sessions search "error handling"
+
+# Show recorded token usage and cost
+sessions usage review/pr-50
 
 # Inspect forensic metadata
 sessions inspect e96bd43a`}</CodeBlock>
@@ -295,6 +302,16 @@ sessions read e96bd43a --from -5           # last 5 messages
 sessions read e96bd43a --tools             # include tool calls`}</CodeBlock>
 
       <Paragraph>
+        <Code>sessions usage</Code>
+        {" reports recorded token usage and cost. It works for one session, or across recent/date-filtered sessions, and attributes usage by the model active at each turn so model switches are visible."}
+      </Paragraph>
+
+      <CodeBlock lang="bash">{`sessions usage e96bd43a                  # one session summary
+sessions usage e96bd43a --turns          # per-turn records
+sessions usage --today                   # aggregate today's recorded usage
+sessions usage --after 2026-06-01 --json # machine-readable aggregate`}</CodeBlock>
+
+      <Paragraph>
         {"For existing sessions you want to work with elsewhere, "}
         <Code>copy</Code>
         {" duplicates a session with its full conversation history plus a fork notice. The copy gets a new ID and can be woken independently — useful for handing off context between agents."}
@@ -314,7 +331,7 @@ mise run test`}</CodeBlock>
         <Link href="https://github.com/bats-core/bats-core">{`BATS ${batsVersion}`}</Link>
         {`. Tasks are bash scripts (session creation, wake, metadata) and Python scripts with `}
         <Link href="https://github.com/Textualize/rich">Rich</Link>
-        {` output (list, read, inspect, search). The JSONL parsing library is ${libLines} lines of Python in `}
+        {` output (list, read, usage, inspect, search). The JSONL parsing library is ${libLines} lines of Python in `}
         <Code>lib/</Code>
         {"."}
       </Paragraph>
@@ -327,6 +344,7 @@ mise run test`}</CodeBlock>
 │   ├── meta         # Read session header metadata
 │   ├── list         # List + filter sessions (Rich tables)
 │   ├── read         # Windowed transcript reader
+│   ├── usage        # Recorded token/cost aggregation
 │   ├── search       # Full-text regex across transcripts
 │   ├── inspect      # Forensic metadata (duration, tools, model)
 │   ├── copy         # Duplicate sessions for handoff

--- a/lib/harness/claude.py
+++ b/lib/harness/claude.py
@@ -62,6 +62,10 @@ def text_messages(entries: list) -> list:
     raise Unsupported("text_messages", harness="claude")
 
 
+def usage_records(entries: list) -> list:
+    raise Unsupported("usage", harness="claude")
+
+
 # --- Location / lookup ---
 
 def sessions_dir() -> str:

--- a/lib/harness/pi.py
+++ b/lib/harness/pi.py
@@ -91,6 +91,71 @@ def model(entries: list) -> str:
     return "unknown"
 
 
+def usage_records(entries: list) -> list:
+    """Normalize pi per-assistant-message usage records.
+
+    Pi stores usage on assistant message entries as ``message.usage``. Model
+    attribution is per record because sessions can switch models midway.
+    Prefer the assistant message's explicit model/provider, falling back to the
+    latest preceding model_change entry, then ``unknown``.
+    """
+    records = []
+    current_model = "unknown"
+    current_provider = ""
+
+    for idx, entry in enumerate(entries):
+        etype = entry.get("type")
+        if etype == "model_change":
+            current_model = entry.get("modelId") or current_model or "unknown"
+            current_provider = entry.get("provider") or current_provider
+            continue
+
+        if etype != "message":
+            continue
+        msg = entry.get("message", {})
+        if msg.get("role") != "assistant":
+            continue
+        usage = msg.get("usage")
+        if not isinstance(usage, dict):
+            continue
+
+        cost = usage.get("cost") if isinstance(usage.get("cost"), dict) else {}
+        records.append({
+            "index": idx,
+            "timestamp": entry.get("timestamp", ""),
+            "provider": msg.get("provider") or current_provider or "",
+            "model": msg.get("model") or current_model or "unknown",
+            "input": _number(usage.get("input")),
+            "output": _number(usage.get("output")),
+            "cacheRead": _number(usage.get("cacheRead")),
+            "cacheWrite": _number(usage.get("cacheWrite")),
+            "totalTokens": _number(usage.get("totalTokens")),
+            "cost": {
+                "input": _float(cost.get("input")),
+                "output": _float(cost.get("output")),
+                "cacheRead": _float(cost.get("cacheRead")),
+                "cacheWrite": _float(cost.get("cacheWrite")),
+                "total": _float(cost.get("total")),
+            },
+        })
+
+    return records
+
+
+def _number(value) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def project(filepath: str) -> str:
     """Decode pi's project directory name into a readable owner/repo path.
 

--- a/lib/parse.py
+++ b/lib/parse.py
@@ -102,6 +102,9 @@ class Session:
     def text_messages(self) -> list:
         return self._h.text_messages(self.entries)
 
+    def usage_records(self) -> list:
+        return self._h.usage_records(self.entries)
+
 
 # --- Generic helpers (harness-agnostic) ---
 

--- a/lib/usage.py
+++ b/lib/usage.py
@@ -1,0 +1,70 @@
+"""Shared helpers for aggregating normalized session usage records."""
+
+TOKEN_KEYS = ("input", "output", "cacheRead", "cacheWrite", "totalTokens")
+COST_KEYS = ("input", "output", "cacheRead", "cacheWrite", "total")
+
+
+def empty_totals() -> dict:
+    return {
+        "calls": 0,
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheWrite": 0,
+        "totalTokens": 0,
+        "cost": {k: 0.0 for k in COST_KEYS},
+    }
+
+
+def add_record(totals: dict, record: dict) -> None:
+    totals["calls"] += 1
+    for key in TOKEN_KEYS:
+        totals[key] += int(record.get(key) or 0)
+    cost = record.get("cost") or {}
+    for key in COST_KEYS:
+        totals["cost"][key] += float(cost.get(key) or 0.0)
+
+
+def aggregate(records: list) -> dict:
+    totals = empty_totals()
+    for record in records:
+        add_record(totals, record)
+    return totals
+
+
+def aggregate_by_model(records: list) -> dict:
+    groups = {}
+    for record in records:
+        model = record.get("model") or "unknown"
+        provider = record.get("provider") or ""
+        key = f"{provider}/{model}" if provider else model
+        if key not in groups:
+            groups[key] = empty_totals()
+            groups[key]["model"] = model
+            groups[key]["provider"] = provider
+        add_record(groups[key], record)
+    return groups
+
+
+def filter_records_by_date(records: list, after: str = "", before: str = "") -> list:
+    filtered = []
+    for record in records:
+        day = (record.get("timestamp") or "")[:10]
+        if after and day < after:
+            continue
+        if before and day > before:
+            continue
+        filtered.append(record)
+    return filtered
+
+
+def format_tokens(value: int) -> str:
+    return f"{int(value):,}"
+
+
+def format_cost(value: float) -> str:
+    return f"${value:,.4f}" if abs(value) < 100 else f"${value:,.2f}"
+
+
+def avg(value, calls: int):
+    return value / calls if calls else 0

--- a/test/usage.bats
+++ b/test/usage.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+
+load helpers
+
+setup() {
+  setup_test_sessions
+  USAGE_SESSION="99999999-aaaa-bbbb-cccc-dddddddddddd"
+  export USAGE_SESSION
+  USAGE_SESSION_2="88888888-aaaa-bbbb-cccc-dddddddddddd"
+  export USAGE_SESSION_2
+  CLAUDE_USAGE_SESSION="77777777-aaaa-bbbb-cccc-dddddddddddd"
+  export CLAUDE_USAGE_SESSION
+
+  cat > "${PROJECT_DIR}2026-03-14T12-00-00-000Z_${USAGE_SESSION}.jsonl" <<JSONL
+{"type":"session","version":3,"id":"${USAGE_SESSION}","timestamp":"2026-03-14T12:00:00.000Z","cwd":"/test/project","meta":{"agent":{"name":"usage-tester"}}}
+{"type":"model_change","id":"mc1","parentId":null,"timestamp":"2026-03-14T12:00:00.001Z","provider":"openai","modelId":"model-a"}
+{"type":"message","id":"a1","parentId":"mc1","timestamp":"2026-03-14T12:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"first"}],"provider":"openai","stopReason":"stop","usage":{"input":100,"output":20,"cacheRead":1000,"cacheWrite":0,"totalTokens":1120,"cost":{"input":0.10,"output":0.20,"cacheRead":0.01,"cacheWrite":0,"total":0.31}}}}
+{"type":"model_change","id":"mc2","parentId":"a1","timestamp":"2026-03-14T12:01:00.000Z","provider":"local","modelId":"model-b"}
+{"type":"message","id":"a2","parentId":"mc2","timestamp":"2026-03-14T12:01:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"second"}],"stopReason":"stop","usage":{"input":50,"output":10,"cacheRead":0,"cacheWrite":0,"totalTokens":60,"cost":{"input":0.05,"output":0.01,"cacheRead":0,"cacheWrite":0,"total":0.06}}}}
+{"type":"message","id":"a3","parentId":"a2","timestamp":"2026-03-14T12:02:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"third"}],"provider":"explicit-provider","model":"explicit-c","stopReason":"stop","usage":{"input":25,"output":5,"cacheRead":0,"cacheWrite":0,"totalTokens":30,"cost":{"input":0.02,"output":0.01,"cacheRead":0,"cacheWrite":0,"total":0.03}}}}
+JSONL
+
+  cat > "${PROJECT_DIR}2026-03-15T12-00-00-000Z_${USAGE_SESSION_2}.jsonl" <<JSONL
+{"type":"session","version":3,"id":"${USAGE_SESSION_2}","timestamp":"2026-03-15T12:00:00.000Z","cwd":"/test/project"}
+{"type":"model_change","id":"mc1","parentId":null,"timestamp":"2026-03-15T12:00:00.001Z","provider":"openai","modelId":"model-a"}
+{"type":"message","id":"a1","parentId":"mc1","timestamp":"2026-03-15T12:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"aggregate"}],"model":"model-a","provider":"openai","stopReason":"stop","usage":{"input":7,"output":3,"cacheRead":0,"cacheWrite":0,"totalTokens":10,"cost":{"input":0.007,"output":0.003,"cacheRead":0,"cacheWrite":0,"total":0.01}}}}
+JSONL
+
+  cat > "${PROJECT_DIR}2026-03-16T12-00-00-000Z_${CLAUDE_USAGE_SESSION}.jsonl" <<JSONL
+{"type":"session","version":3,"id":"${CLAUDE_USAGE_SESSION}","timestamp":"2026-03-16T12:00:00.000Z","cwd":"/test/project"}
+{"type":"harness","name":"claude","timestamp":"2026-03-16T12:00:00.001Z"}
+JSONL
+}
+
+teardown() { teardown_test_sessions; }
+
+@test "usage summarizes a single session as JSON" {
+  run sessions usage "$USAGE_SESSION" --json
+
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+obj = json.load(sys.stdin)
+assert obj['session_id'] == '$USAGE_SESSION'
+assert obj['totals']['calls'] == 3
+assert obj['totals']['input'] == 175
+assert obj['totals']['output'] == 35
+assert obj['totals']['cacheRead'] == 1000
+assert obj['totals']['totalTokens'] == 1210
+assert abs(obj['totals']['cost']['total'] - 0.40) < 0.000001
+"
+}
+
+@test "usage attributes records across model switches" {
+  run sessions usage "$USAGE_SESSION" --json
+
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+by = json.load(sys.stdin)['by_model']
+assert by['openai/model-a']['calls'] == 1
+assert by['local/model-b']['calls'] == 1
+assert by['explicit-provider/explicit-c']['calls'] == 1
+assert by['openai/model-a']['totalTokens'] == 1120
+assert by['local/model-b']['totalTokens'] == 60
+assert by['explicit-provider/explicit-c']['totalTokens'] == 30
+"
+}
+
+@test "usage --turns includes per-turn records" {
+  run sessions usage "$USAGE_SESSION" --json --turns
+
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+turns = json.load(sys.stdin)['turns']
+assert len(turns) == 3
+assert turns[0]['model'] == 'model-a'
+assert turns[1]['model'] == 'model-b'
+assert turns[2]['model'] == 'explicit-c'
+"
+}
+
+@test "usage reports sessions with no recorded usage" {
+  run sessions usage "$SESSION_1"
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "No recorded usage"
+}
+
+@test "usage aggregates date-filtered sessions" {
+  run sessions usage --after 2026-03-15 --before 2026-03-15 --project test-project --json
+
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+obj = json.load(sys.stdin)
+assert obj['totals']['calls'] == 1
+assert obj['totals']['input'] == 7
+assert obj['totals']['output'] == 3
+assert obj['totals']['totalTokens'] == 10
+assert len(obj['sessions']) == 1
+assert obj['sessions'][0]['session_id'] == '$USAGE_SESSION_2'
+"
+}
+
+@test "usage clears inherited optional usage defaults" {
+  run env \
+    usage_today=true \
+    usage_after=2099-01-01 \
+    usage_before=2099-01-01 \
+    usage_limit=1 \
+    usage_project=no-such-project \
+    usage_filter='session.meta.agent.name=nope' \
+    usage_all=true \
+    usage_turns=true \
+    usage_json=true \
+    bash -c 'sessions usage "$1"' _ "$USAGE_SESSION"
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Totals"
+  echo "$output" | grep -q "1,210"
+  ! echo "$output" | python3 -m json.tool >/dev/null 2>&1
+}
+
+@test "usage reports unsupported harness cleanly" {
+  run sessions usage "$CLAUDE_USAGE_SESSION"
+
+  [ "$status" -eq 10 ]
+  echo "$output" | grep -q "claude.*does not support.*usage"
+}

--- a/test/usage.bats
+++ b/test/usage.bats
@@ -104,6 +104,28 @@ assert obj['sessions'][0]['session_id'] == '$USAGE_SESSION_2'
 "
 }
 
+@test "usage applies metadata filters before the default aggregate limit" {
+  for i in $(seq -w 1 20); do
+    cat > "${PROJECT_DIR}2026-03-16T12-${i}-00-000Z_other-${i}.jsonl" <<JSONL
+{"type":"session","version":3,"id":"other-${i}","timestamp":"2026-03-16T12:${i}:00.000Z","cwd":"/test/project","meta":{"agent":{"name":"other"}}}
+{"type":"model_change","id":"mc1","parentId":null,"timestamp":"2026-03-16T12:${i}:00.001Z","provider":"openai","modelId":"model-a"}
+{"type":"message","id":"a1","parentId":"mc1","timestamp":"2026-03-16T12:${i}:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"other"}],"provider":"openai","model":"model-a","stopReason":"stop","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}}}}
+JSONL
+    touch "${PROJECT_DIR}2026-03-16T12-${i}-00-000Z_other-${i}.jsonl"
+  done
+
+  run sessions usage --filter session.meta.agent.name=usage-tester --json
+
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+obj = json.load(sys.stdin)
+assert len(obj['sessions']) == 1
+assert obj['sessions'][0]['session_id'] == '$USAGE_SESSION'
+assert obj['totals']['calls'] == 3
+"
+}
+
 @test "usage clears inherited optional usage defaults" {
   run env \
     usage_today=true \


### PR DESCRIPTION
Fix-it for KnickKnackLabs/sessions#99.

`usage` pre-bounded candidate files before applying metadata `--filter`, so a matching older session could disappear whenever the newest 20 sessions did not match. This makes filtered aggregate usage apply metadata filters before the default aggregate limit and adds a regression.

Validation:

- `mise run test usage`
- `python3 -m py_compile lib/usage.py lib/parse.py lib/harness/pi.py lib/harness/claude.py .mise/tasks/usage`
- `git diff --check origin/main...HEAD`
