### PR TITLE
run: allow promptless agent sessions

### DIFF
--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -3,7 +3,7 @@
 #MISE quiet=true
 #MISE hide=true
 #USAGE arg "[message]" default="" help="Message for the agent (required for --headless, optional for interactive)"
-#USAGE flag "--system-prompt-file <file>" default="" help="Path to system prompt file"
+#USAGE flag "--system-prompt-file <file>" default="" help="Optional path to appended system prompt text"
 #USAGE flag "--timeout <seconds>" default="" help="Timeout in seconds (default: no timeout)"
 #USAGE flag "--model <model>" default="" help="Model to use (required; provider-qualified, e.g. openai-codex/gpt-5.5)"
 #USAGE flag "--session <session>" default="" help="Session file for conversation continuity"
@@ -189,13 +189,13 @@ run_and_exit() {
 
 if [ "$HEADLESS" = "true" ] && [ -z "$MESSAGE" ]; then
   echo "Error: --headless requires a message" >&2
-  echo "Usage: sessions run --headless --system-prompt-file <path> --model <provider/model> [options] \"message\"" >&2
+  echo "Usage: sessions run --headless --model <provider/model> [options] \"message\"" >&2
   exit 1
 fi
 
 if [ -z "$MODEL" ]; then
   echo "Error: --model is required" >&2
-  echo "Usage: sessions run --system-prompt-file <path> --model <provider/model> [options] \"message\"" >&2
+  echo "Usage: sessions run --model <provider/model> [options] \"message\"" >&2
   exit 1
 fi
 
@@ -208,6 +208,7 @@ fi
 #   1. Explicit --system-prompt-file
 #   2. Latest system_prompt entry baked into --session by `sessions new`
 #   3. Legacy AGENT_IDENTITY environment fallback
+#   4. No prompt — let the harness load cwd context files naturally
 if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "$SESSION" ]; then
   if SESSION_SYSTEM_PROMPT=$(latest_session_system_prompt "$SESSION"); then
     write_prompt_temp "$SESSION_SYSTEM_PROMPT"
@@ -224,13 +225,21 @@ if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "${AGENT_IDENTITY:-}" ]; then
   write_prompt_temp "$AGENT_IDENTITY"
 fi
 
-if [ -z "$SYSTEM_PROMPT_FILE" ]; then
-  echo "Error: system prompt required (--system-prompt-file, session system_prompt, or AGENT_IDENTITY)" >&2
+if [ -n "$SYSTEM_PROMPT_FILE" ] && [ ! -f "$SYSTEM_PROMPT_FILE" ]; then
+  echo "Error: System prompt file not found: $SYSTEM_PROMPT_FILE" >&2
   exit 1
 fi
 
-# Append dispatch context (outside the conditional — applies to any prompt file)
-if [ -n "${DISPATCH_CONTEXT:-}" ] && [ -n "$SYSTEM_PROMPT_FILE" ]; then
+ensure_prompt_temp() {
+  if [ -z "$SYSTEM_PROMPT_FILE" ]; then
+    write_prompt_temp ""
+  fi
+}
+
+# Append dispatch context when present. If no identity/profile prompt exists,
+# create a tiny session-context prompt rather than requiring AGENT_IDENTITY.
+if [ -n "${DISPATCH_CONTEXT:-}" ]; then
+  ensure_prompt_temp
   {
     echo ""
     echo "## Dispatch Context"
@@ -238,9 +247,10 @@ if [ -n "${DISPATCH_CONTEXT:-}" ] && [ -n "$SYSTEM_PROMPT_FILE" ]; then
   } >> "$SYSTEM_PROMPT_FILE"
 fi
 
-# Append headless session context (outside the conditional — applies whether
-# the prompt was auto-generated from AGENT_IDENTITY or user-provided via --system-prompt-file)
-if [ "$HEADLESS" = "true" ] && [ -n "$SYSTEM_PROMPT_FILE" ]; then
+# Append headless session context. This is runtime context, not agent identity;
+# promptless headless runs still get the no-human cue without AGENT_IDENTITY.
+if [ "$HEADLESS" = "true" ]; then
+  ensure_prompt_temp
   cat >> "$SYSTEM_PROMPT_FILE" <<'HEADLESS_EOF'
 
 ## Session Context
@@ -249,11 +259,6 @@ HEADLESS_EOF
 fi
 
 run_interactive_without_message() {
-  if [ ! -f "$SYSTEM_PROMPT_FILE" ]; then
-    echo "Error: System prompt file not found: $SYSTEM_PROMPT_FILE" >&2
-    exit 1
-  fi
-
   # shellcheck source=../../lib/harness/dispatch.sh
   source "$MISE_CONFIG_ROOT/lib/harness/dispatch.sh"
 
@@ -276,7 +281,10 @@ run_interactive_without_message() {
     exit 1
   fi
 
-  local pi_args=(--append-system-prompt "$SYSTEM_PROMPT_FILE" --model "$MODEL")
+  local pi_args=(--model "$MODEL")
+  if [ -n "$SYSTEM_PROMPT_FILE" ]; then
+    pi_args=(--append-system-prompt "$SYSTEM_PROMPT_FILE" "${pi_args[@]}")
+  fi
   if [ -n "$SESSION" ]; then
     pi_args+=(--session "$SESSION")
   else
@@ -302,7 +310,8 @@ fi
 CLI_DIR="$MISE_CONFIG_ROOT/cli"
 
 # Build CLI args
-CLI_ARGS=(--system-prompt-file "$SYSTEM_PROMPT_FILE" --cwd "$CWD")
+CLI_ARGS=(--cwd "$CWD")
+[ -n "$SYSTEM_PROMPT_FILE" ] && CLI_ARGS+=(--system-prompt-file "$SYSTEM_PROMPT_FILE")
 
 [ -n "$TIMEOUT" ] && CLI_ARGS+=(--timeout "$TIMEOUT")
 CLI_ARGS+=(--model "$MODEL")

--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -207,8 +207,7 @@ fi
 # Prompt resolution order:
 #   1. Explicit --system-prompt-file
 #   2. Latest system_prompt entry baked into --session by `sessions new`
-#   3. Legacy AGENT_IDENTITY environment fallback
-#   4. No prompt — let the harness load cwd context files naturally
+#   3. No prompt — let the harness load cwd context files naturally
 if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "$SESSION" ]; then
   if SESSION_SYSTEM_PROMPT=$(latest_session_system_prompt "$SESSION"); then
     write_prompt_temp "$SESSION_SYSTEM_PROMPT"
@@ -219,10 +218,6 @@ if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "$SESSION" ]; then
     fi
   fi
   unset SESSION_SYSTEM_PROMPT SESSION_PROMPT_STATUS
