### PR TITLE
Fix proc stat parsing for spaced process names

### DIFF
--- a/.mise/tasks/ps
+++ b/.mise/tasks/ps
@@ -1,0 +1,67 @@
+#!/usr/bin/env -S uv run --script
+#MISE description="Show live session processes"
+#USAGE flag "--limit <n>" default="20" help="Max process rows to show"
+#USAGE flag "--project <filter>" default="" help="Filter by project directory/name substring"
+#USAGE flag "--all" default=#false help="Include exited and dead process records"
+#USAGE flag "--json" default=#false help="Output as JSON"
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["rich"]
+# ///
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.environ["MISE_CONFIG_ROOT"] + "/lib")
+from format import console, format_model, format_relative, make_table
+from processes import collect_process_rows
+
+limit = int(os.environ.get("usage_limit", "20"))
+project_filter = os.environ.get("usage_project", "")
+include_all = os.environ.get("usage_all", "") == "true"
+output_json = os.environ.get("usage_json", "") == "true"
+
+rows = collect_process_rows(
+    limit=limit,
+    project_filter=project_filter,
+    include_all=include_all,
+)
+
+if output_json:
+    print(json.dumps([row.as_dict() for row in rows], indent=2))
+    sys.exit(0)
+
+if not rows:
+    print("No live session processes." if not include_all else "No session processes found.")
+    sys.exit(0)
+
+any_named = any(row.session.name for row in rows)
+
+table = make_table()
+table.add_column("ID", style="cyan", no_wrap=True)
+if any_named:
+    table.add_column("Name", style="green", no_wrap=True)
+table.add_column("Project", no_wrap=True)
+table.add_column("PID", justify="right", no_wrap=True)
+table.add_column("Status", no_wrap=True)
+table.add_column("Started", no_wrap=True)
+table.add_column("Model", style="dim", no_wrap=True)
+table.add_column("Command", style="dim")
+
+for row in rows:
+    data = row.as_dict()
+    row_values = [data["session_id"][:8]]
+    if any_named:
+        row_values.append(data.get("name") or "")
+    row_values.extend([
+        data["project"],
+        str(data.get("pid") or ""),
+        data["status"],
+        format_relative(data["started_at"]),
+        format_model(data.get("model", "")),
+        data.get("command", ""),
+    ])
+    table.add_row(*row_values)
+
+console.print(table)