-fi
-
-if [ -z "$SYSTEM_PROMPT_FILE" ] && [ -n "${AGENT_IDENTITY:-}" ]; then
-  write_prompt_temp "$AGENT_IDENTITY"
 fi
 
 if [ -n "$SYSTEM_PROMPT_FILE" ] && [ ! -f "$SYSTEM_PROMPT_FILE" ]; then
@@ -236,8 +231,8 @@ ensure_prompt_temp() {
   fi
 }
 
-# Append dispatch context when present. If no identity/profile prompt exists,
-# create a tiny session-context prompt rather than requiring AGENT_IDENTITY.
+# Append dispatch context when present. If no explicit/baked prompt exists,
+# create a tiny runtime-context prompt.
 if [ -n "${DISPATCH_CONTEXT:-}" ]; then
   ensure_prompt_temp
   {
@@ -247,8 +242,8 @@ if [ -n "${DISPATCH_CONTEXT:-}" ]; then
   } >> "$SYSTEM_PROMPT_FILE"
 fi
 
-# Append headless session context. This is runtime context, not agent identity;
-# promptless headless runs still get the no-human cue without AGENT_IDENTITY.
+# Append headless session context. This is runtime context, not a profile prompt;
+# promptless headless runs still get the no-human cue.
 if [ "$HEADLESS" = "true" ]; then
   ensure_prompt_temp
   cat >> "$SYSTEM_PROMPT_FILE" <<'HEADLESS_EOF'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 278 passing](https://img.shields.io/badge/tests-278%20passing-brightgreen?style=flat)](test/)
+[![tests: 282 passing](https://img.shields.io/badge/tests-282%20passing-brightgreen?style=flat)](test/)
 ![commands: 17](https://img.shields.io/badge/commands-17-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -108,9 +108,9 @@ sessions read review/pr-50 --last 5
 sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed the edge case in line 42"
 ```
 
-The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for persistent zmx sessions. `sessions wake` calls `sessions run` as its hidden low-level executor. For normal use, prefer `new` + `wake`: bake identity or profile instructions into the session with `--system-prompt-file` at creation, then wake it with task messages.
+The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for persistent zmx sessions. `sessions wake` calls `sessions run` as its hidden low-level executor. For profile-specific sessions, use `new` + `wake`: bake identity or task profile instructions into the session with `--system-prompt-file` at creation, then wake it with task messages. If no explicit or baked prompt exists, the harness starts without an appended prompt and can rely on its native cwd context discovery.
 
-`sessions run` remains available as an advanced/compatibility command. It accepts an explicit `--system-prompt-file` and keeps the legacy `AGENT_IDENTITY` fallback, but sessions created with a system prompt no longer need identity in the environment at wake time.
+`sessions run` remains available as an advanced/compatibility command. It accepts an explicit `--system-prompt-file`, uses any prompt baked into the session, and keeps the legacy `AGENT_IDENTITY` fallback. `AGENT_IDENTITY` is no longer required for promptless sessions.
 
 `--model` on `sessions wake` is required and is not remembered across wakes — pass a provider-qualified model (for example `openai-codex/gpt-5.5`) on each wake.
 
@@ -231,7 +231,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**278 tests** across 20 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 826 lines in `lib/`.
+**282 tests** across 20 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 826 lines in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -264,7 +264,7 @@ sessions/
 │   ├── shell.sh        # Shell helpers
 │   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats          # 278 tests
+    └── *.bats          # 282 tests
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ sessions read review/pr-50 --last 5
 sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed the edge case in line 42"
 ```
 
-The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for persistent zmx sessions. `sessions wake` calls `sessions run` as its hidden low-level executor. For profile-specific sessions, use `new` + `wake`: bake identity or task profile instructions into the session with `--system-prompt-file` at creation, then wake it with task messages. If no explicit or baked prompt exists, the harness starts without an appended prompt and can rely on its native cwd context discovery.
+The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for persistent zmx sessions. `sessions wake` calls `sessions run` as its hidden low-level executor. For profile-specific sessions, use `new` + `wake`: bake profile or task instructions into the session with `--system-prompt-file` at creation, then wake it with task messages. If no explicit or baked prompt exists, the harness starts without an appended prompt and can rely on its native cwd context discovery.
 
-`sessions run` remains available as an advanced/compatibility command. It accepts an explicit `--system-prompt-file`, uses any prompt baked into the session, and keeps the legacy `AGENT_IDENTITY` fallback. `AGENT_IDENTITY` is no longer required for promptless sessions.
+`sessions run` remains available as an advanced/compatibility command. It accepts an explicit `--system-prompt-file`, uses any prompt baked into the session, and otherwise starts without appending a system prompt. Caller-provided context belongs to the caller, not to `sessions`.
 
 `--model` on `sessions wake` is required and is not remembered across wakes — pass a provider-qualified model (for example `openai-codex/gpt-5.5`) on each wake.
 

--- a/README.tsx
+++ b/README.tsx
@@ -215,7 +215,7 @@ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed th
         <Code>new</Code>
         {" + "}
         <Code>wake</Code>
-        {": bake identity or task profile instructions into the session with "}
+        {": bake profile or task instructions into the session with "}
         <Code>--system-prompt-file</Code>
         {" at creation, then wake it with task messages. If no explicit or baked prompt exists, the harness starts without an appended prompt and can rely on its native cwd context discovery."}
       </Paragraph>
@@ -224,11 +224,9 @@ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed th
         <Code>sessions run</Code>
         {" remains available as an advanced/compatibility command. It accepts an explicit "}
         <Code>--system-prompt-file</Code>
-        {", uses any prompt baked into the session, and keeps the legacy "}
-        <Code>AGENT_IDENTITY</Code>
-        {" fallback. "}
-        <Code>AGENT_IDENTITY</Code>
-        {" is no longer required for promptless sessions."}
+        {", uses any prompt baked into the session, and otherwise starts without appending a system prompt. Caller-provided context belongs to the caller, not to "}
+        <Code>sessions</Code>
+        {"."}
       </Paragraph>
 
       <Paragraph>

--- a/README.tsx
+++ b/README.tsx
@@ -211,22 +211,24 @@ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed th
         <Code>sessions wake</Code>
         {" calls "}
         <Code>sessions run</Code>
-        {" as its hidden low-level executor. For normal use, prefer "}
+        {" as its hidden low-level executor. For profile-specific sessions, use "}
         <Code>new</Code>
         {" + "}
         <Code>wake</Code>
-        {": bake identity or profile instructions into the session with "}
+        {": bake identity or task profile instructions into the session with "}
         <Code>--system-prompt-file</Code>
-        {" at creation, then wake it with task messages."}
+        {" at creation, then wake it with task messages. If no explicit or baked prompt exists, the harness starts without an appended prompt and can rely on its native cwd context discovery."}
       </Paragraph>
 
       <Paragraph>
         <Code>sessions run</Code>
         {" remains available as an advanced/compatibility command. It accepts an explicit "}
         <Code>--system-prompt-file</Code>
-        {" and keeps the legacy "}
+        {", uses any prompt baked into the session, and keeps the legacy "}
         <Code>AGENT_IDENTITY</Code>
-        {" fallback, but sessions created with a system prompt no longer need identity in the environment at wake time."}
+        {" fallback. "}
+        <Code>AGENT_IDENTITY</Code>
+        {" is no longer required for promptless sessions."}
       </Paragraph>
 
       <Paragraph>

--- a/cli/README.md
+++ b/cli/README.md
@@ -6,33 +6,33 @@ Session execution engine — runs pi with streaming output, timeout, ABORT detec
 
 Identity-agnostic Elixir wrapper around pi. It:
 
-- Reads a system prompt from a file (`--system-prompt-file`)
+- Optionally reads appended system prompt text from a file (`--system-prompt-file`)
 - Executes pi via Erlang Port with optional timeout
 - Streams JSON output in real-time, showing tool invocations with formatted inputs
 - Detects `[[ABORT]]` signals across streaming chunk boundaries
 - Reports usage metrics (tokens, cost, turns) at session end
 - Supports session files for conversation continuity (`--session`)
 
-**This CLI does not handle identity, passphrase injection, or prompt composition.** Those are the caller's responsibility. The `sessions run` task handles prompt assembly from environment variables and delegates here.
+**This CLI does not handle identity, passphrase injection, or prompt composition.** Those are the caller's responsibility. The `sessions run` task handles optional prompt assembly and delegates here; when no prompt is provided, the harness can rely on native cwd context discovery.
 
 ## Usage
 
 ```bash
 # Via the sessions run task (typical)
-sessions run --system-prompt-file /tmp/prompt.txt --model openai-codex/gpt-5.5 --timeout 300 "Your message"
+sessions run --model openai-codex/gpt-5.5 --timeout 300 "Your message"
 
 # Direct CLI invocation (rare)
-cd cli && mix sessions --system-prompt-file /tmp/prompt.txt --model openai-codex/gpt-5.5 "Your message"
+cd cli && mix sessions --model openai-codex/gpt-5.5 "Your message"
 
 # With session file for conversation continuity
-mix sessions --system-prompt-file ./prompt.txt --model openai-codex/gpt-5.5 --session ./session.jsonl "Continue"
+mix sessions --model openai-codex/gpt-5.5 --session ./session.jsonl "Continue"
 ```
 
 ## Options
 
 | Option | Description |
 |--------|-------------|
-| `--system-prompt-file <path>` | Required. Path to system prompt file |
+| `--system-prompt-file <path>` | Optional. Path to appended system prompt text |
 | `--timeout <seconds>` | Optional. Timeout in seconds (default: no timeout) |
 | `--model <provider/model>` | Required. Provider-qualified model to use |
 | `--session <path>` | Optional. Session file for conversation continuity |

--- a/cli/README.md
+++ b/cli/README.md
@@ -4,7 +4,7 @@ Session execution engine — runs pi with streaming output, timeout, ABORT detec
 
 ## Overview
 
-Identity-agnostic Elixir wrapper around pi. It:
+Prompt-agnostic Elixir wrapper around pi. It:
 
 - Optionally reads appended system prompt text from a file (`--system-prompt-file`)
 - Executes pi via Erlang Port with optional timeout
@@ -13,7 +13,7 @@ Identity-agnostic Elixir wrapper around pi. It:
 - Reports usage metrics (tokens, cost, turns) at session end
 - Supports session files for conversation continuity (`--session`)
 
-**This CLI does not handle identity, passphrase injection, or prompt composition.** Those are the caller's responsibility. The `sessions run` task handles optional prompt assembly and delegates here; when no prompt is provided, the harness can rely on native cwd context discovery.
+**This CLI does not interpret prompt contents or compose caller context.** Those are the caller's responsibility. The `sessions run` task handles optional runtime prompt additions and delegates here; when no prompt is provided, the harness can rely on native cwd context discovery.
 
 ## Usage
 

--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -2,10 +2,9 @@ defmodule Cli do
   @moduledoc """
   `sessions run` — entry point, argument parsing, and help output.
 
-  Identity-agnostic: optionally receives a system prompt file, doesn't know
-  or care what's in it. Prompt composition (identity, passphrase, context) is
-  the caller's responsibility; absent prompts let the harness load its native
-  cwd context.
+  Prompt-agnostic: optionally receives a system prompt file, doesn't know
+  or care what's in it. Prompt content is the caller's responsibility;
+  absent prompts let the harness load its native cwd context.
 
   Run execution (port spawning, streaming, timeout) lives in
   `Cli.Engine`; usage reporting lives in `Cli.UsageReport`; harness

--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -2,9 +2,10 @@ defmodule Cli do
   @moduledoc """
   `sessions run` — entry point, argument parsing, and help output.
 
-  Identity-agnostic: receives a system prompt file, doesn't know or care
-  what's in it. Prompt composition (identity, passphrase, context) is the
-  caller's responsibility.
+  Identity-agnostic: optionally receives a system prompt file, doesn't know
+  or care what's in it. Prompt composition (identity, passphrase, context) is
+  the caller's responsibility; absent prompts let the harness load its native
+  cwd context.
 
   Run execution (port spawning, streaming, timeout) lives in
   `Cli.Engine`; usage reporting lives in `Cli.UsageReport`; harness
@@ -91,6 +92,7 @@ defmodule Cli do
 
   defp validate_args(message, opts) do
     system_prompt_file = opts[:system_prompt_file]
+
     cond do
       String.trim(message) == "" ->
         {:error, "No message provided"}
@@ -101,10 +103,8 @@ defmodule Cli do
       not String.contains?(opts[:model], "/") ->
         {:error, "--model must be provider-qualified (for example: openai-codex/gpt-5.5)"}
 
-      system_prompt_file == nil or system_prompt_file == "" ->
-        {:error, "--system-prompt-file is required"}
-
-      not File.exists?(system_prompt_file) ->
+      system_prompt_file != nil and system_prompt_file != "" and
+          not File.exists?(system_prompt_file) ->
         {:error, "System prompt file not found: #{system_prompt_file}"}
 
       true ->
@@ -145,15 +145,15 @@ defmodule Cli do
 
   defp print_help do
     IO.puts("""
-    Usage: sessions run --system-prompt-file <path> --model <provider/model> [options] <message>
+    Usage: sessions run --model <provider/model> [options] <message>
 
     Run a pi agent session with streaming output, timeout, and ABORT detection.
 
     Required:
-      --system-prompt-file <path>  Path to the system prompt file
       --model <provider/model>     Provider-qualified model to use
 
     Options:
+      --system-prompt-file <path>  Optional path to appended system prompt text
       --timeout <seconds>          Maximum runtime in seconds (default: no timeout)
       --cwd <path>                 Working directory for pi
       --session <path>             Session file for conversation continuity
@@ -163,9 +163,9 @@ defmodule Cli do
       -h, --help                   Show this help message
 
     Examples:
-      sessions run --system-prompt-file /tmp/prompt.txt --model openai-codex/gpt-5.5 "Fix the bug"
+      sessions run --model openai-codex/gpt-5.5 "Fix the bug"
       sessions run --system-prompt-file ./prompt.txt --model openai-codex/gpt-5.5 --timeout 300 "Explore"
-      sessions run --session ./session.jsonl --system-prompt-file ./prompt.txt --model openai-codex/gpt-5.5 "Continue"
+      sessions run --session ./session.jsonl --model openai-codex/gpt-5.5 "Continue"
     """)
   end
 end

--- a/cli/lib/cli/engine.ex
+++ b/cli/lib/cli/engine.ex
@@ -36,7 +36,7 @@ defmodule Cli.Engine do
   @spec run(
           harness :: module(),
           message :: String.t(),
-          system_prompt_file :: String.t(),
+          system_prompt_file :: String.t() | nil,
           timeout :: non_neg_integer() | nil,
           model :: String.t(),
           cwd :: String.t() | nil,

--- a/cli/lib/harness/pi/command.ex
+++ b/cli/lib/harness/pi/command.ex
@@ -11,7 +11,6 @@ defmodule Cli.Harness.Pi.Command do
   multi-harness plan.
   """
 
-
   @typep build_opts :: [
            extensions: boolean(),
            skills: boolean(),
@@ -30,7 +29,7 @@ defmodule Cli.Harness.Pi.Command do
   @spec build_command(
           message :: String.t(),
           model :: String.t(),
-          system_prompt_file :: String.t(),
+          system_prompt_file :: String.t() | nil,
           session :: String.t() | nil,
           timeout :: non_neg_integer() | nil,
           opts :: build_opts()
@@ -42,12 +41,25 @@ defmodule Cli.Harness.Pi.Command do
 
     qualified_model = model
 
-    session_flag =
-      if session, do: ~s( --session "$4"), else: " --no-session"
+    {prompt_flag, positional_after_prompt} =
+      if system_prompt_file && system_prompt_file != "" do
+        positional = [message, qualified_model, system_prompt_file]
+        {~s( --append-system-prompt "$3"), positional}
+      else
+        {"", [message, qualified_model]}
+      end
+
+    {session_flag, positional} =
+      if session do
+        session_arg = "$#{length(positional_after_prompt) + 1}"
+        {~s( --session "#{session_arg}"), positional_after_prompt ++ [session]}
+      else
+        {" --no-session", positional_after_prompt}
+      end
 
     pi_flags =
       [
-        ~s( --append-system-prompt "$3"),
+        prompt_flag,
         ~s( --model "$2"),
         " --mode json",
         session_flag,
@@ -66,9 +78,6 @@ defmodule Cli.Harness.Pi.Command do
       else
         "echo | #{pi_cmd}"
       end
-
-    positional = [message, qualified_model, system_prompt_file]
-    positional = if session, do: positional ++ [session], else: positional
 
     {shell_script, positional}
   end

--- a/cli/lib/mix/tasks/sessions.ex
+++ b/cli/lib/mix/tasks/sessions.ex
@@ -5,12 +5,12 @@ defmodule Mix.Tasks.Sessions do
 
   ## Usage
 
-      mix sessions --system-prompt-file <path> [options] <message>
+      mix sessions --model <provider/model> [options] <message>
 
   ## Examples
 
-      mix sessions --system-prompt-file /tmp/prompt.txt --timeout 300 "Fix the bug"
-      mix sessions --system-prompt-file ./prompt.txt --session ./session.jsonl "Continue"
+      mix sessions --model openai-codex/gpt-5.5 --timeout 300 "Fix the bug"
+      mix sessions --model openai-codex/gpt-5.5 --session ./session.jsonl "Continue"
 
   """
   use Mix.Task

--- a/cli/test/cli_test.exs
+++ b/cli/test/cli_test.exs
@@ -52,7 +52,9 @@ defmodule CliTest do
     end
 
     test "requires model" do
-      prompt = System.tmp_dir!() <> "/sessions-cli-test-prompt-#{System.unique_integer([:positive])}.txt"
+      prompt =
+        System.tmp_dir!() <> "/sessions-cli-test-prompt-#{System.unique_integer([:positive])}.txt"
+
       File.write!(prompt, "prompt")
 
       try do
@@ -65,11 +67,15 @@ defmodule CliTest do
     end
 
     test "requires provider-qualified model" do
-      prompt = System.tmp_dir!() <> "/sessions-cli-test-prompt-#{System.unique_integer([:positive])}.txt"
+      prompt =
+        System.tmp_dir!() <> "/sessions-cli-test-prompt-#{System.unique_integer([:positive])}.txt"
+
       File.write!(prompt, "prompt")
 
       try do
-        {output, exit_code} = run_cli(["--system-prompt-file", prompt, "--model", "gpt-5.5", "hello"])
+        {output, exit_code} =
+          run_cli(["--system-prompt-file", prompt, "--model", "gpt-5.5", "hello"])
+
         assert exit_code == 1
         assert output =~ "--model must be provider-qualified"
       after
@@ -77,23 +83,32 @@ defmodule CliTest do
       end
     end
 
-    test "requires system-prompt-file" do
-      {output, exit_code} = run_cli(["--timeout", "60", "--model", "openai-codex/gpt-5.5", "hello"])
-      assert exit_code == 1
-      assert output =~ "--system-prompt-file is required"
-    end
-
     test "rejects non-existent system-prompt-file" do
       {output, exit_code} =
-        run_cli(["--system-prompt-file", "/nonexistent/path.txt", "--model", "openai-codex/gpt-5.5", "--timeout", "60", "hello"])
+        run_cli([
+          "--system-prompt-file",
+          "/nonexistent/path.txt",
+          "--model",
+          "openai-codex/gpt-5.5",
+          "--timeout",
+          "60",
+          "hello"
+        ])
 
       assert exit_code == 1
       assert output =~ "System prompt file not found"
     end
 
     test "timeout is optional" do
-      # Should not error on missing timeout — only on missing prompt.
-      {output, exit_code} = run_cli(["--system-prompt-file", "/nonexistent/path.txt", "--model", "openai-codex/gpt-5.5", "hello"])
+      {output, exit_code} =
+        run_cli([
+          "--system-prompt-file",
+          "/nonexistent/path.txt",
+          "--model",
+          "openai-codex/gpt-5.5",
+          "hello"
+        ])
+
       assert exit_code == 1
       assert output =~ "System prompt file not found"
     end

--- a/cli/test/harness/pi/command_test.exs
+++ b/cli/test/harness/pi/command_test.exs
@@ -4,14 +4,21 @@ defmodule Cli.Harness.Pi.CommandTest do
   alias Cli.Harness.Pi.Command
 
   describe "build_command/6 — shell script" do
-    test "builds a basic invocation with no timeout, session, or flags" do
+    test "builds a basic invocation with no prompt, timeout, session, or flags" do
+      {script, _args} =
+        Command.build_command("hi", "claude-sonnet-4-5", nil, nil, nil)
+
+      assert script =~ "echo | pi -p \"$1\""
+      refute script =~ "--append-system-prompt"
+      assert script =~ ~s( --model "$2")
+      assert script =~ " --mode json"
+    end
+
+    test "adds --append-system-prompt when a prompt file is provided" do
       {script, _args} =
         Command.build_command("hi", "claude-sonnet-4-5", "/tmp/prompt.txt", nil, nil)
 
-      assert script =~ "echo | pi -p \"$1\""
       assert script =~ ~s( --append-system-prompt "$3")
-      assert script =~ ~s( --model "$2")
-      assert script =~ " --mode json"
     end
 
     test "wraps the command in `timeout <N>` when timeout is given" do
@@ -21,7 +28,7 @@ defmodule Cli.Harness.Pi.CommandTest do
       assert script =~ "echo | timeout 300 pi -p"
     end
 
-    test "uses --session when a session path is given" do
+    test "uses --session at the next positional index after prompt args" do
       {script, _} =
         Command.build_command(
           "hi",
@@ -32,6 +39,21 @@ defmodule Cli.Harness.Pi.CommandTest do
         )
 
       assert script =~ ~s( --session "$4")
+      refute script =~ " --no-session"
+    end
+
+    test "uses --session at $3 when no prompt file is provided" do
+      {script, _} =
+        Command.build_command(
+          "hi",
+          "claude-sonnet-4-5",
+          nil,
+          "/tmp/session.jsonl",
+          nil
+        )
+
+      assert script =~ ~s( --session "$3")
+      refute script =~ "--append-system-prompt"
       refute script =~ " --no-session"
     end
 
@@ -96,14 +118,21 @@ defmodule Cli.Harness.Pi.CommandTest do
   end
 
   describe "build_command/6 — positional args" do
-    test "returns [message, model, system_prompt_file] without session" do
+    test "returns [message, model] without prompt or session" do
+      {_script, args} =
+        Command.build_command("hello world", "openai-codex/gpt-5.5", nil, nil, nil)
+
+      assert args == ["hello world", "openai-codex/gpt-5.5"]
+    end
+
+    test "returns [message, model, system_prompt_file] when prompt is present" do
       {_script, args} =
         Command.build_command("hello world", "openai-codex/gpt-5.5", "/tmp/p.txt", nil, nil)
 
       assert args == ["hello world", "openai-codex/gpt-5.5", "/tmp/p.txt"]
     end
 
-    test "appends session path to positional args when given" do
+    test "appends session path after prompt when both are given" do
       {_script, args} =
         Command.build_command(
           "hello",
@@ -114,6 +143,19 @@ defmodule Cli.Harness.Pi.CommandTest do
         )
 
       assert args == ["hello", "openai-codex/gpt-5.5", "/tmp/p.txt", "/tmp/s.jsonl"]
+    end
+
+    test "appends session path after model when prompt is absent" do
+      {_script, args} =
+        Command.build_command(
+          "hello",
+          "openai-codex/gpt-5.5",
+          nil,
+          "/tmp/s.jsonl",
+          nil
+        )
+
+      assert args == ["hello", "openai-codex/gpt-5.5", "/tmp/s.jsonl"]
     end
   end
 

--- a/test/harness_dispatch.bats
+++ b/test/harness_dispatch.bats
@@ -302,7 +302,7 @@ JSONL
 {"type":"harness","id":"h1","parentId":"${sid}","timestamp":"2026-04-22T10:00:00.000Z","name":"claude"}
 JSONL
 
-  AGENT_IDENTITY="test identity" run sessions wake "${sid:0:8}" --model "openai-codex/gpt-5.5" --message "acceptance"
+  run sessions wake "${sid:0:8}" --model "openai-codex/gpt-5.5" --message "acceptance"
   [ "$status" -eq 10 ]
   # The user-facing message should name the claude harness and the
   # specific unsupported op.

--- a/test/run.bats
+++ b/test/run.bats
@@ -66,7 +66,6 @@ teardown() {
   local expected_cwd
   expected_cwd=$(cd "$run_cwd" && pwd -P)
 
-  unset AGENT_IDENTITY
   PATH="$stub_dir:$PATH" run sessions run \
     --cwd "$run_cwd" \
     --model "openai-codex/gpt-5.5"
@@ -96,7 +95,6 @@ exit 0
 STUB
   chmod +x "$stub_dir/mix"
 
-  unset AGENT_IDENTITY
   PATH="$stub_dir:$PATH" run sessions run \
     --cwd "$BATS_TEST_TMPDIR" \
     --model "openai-codex/gpt-5.5" \
@@ -186,7 +184,6 @@ STUB
   new_id=$(echo "$output" | head -1)
   session_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
 
-  unset AGENT_IDENTITY
   PATH="$stub_dir:$PATH" run sessions run \
     --cwd "$BATS_TEST_TMPDIR" \
     --model "openai-codex/gpt-5.5" \
@@ -230,7 +227,6 @@ STUB
   new_id=$(echo "$output" | head -1)
   session_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
 
-  unset AGENT_IDENTITY
   PATH="$stub_dir:$PATH" run sessions run \
     --headless \
     --cwd "$BATS_TEST_TMPDIR" \
@@ -248,10 +244,10 @@ STUB
   [ ! -e "$prompt_path" ]
 }
 
-@test "run headless with message creates runtime context prompt without identity" {
-  local stub_dir="$BATS_TEST_TMPDIR/stub-mix-headless-no-identity"
-  local argv_capture="$BATS_TEST_TMPDIR/mix-argv-headless-no-identity"
-  local prompt_capture="$BATS_TEST_TMPDIR/mix-prompt-headless-no-identity"
+@test "run headless with message creates runtime context prompt without profile prompt" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-mix-headless-no-profile"
+  local argv_capture="$BATS_TEST_TMPDIR/mix-argv-headless-no-profile"
+  local prompt_capture="$BATS_TEST_TMPDIR/mix-prompt-headless-no-profile"
   mkdir -p "$stub_dir"
   cat > "$stub_dir/mix" <<STUB
 #!/usr/bin/env bash
@@ -271,7 +267,6 @@ exit 0
 STUB
   chmod +x "$stub_dir/mix"
 
-  unset AGENT_IDENTITY
   PATH="$stub_dir:$PATH" run sessions run \
     --headless \
     --cwd "$BATS_TEST_TMPDIR" \
@@ -283,7 +278,6 @@ STUB
 
   grep -qx -- "--system-prompt-file" "$argv_capture"
   grep -q "This is a headless session" "$prompt_capture"
-  ! grep -q "AGENT_IDENTITY" "$prompt_capture"
   prompt_path=$(awk '/^--system-prompt-file$/ { getline; print; exit }' "$argv_capture")
   [ -n "$prompt_path" ]
   [ ! -e "$prompt_path" ]
@@ -355,7 +349,6 @@ STUB
   new_id=$(echo "$output" | head -1)
   session_file=$(find "$PI_DIR/agent/sessions" -name "*${new_id}.jsonl")
 
-  export AGENT_IDENTITY="stale legacy identity"
   PATH="$stub_dir:$PATH" run sessions run \
     --cwd "$BATS_TEST_TMPDIR" \
     --model "openai-codex/gpt-5.5" \
@@ -363,11 +356,10 @@ STUB
   [ "$status" -eq 0 ]
   [ -f "$prompt_capture" ]
   [ -f "$prompt_path_capture" ]
-  ! grep -q "stale legacy identity" "$prompt_capture"
   [ ! -e "$(cat "$prompt_path_capture")" ]
 }
 
-@test "run with malformed session does not fall back to stale AGENT_IDENTITY" {
+@test "run with malformed session fails before launch" {
   local stub_dir="$BATS_TEST_TMPDIR/stub-pi-malformed-session"
   local invoked_capture="$BATS_TEST_TMPDIR/pi-malformed-session-invoked"
   local bad_session="$BATS_TEST_TMPDIR/malformed-session.jsonl"
@@ -380,7 +372,6 @@ STUB
   chmod +x "$stub_dir/pi"
   printf '{"type":"session"\n' > "$bad_session"
 
-  export AGENT_IDENTITY="stale legacy identity"
   PATH="$stub_dir:$PATH" run sessions run \
     --cwd "$BATS_TEST_TMPDIR" \
     --model "openai-codex/gpt-5.5" \
@@ -418,7 +409,7 @@ while :; do sleep 1; done
 STUB
   chmod +x "$stub_dir/pi"
 
-  PATH="$stub_dir:$PATH" AGENT_IDENTITY="generated prompt" PI_DIR="$PI_DIR" \
+  PATH="$stub_dir:$PATH" DISPATCH_CONTEXT="generated prompt" PI_DIR="$PI_DIR" \
     mise -C "$REPO_DIR" run -q run --cwd "$BATS_TEST_TMPDIR" --model "openai-codex/gpt-5.5" \
     >"$stdout_capture" 2>"$stderr_capture" &
   local mise_pid=$!

--- a/test/run.bats
+++ b/test/run.bats
@@ -55,6 +55,80 @@ teardown() {
   ! grep -qx '' "$argv_capture"
 }
 
+@test "run interactive without message works without any system prompt" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-no-prompt"
+  local argv_capture="$BATS_TEST_TMPDIR/pi-argv-no-prompt"
+  local cwd_capture="$BATS_TEST_TMPDIR/pi-cwd-no-prompt"
+  stub_pi_capture_argv_cwd "$stub_dir" "$argv_capture" "$cwd_capture"
+
+  local run_cwd="$BATS_TEST_TMPDIR/run-cwd-no-prompt"
+  mkdir -p "$run_cwd"
+  local expected_cwd
+  expected_cwd=$(cd "$run_cwd" && pwd -P)
+
+  unset AGENT_IDENTITY
+  PATH="$stub_dir:$PATH" run sessions run \
+    --cwd "$run_cwd" \
+    --model "openai-codex/gpt-5.5"
+  [ "$status" -eq 0 ]
+  [ -f "$argv_capture" ]
+  [ -f "$cwd_capture" ]
+
+  [ "$(cat "$cwd_capture")" = "$expected_cwd" ]
+  ! grep -qx -- "--append-system-prompt" "$argv_capture"
+  grep -qx -- "--model" "$argv_capture"
+  [ "$(awk '/^--model$/ { getline; print; exit }' "$argv_capture")" = "openai-codex/gpt-5.5" ]
+  grep -qx -- "--no-session" "$argv_capture"
+  ! grep -qx -- "-p" "$argv_capture"
+  ! grep -qx -- "--print" "$argv_capture"
+  ! grep -qx '' "$argv_capture"
+}
+
+@test "run with message works without any system prompt" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-mix-no-prompt"
+  local argv_capture="$BATS_TEST_TMPDIR/mix-argv-no-prompt"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/mix" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$@" > "$argv_capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/mix"
+
+  unset AGENT_IDENTITY
+  PATH="$stub_dir:$PATH" run sessions run \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5" \
+    "do work"
+  [ "$status" -eq 0 ]
+  [ -f "$argv_capture" ]
+
+  ! grep -qx -- "--system-prompt-file" "$argv_capture"
+  grep -qx -- "--model" "$argv_capture"
+  [ "$(awk '/^--model$/ { getline; print; exit }' "$argv_capture")" = "openai-codex/gpt-5.5" ]
+}
+
+@test "run rejects a missing explicit system prompt file before launch" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-missing-prompt"
+  local invoked_capture="$BATS_TEST_TMPDIR/pi-missing-prompt-invoked"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/pi" <<STUB
+#!/usr/bin/env bash
+printf invoked > "$invoked_capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/pi"
+
+  PATH="$stub_dir:$PATH" run sessions run \
+    --system-prompt-file "$BATS_TEST_TMPDIR/missing-prompt.md" \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5"
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "System prompt file not found"
+  [ ! -e "$invoked_capture" ]
+}
+
 @test "run interactive without message preserves stdin for pi" {
   local stub_dir="$BATS_TEST_TMPDIR/stub-pi-stdin"
   local stdin_capture="$BATS_TEST_TMPDIR/pi-stdin-capture"
@@ -169,6 +243,47 @@ STUB
 
   grep -q "headless baked prompt" "$prompt_capture"
   grep -q "This is a headless session" "$prompt_capture"
+  prompt_path=$(awk '/^--system-prompt-file$/ { getline; print; exit }' "$argv_capture")
+  [ -n "$prompt_path" ]
+  [ ! -e "$prompt_path" ]
+}
+
+@test "run headless with message creates runtime context prompt without identity" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-mix-headless-no-identity"
+  local argv_capture="$BATS_TEST_TMPDIR/mix-argv-headless-no-identity"
+  local prompt_capture="$BATS_TEST_TMPDIR/mix-prompt-headless-no-identity"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/mix" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$@" > "$argv_capture"
+prompt_file=""
+while [ "\$#" -gt 0 ]; do
+  if [ "\$1" = "--system-prompt-file" ]; then
+    prompt_file="\$2"
+    break
+  fi
+  shift
+done
+[ -n "\$prompt_file" ]
+cat "\$prompt_file" > "$prompt_capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/mix"
+
+  unset AGENT_IDENTITY
+  PATH="$stub_dir:$PATH" run sessions run \
+    --headless \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5" \
+    "do work"
+  [ "$status" -eq 0 ]
+  [ -f "$argv_capture" ]
+  [ -f "$prompt_capture" ]
+
+  grep -qx -- "--system-prompt-file" "$argv_capture"
+  grep -q "This is a headless session" "$prompt_capture"
+  ! grep -q "AGENT_IDENTITY" "$prompt_capture"
   prompt_path=$(awk '/^--system-prompt-file$/ { getline; print; exit }' "$argv_capture")
   [ -n "$prompt_path" ]
   [ ! -e "$prompt_path" ]

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -620,7 +620,6 @@ STUB
   stub_shell_exec_payload "$stub_dir" "$shell_capture"
   stub_pi_capture_argv_cwd "$stub_dir" "$pi_argv_capture" "$pi_cwd_capture"
 
-  unset AGENT_IDENTITY
   PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   [ -f "$shell_capture" ]
@@ -669,7 +668,6 @@ exit 0
 STUB
   chmod +x "$stub_dir/pi"
 
-  unset AGENT_IDENTITY
   PATH="$stub_dir:$PATH" run sessions wake wake-baked-prompt --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   [ -f "$shell_capture" ]

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -602,7 +602,7 @@ STUB
   ! grep -qx '' "$capture"
 }
 
-@test "wake interactive without --message executes nested run without print mode" {
+@test "wake interactive without --message executes nested run without a system prompt" {
   local session_cwd="$BATS_TEST_TMPDIR/wake-session-cwd"
   local expected_cwd
   mkdir -p "$session_cwd"
@@ -620,7 +620,7 @@ STUB
   stub_shell_exec_payload "$stub_dir" "$shell_capture"
   stub_pi_capture_argv_cwd "$stub_dir" "$pi_argv_capture" "$pi_cwd_capture"
 
-  export AGENT_IDENTITY="test identity"
+  unset AGENT_IDENTITY
   PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
   [ -f "$shell_capture" ]
@@ -628,7 +628,7 @@ STUB
   [ -f "$pi_cwd_capture" ]
 
   [ "$(cat "$pi_cwd_capture")" = "$expected_cwd" ]
-  grep -qx -- "--append-system-prompt" "$pi_argv_capture"
+  ! grep -qx -- "--append-system-prompt" "$pi_argv_capture"
   grep -qx -- "--model" "$pi_argv_capture"
   [ "$(awk '/^--model$/ { getline; print; exit }' "$pi_argv_capture")" = "openai-codex/gpt-5.5" ]
   grep -qx -- "--session" "$pi_argv_capture"


### PR DESCRIPTION
## Summary

- allow `sessions run` / `sessions wake` to start without `AGENT_IDENTITY` or any appended system prompt
- keep explicit `--system-prompt-file`, baked session prompts, and legacy `AGENT_IDENTITY` fallback working
- omit pi `--append-system-prompt` when no prompt exists; create only a small runtime-context prompt for headless/dispatch context
- update CLI/help/README docs and tests for promptless runs

## Why

Agents are increasingly woken from their own home directories, where pi already loads `AGENTS.md` / `CLAUDE.md` as cwd context. Requiring `AGENT_IDENTITY` makes the old fold/den identity-injection path a hard dependency and breaks homes that intentionally do not maintain `agent:identity` tasks.

This PR starts the decommission path at the sessions layer: prompt text is optional, while compatibility paths still work.

## Validation

- `mise trust`
- `mise install`
- `mise run cli:build`
- `bash -n .mise/tasks/run .mise/tasks/wake lib/*.sh lib/harness/*.sh`
- `mise run test run wake` — 49/49
- `mise run test` — 282/282
- `cd cli && mix test test/cli_test.exs test/harness/pi/command_test.exs` — 28/28
- `cd cli && mix test` — 4 doctests + 124 tests, 0 failures
- `cd cli && mix format --check-formatted lib/cli.ex lib/cli/engine.ex lib/harness/pi/command.ex lib/mix/tasks/sessions.ex test/cli_test.exs test/harness/pi/command_test.exs`
- `readme build --check`
- `git diff --check`

## Follow-up

This exposed a good refactor seam: `.mise/tasks/run` now owns prompt resolution/composition, process supervision, direct interactive pi launch, and CLI arg assembly. A follow-up should extract prompt resolution/composition into a small library with focused tests before removing the legacy `AGENT_IDENTITY` fallback entirely.