--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -96,7 +96,10 @@ process_start_time_token_once() {
   local token=""
 
   if [ -r "/proc/$pid/stat" ]; then
-    if token=$(awk '{print $22}' "/proc/$pid/stat" 2>/dev/null); then
+    # /proc/<pid>/stat field 2 (comm) is parenthesized and may contain
+    # spaces, so split only after the final ") "; the remainder starts at
+    # field 3 (state), making starttime field 22 the 20th remaining field.
+    if token=$(awk '{ stat=$0; sub(/^.*\) /, "", stat); split(stat, fields, " "); print fields[20] }' "/proc/$pid/stat" 2>/dev/null); then
       if [ -n "$token" ]; then
         printf 'linux:%s\n' "$token"
         return 0

--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -29,8 +29,11 @@ PROMPT_TEMPLATES="${usage_prompt_templates:-false}"
 
 # shellcheck source=../../lib/harness-env.sh
 source "$MISE_CONFIG_ROOT/lib/harness-env.sh"
+# shellcheck source=../../lib/harness/dispatch.sh
+source "$MISE_CONFIG_ROOT/lib/harness/dispatch.sh"
 
 PROMPT_TEMP_FILE=""
+PROCESS_START_ID=""
 # shellcheck disable=SC2329  # Invoked by EXIT trap below.
 cleanup_prompt_temp() {
   if [ -n "$PROMPT_TEMP_FILE" ]; then
@@ -71,6 +74,104 @@ write_prompt_temp() {
   SYSTEM_PROMPT_FILE="$PROMPT_TEMP_FILE"
 }
 
+entry_id() {
+  uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8
+}
+
+now_iso() {
+  date -u +"%Y-%m-%dT%H:%M:%S.000Z"
+}
+
+latest_session_entry_id() {
+  local session_file="$1"
+  local entry_id=""
+  [ -f "$session_file" ] || return 0
+  if entry_id=$(tail -n 1 "$session_file" | jq -r '.id // empty' 2>/dev/null); then
+    printf '%s\n' "$entry_id"
+  fi
+}
+
+process_start_time_token_once() {
+  local pid="$1"
+  local token=""
+
+  if [ -r "/proc/$pid/stat" ]; then
+    if token=$(awk '{print $22}' "/proc/$pid/stat" 2>/dev/null); then
+      if [ -n "$token" ]; then
+        printf 'linux:%s\n' "$token"
+        return 0
+      fi
+    fi
+  fi
+
+  if command -v ps >/dev/null 2>&1; then
+    if token=$(ps -p "$pid" -o lstart= 2>/dev/null | awk '{$1=$1; print}'); then
+      if [ -n "$token" ]; then
+        printf 'ps:%s\n' "$token"
+        return 0
+      fi
+    fi
+  fi
+}
+
+process_start_time_token() {
+  local pid="$1"
+  local token=""
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    token=$(process_start_time_token_once "$pid")
+    if [ -n "$token" ]; then
+      printf '%s\n' "$token"
+      return 0
+    fi
+    sleep 0.05
+  done
+}
+
+record_process_start() {
+  local child_pid="$1"
+  shift
+  [ -n "$SESSION" ] || return 0
+  [ -f "$SESSION" ] || return 0
+
+  local parent_id ts pid_start_time harness_name command_text argv_json
+  parent_id=$(latest_session_entry_id "$SESSION")
+  ts=$(now_iso)
+  pid_start_time=$(process_start_time_token "$child_pid")
+  harness_name=$(harness_resolve --session "$SESSION" 2>/dev/null || echo "unknown")
+  argv_json=$(jq -nc --args '$ARGS.positional' -- "$@")
+  command_text=$(printf '%s ' "$@")
+  command_text="${command_text% }"
+  PROCESS_START_ID=$(entry_id)
+
+  process_start_entry \
+    "$PROCESS_START_ID" \
+    "$parent_id" \
+    "$ts" \
+    "$child_pid" \
+    "$pid_start_time" \
+    "$CWD" \
+    "$command_text" \
+    "$argv_json" \
+    "$harness_name" \
+    "$MODEL" \
+    "$HEADLESS" >> "$SESSION"
+}
+
+record_process_exit() {
+  local child_pid="$1"
+  local rc="$2"
+  [ -n "$SESSION" ] || return 0
+  [ -f "$SESSION" ] || return 0
+  [ -n "$PROCESS_START_ID" ] || return 0
+
+  local parent_id ts exit_id
+  parent_id=$(latest_session_entry_id "$SESSION")
+  ts=$(now_iso)
+  exit_id=$(entry_id)
+  process_exit_entry "$exit_id" "$parent_id" "$ts" "$PROCESS_START_ID" "$child_pid" "$rc" >> "$SESSION"
+}
+
 run_and_exit() {
   set +e
   (
@@ -78,6 +179,17 @@ run_and_exit() {
     exec "$@"
   ) <&0 &
   local child_pid=$!
+
+  if ! record_process_start "$child_pid" "$@"; then
+    echo "Error: failed to record process_start for session $SESSION" >&2
+    if ! kill "$child_pid" 2>/dev/null; then
+      :
+    fi
+    if ! wait "$child_pid" 2>/dev/null; then
+      :
+    fi
+    exit 1
+  fi
 
   # shellcheck disable=SC2329  # Invoked by signal traps below.
   forward_child_signal() {
@@ -93,6 +205,7 @@ run_and_exit() {
       sig_num=$(kill -l "$sig" 2>/dev/null || echo 0)
       rc=$((128 + sig_num))
     fi
+    record_process_exit "$child_pid" "$rc" || echo "Warning: failed to record process_exit for session $SESSION" >&2
     exit "$rc"
   }
 
@@ -104,6 +217,7 @@ run_and_exit() {
   wait "$child_pid"
   local rc=$?
   trap - INT TERM HUP QUIT
+  record_process_exit "$child_pid" "$rc" || echo "Warning: failed to record process_exit for session $SESSION" >&2
   set -e
   exit "$rc"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+## Harness boundary
+
+`sessions` has a generic core plus per-harness adapters.
+
+Keep these generic in core task/library code:
+
+- session-tool entries that harnesses ignore (`wake`, `harness`, `system_prompt`, `process_start`, `process_exit`);
+- task orchestration (`new`, `wake`, `run`, `ps`, `wait`, `usage`, etc.);
+- filtering, process-liveness checks, and output formatting that operate on generic entries.
+
+Keep harness-specific knowledge in `lib/harness/<name>.sh` and `lib/harness/<name>.py`:
+
+- session file locations and path encoding;
+- native JSONL message schemas;
+- launch arguments for a harness binary;
+- fallback parsing of harness-owned transcript/event shapes.
+
+For example, `sessions run` writes generic `process_start` / `process_exit` records, and `sessions ps` reads those generic records. If a future harness exposes its own process metadata, parse that in the harness adapter and convert it to the generic shape instead of baking the harness schema into `ps`.
+
+## Python mise tasks
+
+Python file tasks that need packages should use the uv/PEP 723 pattern:
+
+```python
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = ["rich"]
+# ///
+```
+
+Import shared repo libraries with:
+
+```python
+import os
+import sys
+sys.path.insert(0, os.environ["MISE_CONFIG_ROOT"] + "/lib")
+```
+
+Do not add a mise-managed `python` tool just because a task uses `uv run --script`; `uv` owns the script interpreter unless the repo has a separate reason to expose Python as a tool.
+
+## Validation
+
+Run targeted tests first, then the full suite before merge:
+
+```sh
+mise run test ps run lint
+mise run test
+readme build --check
+git diff --check
+```
+
+The BATS suite includes `test/lint.bats`, which runs the configured `[_.codebase].lint` subtasks individually. The installed `codebase` package may not expose an aggregate `lint` task, so use `codebase lint:<name>` for each configured lint.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 270 passing](https://img.shields.io/badge/tests-270%20passing-brightgreen?style=flat)](test/)
-![commands: 16](https://img.shields.io/badge/commands-16-blue?style=flat)
+[![tests: 275 passing](https://img.shields.io/badge/tests-275%20passing-brightgreen?style=flat)](test/)
+![commands: 17](https://img.shields.io/badge/commands-17-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
 </div>
@@ -27,6 +27,9 @@ $ sessions read review/pr-50 --last 3
 
 $ sessions wait review/pr-50 --assistant-only --timeout 120
 ┃ assistant  Re-ran CI; all checks are green.
+
+$ sessions ps
+  e96bd43a  ikma/den  12345  live  3m ago  openai-codex/gpt-5.5
 
 $ sessions usage review/pr-50
 ┃ total  1.2M tokens  $0.84
@@ -55,6 +58,9 @@ sessions wait review/pr-50 --assistant-only --timeout 120
 # Search across all sessions
 sessions search "error handling"
 
+# Show live local session processes
+sessions ps
+
 # Show recorded token usage and cost
 sessions usage review/pr-50
 
@@ -75,11 +81,14 @@ Sessions aren't just transcript files agents leave behind — they're managed ar
                    └─ pi    harness — processes message or opens interactively
   sessions read             observe the transcript
   sessions wait             block until new transcript messages arrive
+  sessions ps               show live local session processes
   sessions usage            inspect recorded tokens + costs
   sessions wake (again)     re-enter with corrections
 ```
 
 Each wake event is a first-class entry in the session file — timestamped, attributed, with its own metadata. A session that's been woken three times has three `wake` entries you can filter on. The full conversation history carries forward, so the agent sees everything that happened before.
+
+`sessions run` also records generic `process_start` / `process_exit` entries for managed sessions. `sessions ps` uses those entries plus PID start-time verification, so a missing exit entry from a crash does not make a stale or reused PID look live.
 
 ```bash
 # Create a named session with a baked system prompt, metadata, and context
@@ -191,6 +200,14 @@ sessions wait e96bd43a --tools                 # include tool calls/results
 sessions wait e96bd43a --timeout 120 --json
 ```
 
+`sessions ps` shows currently-live local session processes recorded by `sessions run`. By default it hides exited processes and dead missing-exit records; pass `--all` to inspect those records too.
+
+```bash
+sessions ps                  # live managed session processes
+sessions ps --project k7r2   # filter by project/session path
+sessions ps --all --json     # include exited/dead records
+```
+
 `sessions usage` reports recorded token usage and cost. It works for one session, or across recent/date-filtered sessions, and attributes usage by the model active at each turn so model switches are visible.
 
 ```bash
@@ -214,7 +231,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**270 tests** across 18 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The JSONL parsing library is 632 lines of Python in `lib/`.
+**275 tests** across 20 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 809 lines in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -228,6 +245,7 @@ sessions/
 │   ├── list         # List + filter sessions (Rich tables)
 │   ├── read         # Windowed transcript reader
 │   ├── wait         # Wait for new transcript messages
+│   ├── ps           # Live local process view
 │   ├── usage        # Recorded token/cost aggregation
 │   ├── search       # Full-text regex across transcripts
 │   ├── inspect      # Forensic metadata (duration, tools, model)
@@ -246,7 +264,7 @@ sessions/
 │   ├── shell.sh        # Shell helpers
 │   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats          # 270 tests
+    └── *.bats          # 275 tests
 ```
 
 </details>

--- a/README.tsx
+++ b/README.tsx
@@ -59,6 +59,9 @@ const lifecycle = [
   "$ sessions wait review/pr-50 --assistant-only --timeout 120",
   "┃ assistant  Re-ran CI; all checks are green.",
   "",
+  "$ sessions ps",
+  "  e96bd43a  ikma/den  12345  live  3m ago  openai-codex/gpt-5.5",
+  "",
   "$ sessions usage review/pr-50",
   "┃ total  1.2M tokens  $0.84",
   "",
@@ -77,6 +80,7 @@ const stack = [
   "                   └─ pi    harness — processes message or opens interactively",
   "  sessions read             observe the transcript",
   "  sessions wait             block until new transcript messages arrive",
+  "  sessions ps               show live local session processes",
   "  sessions usage            inspect recorded tokens + costs",
   "  sessions wake (again)     re-enter with corrections",
 ].join("\n");
@@ -146,6 +150,9 @@ sessions wait review/pr-50 --assistant-only --timeout 120
 # Search across all sessions
 sessions search "error handling"
 
+# Show live local session processes
+sessions ps
+
 # Show recorded token usage and cost
 sessions usage review/pr-50
 
@@ -168,6 +175,17 @@ sessions inspect e96bd43a`}</CodeBlock>
         {"Each wake event is a first-class entry in the session file — timestamped, attributed, with its own metadata. A session that's been woken three times has three "}
         <Code>wake</Code>
         {" entries you can filter on. The full conversation history carries forward, so the agent sees everything that happened before."}
+      </Paragraph>
+
+      <Paragraph>
+        <Code>sessions run</Code>
+        {" also records generic "}
+        <Code>process_start</Code>
+        {" / "}
+        <Code>process_exit</Code>
+        {" entries for managed sessions. "}
+        <Code>sessions ps</Code>
+        {" uses those entries plus PID start-time verification, so a missing exit entry from a crash does not make a stale or reused PID look live."}
       </Paragraph>
 
       <CodeBlock lang="bash">{`# Create a named session with a baked system prompt, metadata, and context
@@ -321,6 +339,19 @@ sessions wait e96bd43a --tools                 # include tool calls/results
 sessions wait e96bd43a --timeout 120 --json`}</CodeBlock>
 
       <Paragraph>
+        <Code>sessions ps</Code>
+        {" shows currently-live local session processes recorded by "}
+        <Code>sessions run</Code>
+        {". By default it hides exited processes and dead missing-exit records; pass "}
+        <Code>--all</Code>
+        {" to inspect those records too."}
+      </Paragraph>
+
+      <CodeBlock lang="bash">{`sessions ps                  # live managed session processes
+sessions ps --project k7r2   # filter by project/session path
+sessions ps --all --json     # include exited/dead records`}</CodeBlock>
+
+      <Paragraph>
         <Code>sessions usage</Code>
         {" reports recorded token usage and cost. It works for one session, or across recent/date-filtered sessions, and attributes usage by the model active at each turn so model switches are visible."}
       </Paragraph>
@@ -350,7 +381,7 @@ mise run test`}</CodeBlock>
         <Link href="https://github.com/bats-core/bats-core">{`BATS ${batsVersion}`}</Link>
         {`. Tasks are bash scripts (session creation, wake, metadata) and Python scripts with `}
         <Link href="https://github.com/Textualize/rich">Rich</Link>
-        {` output (list, read, wait, usage, inspect, search). The JSONL parsing library is ${libLines} lines of Python in `}
+        {` output (list, read, wait, usage, inspect, search). The shared Python support library is ${libLines} lines in `}
         <Code>lib/</Code>
         {"."}
       </Paragraph>
@@ -364,6 +395,7 @@ mise run test`}</CodeBlock>
 │   ├── list         # List + filter sessions (Rich tables)
 │   ├── read         # Windowed transcript reader
 │   ├── wait         # Wait for new transcript messages
+│   ├── ps           # Live local process view
 │   ├── usage        # Recorded token/cost aggregation
 │   ├── search       # Full-text regex across transcripts
 │   ├── inspect      # Forensic metadata (duration, tools, model)

--- a/lib/harness/dispatch.sh
+++ b/lib/harness/dispatch.sh
@@ -371,3 +371,86 @@ wake_entry() {
       }'"$model_fragment""$os_user_fragment"
   fi
 }
+
+# Process lifecycle entries — records the local process that `sessions run`
+# started for a managed session. Shape is uniform across harnesses: the
+# harness binaries ignore these entries; sessions owns the schema.
+#
+# Liveness rule for readers: a process is live only if both `.pid` exists and
+# the current OS process reports the same `.pid_start_time` token. This avoids
+# treating a reused PID as live after a wrapper crash or missing exit entry.
+#
+#   $1 entry_id, $2 parent_id, $3 timestamp_iso, $4 pid,
+#   $5 pid_start_time, $6 cwd, $7 command, $8 argv_json,
+#   $9 harness_name, $10 model, $11 headless ("true" | "false")
+process_start_entry() {
+  local entry_id="$1"
+  local parent_id="$2"
+  local ts="$3"
+  local pid="$4"
+  local pid_start_time="$5"
+  local cwd="$6"
+  local command="$7"
+  local argv_json="$8"
+  local harness_name="$9"
+  local model="${10:-}"
+  local headless="${11:-false}"
+
+  local headless_bool=false
+  [ "$headless" = "true" ] && headless_bool=true
+
+  jq -nc \
+    --arg id "$entry_id" \
+    --arg parent_id "$parent_id" \
+    --arg ts "$ts" \
+    --argjson pid "$pid" \
+    --arg pid_start_time "$pid_start_time" \
+    --arg cwd "$cwd" \
+    --arg command "$command" \
+    --argjson argv "$argv_json" \
+    --arg harness "$harness_name" \
+    --arg model "$model" \
+    --argjson headless "$headless_bool" \
+    '{
+      type: "process_start",
+      id: $id,
+      parentId: $parent_id,
+      timestamp: $ts,
+      pid: $pid,
+      pid_start_time: $pid_start_time,
+      cwd: $cwd,
+      command: $command,
+      argv: $argv,
+      harness: $harness,
+      model: $model,
+      headless: $headless
+    }'
+}
+
+#   $1 entry_id, $2 parent_id, $3 timestamp_iso, $4 process_start_id,
+#   $5 pid, $6 exit_code
+process_exit_entry() {
+  local entry_id="$1"
+  local parent_id="$2"
+  local ts="$3"
+  local process_start_id="$4"
+  local pid="$5"
+  local exit_code="$6"
+
+  jq -nc \
+    --arg id "$entry_id" \
+    --arg parent_id "$parent_id" \
+    --arg ts "$ts" \
+    --arg process_start_id "$process_start_id" \
+    --argjson pid "$pid" \
+    --argjson exit_code "$exit_code" \
+    '{
+      type: "process_exit",
+      id: $id,
+      parentId: $parent_id,
+      timestamp: $ts,
+      process_start_id: $process_start_id,
+      pid: $pid,
+      exit_code: $exit_code
+    }'
+}

--- a/lib/processes.py
+++ b/lib/processes.py
@@ -57,10 +57,16 @@ def process_start_time_token(pid: int) -> str:
     proc_stat = f"/proc/{pid}/stat"
     try:
         with open(proc_stat, encoding="utf-8") as f:
-            fields = f.read().split()
-        if len(fields) >= 22 and fields[21]:
-            return f"linux:{fields[21]}"
-    except OSError:
+            stat = f.read()
+        # /proc/<pid>/stat field 2 (comm) is parenthesized and may contain
+        # spaces, so plain split() shifts field 22 for executables like
+        # "sleep space". Strip through the final ") " first; the remainder
+        # starts at field 3 (state), making starttime field 22 index 19.
+        _, rest = stat.rsplit(") ", 1)
+        fields = rest.split()
+        if len(fields) >= 20 and fields[19]:
+            return f"linux:{fields[19]}"
+    except (OSError, ValueError):
         pass
 
     try:

--- a/lib/processes.py
+++ b/lib/processes.py
@@ -1,0 +1,176 @@
+"""Generic session process-lifecycle helpers.
+
+`sessions run` writes harness-agnostic ``process_start`` / ``process_exit``
+entries for managed sessions. This module turns those entries into process rows
+and verifies local liveness by checking both PID existence and the process start
+time token captured at launch.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from typing import Iterator
+
+import harness
+import parse
+
+
+@dataclass
+class ProcessRow:
+    session: parse.Session
+    filepath: str
+    start: dict
+    exit: dict | None
+    status: str
+
+    def as_dict(self) -> dict:
+        meta = self.session.metadata()
+        result = {
+            "session_id": meta["session_id"],
+            "name": meta.get("name", ""),
+            "project": meta["project"],
+            "filepath": self.filepath,
+            "process_start_id": self.start.get("id", ""),
+            "pid": self.start.get("pid"),
+            "pid_start_time": self.start.get("pid_start_time", ""),
+            "status": self.status,
+            "started_at": self.start.get("timestamp", ""),
+            "cwd": self.start.get("cwd", ""),
+            "command": self.start.get("command", ""),
+            "argv": self.start.get("argv", []),
+            "harness": self.start.get("harness", ""),
+            "model": self.start.get("model", meta.get("model", "")),
+            "headless": self.start.get("headless", False),
+        }
+        if self.exit is not None:
+            result.update({
+                "exited_at": self.exit.get("timestamp", ""),
+                "exit_code": self.exit.get("exit_code"),
+            })
+        return result
+
+
+def process_start_time_token(pid: int) -> str:
+    """Return the same PID start token that `.mise/tasks/run` records."""
+    proc_stat = f"/proc/{pid}/stat"
+    try:
+        with open(proc_stat, encoding="utf-8") as f:
+            fields = f.read().split()
+        if len(fields) >= 22 and fields[21]:
+            return f"linux:{fields[21]}"
+    except OSError:
+        pass
+
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "lstart="],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+
+    if result.returncode != 0:
+        return ""
+    normalized = " ".join(result.stdout.split())
+    return f"ps:{normalized}" if normalized else ""
+
+
+def process_is_live(start: dict) -> bool:
+    try:
+        pid = int(start.get("pid"))
+    except (TypeError, ValueError):
+        return False
+
+    expected = start.get("pid_start_time", "")
+    if not expected:
+        return False
+
+    return process_start_time_token(pid) == expected
+
+
+def iter_session_files() -> Iterator[str]:
+    for name in harness.available():
+        adapter = harness.adapter(name)
+        try:
+            sessions_dir = adapter.sessions_dir()
+        except harness.Unsupported:
+            continue
+        if not sessions_dir or not os.path.isdir(sessions_dir):
+            continue
+        for project_dir in os.listdir(sessions_dir):
+            project_path = os.path.join(sessions_dir, project_dir)
+            if not os.path.isdir(project_path):
+                continue
+            for fname in os.listdir(project_path):
+                if not fname.endswith(".jsonl"):
+                    continue
+                yield os.path.join(project_path, fname)
+
+
+def session_process_rows(
+    filepath: str,
+    *,
+    project_filter: str = "",
+    include_all: bool = False,
+) -> list[ProcessRow]:
+    session = parse.load(filepath)
+    meta = session.metadata()
+    if project_filter and project_filter not in meta["project"] and project_filter not in filepath:
+        return []
+
+    starts: list[dict] = []
+    exits_by_start: dict[str, dict] = {}
+    for entry in session.entries:
+        etype = entry.get("type")
+        if etype == "process_start":
+            starts.append(entry)
+        elif etype == "process_exit":
+            start_id = entry.get("process_start_id")
+            if start_id:
+                exits_by_start[start_id] = entry
+
+    rows: list[ProcessRow] = []
+    for start in starts:
+        exit_entry = exits_by_start.get(start.get("id", ""))
+        if exit_entry is not None:
+            status = "exited"
+        elif process_is_live(start):
+            status = "live"
+        else:
+            status = "dead"
+
+        if include_all or status == "live":
+            rows.append(ProcessRow(
+                session=session,
+                filepath=filepath,
+                start=start,
+                exit=exit_entry,
+                status=status,
+            ))
+    return rows
+
+
+def collect_process_rows(
+    *,
+    limit: int = 20,
+    project_filter: str = "",
+    include_all: bool = False,
+) -> list[ProcessRow]:
+    rows: list[ProcessRow] = []
+    for filepath in iter_session_files():
+        try:
+            rows.extend(session_process_rows(
+                filepath,
+                project_filter=project_filter,
+                include_all=include_all,
+            ))
+        except Exception:
+            continue
+
+    rows.sort(key=lambda row: row.start.get("timestamp", ""), reverse=True)
+    return rows[:limit]

--- a/test/lint.bats
+++ b/test/lint.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "configured codebase lints pass" {
+  local lints
+  lints=$(python3 - "$REPO_DIR/mise.toml" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as f:
+    config = tomllib.load(f)
+
+for lint in config.get("_", {}).get("codebase", {}).get("lint", []):
+    print(lint)
+PY
+)
+  [ -n "$lints" ]
+
+  local lint
+  while IFS= read -r lint; do
+    [ -n "$lint" ]
+    run bash -c 'cd "$1" && mise exec codebase -- codebase "lint:$2" "$1"' bash "$REPO_DIR" "$lint"
+    if [ "$status" -ne 0 ]; then
+      echo "lint:$lint failed"
+      echo "$output"
+      return 1
+    fi
+  done <<< "$lints"
+}

--- a/test/ps.bats
+++ b/test/ps.bats
@@ -12,7 +12,7 @@ process_start_token_for_pid() {
   local pid="$1"
   local token=""
   if [ -r "/proc/$pid/stat" ]; then
-    token=$(awk '{print $22}' "/proc/$pid/stat")
+    token=$(awk '{ stat=$0; sub(/^.*\) /, "", stat); split(stat, fields, " "); print fields[20] }' "/proc/$pid/stat")
     if [ -n "$token" ]; then
       printf 'linux:%s\n' "$token"
       return 0
@@ -50,6 +50,39 @@ assert row["process_start_id"] == "p-live", row
 assert row["status"] == "live", row
 assert row["pid"] > 0, row
 '
+}
+
+@test "ps handles Linux process names containing spaces" {
+  if [ ! -d /proc ]; then
+    skip "Linux /proc-only regression"
+  fi
+
+  local session_file sleep_bin spaced_sleep pid token
+  session_file=$(session_file_for "$SESSION_1")
+  sleep_bin=$(command -v sleep)
+  spaced_sleep="$BATS_TEST_TMPDIR/sleep space"
+  ln -s "$sleep_bin" "$spaced_sleep"
+  "$spaced_sleep" 5 &
+  pid=$!
+  token=$(process_start_token_for_pid "$pid")
+  [ -n "$token" ]
+
+  cat >> "$session_file" <<JSONL
+{"type":"process_start","id":"p-spaced","parentId":"u4","timestamp":"2026-03-14T10:31:00.000Z","pid":$pid,"pid_start_time":"$token","cwd":"$BATS_TEST_TMPDIR","command":"sleep space","harness":"pi","model":"openai-codex/gpt-5.5","headless":false}
+JSONL
+
+  run sessions ps --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c '
+import json, sys
+rows = json.load(sys.stdin)
+assert len(rows) == 1, rows
+assert rows[0]["process_start_id"] == "p-spaced", rows
+assert rows[0]["status"] == "live", rows
+'
+
+  kill "$pid"
+  wait "$pid" 2>/dev/null || true
 }
 
 @test "ps hides dead missing-exit processes by default" {

--- a/test/ps.bats
+++ b/test/ps.bats
@@ -1,0 +1,127 @@
+#!/usr/bin/env bats
+
+load helpers
+
+setup() {
+  setup_test_sessions
+  sessions ps --json >/dev/null 2>&1
+}
+teardown() { teardown_test_sessions; }
+
+process_start_token_for_pid() {
+  local pid="$1"
+  local token=""
+  if [ -r "/proc/$pid/stat" ]; then
+    token=$(awk '{print $22}' "/proc/$pid/stat")
+    if [ -n "$token" ]; then
+      printf 'linux:%s\n' "$token"
+      return 0
+    fi
+  fi
+  token=$(ps -p "$pid" -o lstart= 2>/dev/null | awk '{$1=$1; print}')
+  if [ -n "$token" ]; then
+    printf 'ps:%s\n' "$token"
+  fi
+}
+
+session_file_for() {
+  local session_id="$1"
+  find "$PROJECT_DIR" -name "*${session_id}.jsonl" | head -1
+}
+
+@test "ps --json shows live process with matching pid start time" {
+  local session_file token
+  session_file=$(session_file_for "$SESSION_1")
+  token=$(process_start_token_for_pid "$$")
+  [ -n "$token" ]
+
+  cat >> "$session_file" <<JSONL
+{"type":"process_start","id":"p-live","parentId":"u4","timestamp":"2026-03-14T10:31:00.000Z","pid":$$,"pid_start_time":"$token","cwd":"$BATS_TEST_TMPDIR","command":"bash","harness":"pi","model":"openai-codex/gpt-5.5","headless":false}
+JSONL
+
+  run sessions ps --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c '
+import json, sys
+rows = json.load(sys.stdin)
+assert len(rows) == 1, rows
+row = rows[0]
+assert row["process_start_id"] == "p-live", row
+assert row["status"] == "live", row
+assert row["pid"] > 0, row
+'
+}
+
+@test "ps hides dead missing-exit processes by default" {
+  local session_file
+  session_file=$(session_file_for "$SESSION_1")
+  cat >> "$session_file" <<JSONL
+{"type":"process_start","id":"p-dead","parentId":"u4","timestamp":"2026-03-14T10:31:00.000Z","pid":999999,"pid_start_time":"ps:not a real process","cwd":"$BATS_TEST_TMPDIR","command":"missing","harness":"pi","model":"openai-codex/gpt-5.5","headless":true}
+JSONL
+
+  run sessions ps --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c 'import json, sys; assert json.load(sys.stdin) == []'
+
+  run sessions ps --all --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c '
+import json, sys
+rows = json.load(sys.stdin)
+assert len(rows) == 1, rows
+assert rows[0]["process_start_id"] == "p-dead", rows
+assert rows[0]["status"] == "dead", rows
+'
+}
+
+@test "ps treats exited process records as not live even if pid still exists" {
+  local session_file token
+  session_file=$(session_file_for "$SESSION_1")
+  token=$(process_start_token_for_pid "$$")
+  [ -n "$token" ]
+
+  cat >> "$session_file" <<JSONL
+{"type":"process_start","id":"p-exited","parentId":"u4","timestamp":"2026-03-14T10:31:00.000Z","pid":$$,"pid_start_time":"$token","cwd":"$BATS_TEST_TMPDIR","command":"bash","harness":"pi","model":"openai-codex/gpt-5.5","headless":false}
+{"type":"process_exit","id":"x-exited","parentId":"p-exited","timestamp":"2026-03-14T10:32:00.000Z","process_start_id":"p-exited","pid":$$,"exit_code":0}
+JSONL
+
+  run sessions ps --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c 'import json, sys; assert json.load(sys.stdin) == []'
+
+  run sessions ps --all --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c '
+import json, sys
+rows = json.load(sys.stdin)
+assert len(rows) == 1, rows
+assert rows[0]["process_start_id"] == "p-exited", rows
+assert rows[0]["status"] == "exited", rows
+assert rows[0]["exit_code"] == 0, rows
+'
+}
+
+@test "run writes process_start and process_exit for managed sessions" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-process-events"
+  local prompt="$BATS_TEST_TMPDIR/prompt.md"
+  local session_file
+  mkdir -p "$stub_dir"
+  echo "test prompt" > "$prompt"
+  cat > "$stub_dir/pi" <<'STUB'
+#!/usr/bin/env bash
+sleep 0.2
+exit 0
+STUB
+  chmod +x "$stub_dir/pi"
+  session_file=$(session_file_for "$SESSION_1")
+
+  PATH="$stub_dir:$PATH" run sessions run \
+    --system-prompt-file "$prompt" \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5" \
+    --session "$session_file"
+  [ "$status" -eq 0 ]
+
+  jq -s -e 'any(.[]; .type == "process_start" and .pid > 0 and (.pid_start_time | length > 0) and .harness == "pi" and (.argv | length > 0))' "$session_file" >/dev/null
+  jq -s -e 'any(.[]; .type == "process_exit" and .exit_code == 0)' "$session_file" >/dev/null
+}


### PR DESCRIPTION
## Summary

- parse Linux `/proc/<pid>/stat` by stripping the parenthesized `comm` field before selecting starttime
- keep the Bash recorder and Python liveness reader in sync
- add a Linux regression with a live process whose executable name contains a space

## Validation

- `bash -n .mise/tasks/run && python3 -m py_compile lib/processes.py`
- `mise run test ps`
- `mise run test lint`
- `git diff --check origin/k7r2/sessions-ps...HEAD`
