### PR TITLE
Keep interactive wakes persistent with messages

### DIFF
--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -9,9 +9,10 @@
 #USAGE flag "--session <session>" default="" help="Session file for conversation continuity"
 #USAGE flag "--cwd <cwd>" default="" help="Working directory for pi"
 #USAGE flag "--headless" default=#false help="Non-interactive mode (appends headless context to system prompt)"
-#USAGE flag "--extensions" default=#false help="Enable pi extensions for print-mode runs (interactive no-message runs use pi defaults)"
-#USAGE flag "--skills" default=#false help="Enable pi skills for print-mode runs (interactive no-message runs use pi defaults)"
-#USAGE flag "--prompt-templates" default=#false help="Enable pi prompt templates for print-mode runs (interactive no-message runs use pi defaults)"
+#USAGE flag "--interactive" default=#false help="Open a persistent interactive harness even when a message is provided"
+#USAGE flag "--extensions" default=#false help="Enable pi extensions for print-mode runs (interactive runs use pi defaults)"
+#USAGE flag "--skills" default=#false help="Enable pi skills for print-mode runs (interactive runs use pi defaults)"
+#USAGE flag "--prompt-templates" default=#false help="Enable pi prompt templates for print-mode runs (interactive runs use pi defaults)"
 
 set -euo pipefail
 
@@ -22,6 +23,7 @@ MODEL="${usage_model:-}"
 SESSION="${usage_session:-}"
 CWD="${usage_cwd:-${SESSIONS_CALLER_PWD:-${CALLER_PWD:-.}}}"
 HEADLESS="${usage_headless:-false}"
+INTERACTIVE="${usage_interactive:-false}"
 # Extensions disabled by default (determinism for CI). Pass --extensions etc. to enable.
 EXTENSIONS="${usage_extensions:-false}"
 SKILLS="${usage_skills:-false}"
@@ -193,6 +195,11 @@ if [ "$HEADLESS" = "true" ] && [ -z "$MESSAGE" ]; then
   exit 1
 fi
 
+if [ "$HEADLESS" = "true" ] && [ "$INTERACTIVE" = "true" ]; then
+  echo "Error: --headless cannot be combined with --interactive" >&2
+  exit 1
+fi
+
 if [ -z "$MODEL" ]; then
   echo "Error: --model is required" >&2
   echo "Usage: sessions run --model <provider/model> [options] \"message\"" >&2
@@ -253,7 +260,7 @@ This is a headless session. No human is present. You are running non-interactive
 HEADLESS_EOF
 fi
 
-run_interactive_without_message() {
+run_interactive() {
   # shellcheck source=../../lib/harness/dispatch.sh
   source "$MISE_CONFIG_ROOT/lib/harness/dispatch.sh"
 
@@ -285,6 +292,9 @@ run_interactive_without_message() {
   else
     pi_args+=(--no-session)
   fi
+  if [ -n "$MESSAGE" ]; then
+    pi_args+=("$MESSAGE")
+  fi
   cd "$CWD"
 
   if [ -n "$TIMEOUT" ]; then
@@ -298,8 +308,8 @@ run_interactive_without_message() {
   run_and_exit pi "${pi_args[@]}"
 }
 
-if [ -z "$MESSAGE" ]; then
-  run_interactive_without_message
+if [ "$INTERACTIVE" = "true" ] || [ -z "$MESSAGE" ]; then
+  run_interactive
 fi
 
 CLI_DIR="$MISE_CONFIG_ROOT/cli"

--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -99,8 +99,12 @@ HARNESS_NAME=$(harness_resolve --session "$SESSION_FILE") || exit 1
 # shellcheck source=/dev/null
 source "$MISE_CONFIG_ROOT/lib/harness/$HARNESS_NAME.sh"
 
-if [ -z "$MESSAGE" ] && [ "$HARNESS_NAME" != "pi" ]; then
-  echo "sessions: '$HARNESS_NAME' harness does not support interactive no-message wake yet" >&2
+if [ "$HEADLESS" != "true" ] && [ "$HARNESS_NAME" != "pi" ]; then
+  if [ -z "$MESSAGE" ]; then
+    echo "sessions: '$HARNESS_NAME' harness does not support interactive no-message wake yet" >&2
+  else
+    echo "sessions: '$HARNESS_NAME' harness does not support interactive wake with --message yet" >&2
+  fi
   exit "$HARNESS_UNSUPPORTED_EXIT"
 fi
 
@@ -205,9 +209,13 @@ SESSION_CWD=$(cd "$SESSION_CWD" && pwd -P)
 # --- Launch ---
 
 RUN_CMD=("${mise_run[@]}" run --session "$SESSION_FILE" --cwd "$SESSION_CWD" --model "$MODEL")
-[ "$HEADLESS" = "true" ] && RUN_CMD+=(--headless)
-if [ -n "$MESSAGE" ]; then
-  RUN_CMD+=("$MESSAGE")
+if [ "$HEADLESS" = "true" ]; then
+  RUN_CMD+=(--headless)
+  if [ -n "$MESSAGE" ]; then
+    RUN_CMD+=("$MESSAGE")
+  fi
+elif [ -n "$MESSAGE" ]; then
+  RUN_CMD+=(--interactive "$MESSAGE")
 fi
 
 if [ -n "$OS_USER" ]; then

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 282 passing](https://img.shields.io/badge/tests-282%20passing-brightgreen?style=flat)](test/)
+[![tests: 286 passing](https://img.shields.io/badge/tests-286%20passing-brightgreen?style=flat)](test/)
 ![commands: 17](https://img.shields.io/badge/commands-17-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -114,7 +114,7 @@ The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for per
 
 `--model` on `sessions wake` is required and is not remembered across wakes — pass a provider-qualified model (for example `openai-codex/gpt-5.5`) on each wake.
 
-`--message` is optional for interactive wakes/runs; omit it to open the harness and let the human start the conversation. `--headless` still requires `--message`.
+`--message` is optional for interactive `sessions wake`: with a message, wake sends an initial prompt and keeps the harness open; without one, it opens the harness for the human. `--headless` still requires `--message`. For low-level `sessions run`, pass `--interactive` when a provided message should keep the harness open; otherwise a message uses the print/one-turn compatibility path.
 
 To run only the payload process as a local agent OS user, pass `--os-user` or set `SHIMMER_OS_USER`. The shell/zmx session remains owned by the caller. This does not copy caller environment, secrets, or auth into the target account; the target user's session environment is a separate setup step.
 
@@ -231,7 +231,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**282 tests** across 20 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 826 lines in `lib/`.
+**286 tests** across 20 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 826 lines in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -264,7 +264,7 @@ sessions/
 │   ├── shell.sh        # Shell helpers
 │   └── harness/        # Per-harness adapters (pi, …)
 └── test/
-    └── *.bats          # 282 tests
+    └── *.bats          # 286 tests
 ```
 
 </details>

--- a/README.tsx
+++ b/README.tsx
@@ -240,11 +240,17 @@ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed th
 
       <Paragraph>
         <Code>--message</Code>
-        {" is optional for interactive wakes/runs; omit it to open the harness and let the human start the conversation. "}
+        {" is optional for interactive "}
+        <Code>sessions wake</Code>
+        {": with a message, wake sends an initial prompt and keeps the harness open; without one, it opens the harness for the human. "}
         <Code>--headless</Code>
         {" still requires "}
         <Code>--message</Code>
-        {"."}
+        {". For low-level "}
+        <Code>sessions run</Code>
+        {", pass "}
+        <Code>--interactive</Code>
+        {" when a provided message should keep the harness open; otherwise a message uses the print/one-turn compatibility path."}
       </Paragraph>
 
       <Paragraph>

--- a/test/harness_dispatch.bats
+++ b/test/harness_dispatch.bats
@@ -290,7 +290,7 @@ JSONL
   # lives under PI_DIR so pi's find_session locates it; the harness
   # entry then wins over path-based detection (see the priority test
   # above), so wake dispatches to claude — which errors UNSUPPORTED
-  # when the Elixir run path asks claude to build the harness command.
+  # when the Elixir headless run path asks claude to build the harness command.
   # Foreground wake (no --background) — execs mise run directly, so
   # `shell` isn't required.
 
@@ -302,7 +302,7 @@ JSONL
 {"type":"harness","id":"h1","parentId":"${sid}","timestamp":"2026-04-22T10:00:00.000Z","name":"claude"}
 JSONL
 
-  run sessions wake "${sid:0:8}" --model "openai-codex/gpt-5.5" --message "acceptance"
+  run sessions wake "${sid:0:8}" --headless --model "openai-codex/gpt-5.5" --message "acceptance"
   [ "$status" -eq 10 ]
   # The user-facing message should name the claude harness and the
   # specific unsupported op.

--- a/test/run.bats
+++ b/test/run.bats
@@ -55,6 +55,42 @@ teardown() {
   ! grep -qx '' "$argv_capture"
 }
 
+@test "run --interactive with message execs pi without print mode" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-interactive-message"
+  local argv_capture="$BATS_TEST_TMPDIR/pi-argv-interactive-message"
+  local cwd_capture="$BATS_TEST_TMPDIR/pi-cwd-interactive-message"
+  stub_pi_capture_argv_cwd "$stub_dir" "$argv_capture" "$cwd_capture"
+
+  local run_cwd="$BATS_TEST_TMPDIR/run-cwd-interactive-message"
+  mkdir -p "$run_cwd"
+  local expected_cwd
+  expected_cwd=$(cd "$run_cwd" && pwd -P)
+
+  local session_file
+  session_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+
+  PATH="$stub_dir:$PATH" run sessions run \
+    --interactive \
+    --cwd "$run_cwd" \
+    --model "openai-codex/gpt-5.5" \
+    --session "$session_file" \
+    "stay attached"
+  [ "$status" -eq 0 ]
+  [ -f "$argv_capture" ]
+  [ -f "$cwd_capture" ]
+
+  [ "$(cat "$cwd_capture")" = "$expected_cwd" ]
+  grep -qx -- "--model" "$argv_capture"
+  [ "$(awk '/^--model$/ { getline; print; exit }' "$argv_capture")" = "openai-codex/gpt-5.5" ]
+  grep -qx -- "--session" "$argv_capture"
+  [ "$(awk '/^--session$/ { getline; print; exit }' "$argv_capture")" = "$session_file" ]
+  [ "$(tail -1 "$argv_capture")" = "stay attached" ]
+
+  ! grep -qx -- "-p" "$argv_capture"
+  ! grep -qx -- "--print" "$argv_capture"
+  ! grep -qx -- "--mode" "$argv_capture"
+}
+
 @test "run interactive without message works without any system prompt" {
   local stub_dir="$BATS_TEST_TMPDIR/stub-pi-no-prompt"
   local argv_capture="$BATS_TEST_TMPDIR/pi-argv-no-prompt"
@@ -475,6 +511,12 @@ STUB
   grep -q "$pi_bin" "$env_capture"
   ! grep -q "$stale_bin" "$env_capture"
   ! grep -q "$fresh_bin" "$env_capture"
+}
+
+@test "run rejects --headless with --interactive" {
+  run sessions run --headless --interactive --model "openai-codex/gpt-5.5" "do work"
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q -- "--headless cannot be combined with --interactive"
 }
 
 @test "run --headless requires a message" {

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -569,6 +569,21 @@ STUB
   [ "$after" = "$((before + 1))" ]
 }
 
+@test "wake interactive with --message rejects unsupported harness before recording wake" {
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  local before
+  before=$(wc -l < "$src_file" | tr -d ' ')
+  echo '{"type":"harness","id":"h-claude","parentId":"u4","timestamp":"2026-03-14T10:31:00.000Z","name":"claude"}' >> "$src_file"
+
+  run sessions wake "$SESSION_1" --background --model "openai-codex/gpt-5.5" --message "stay attached"
+  [ "$status" -eq 10 ]
+  echo "$output" | grep -q -- "claude.*does not support interactive wake with --message"
+
+  local after
+  after=$(wc -l < "$src_file" | tr -d ' ')
+  [ "$after" = "$((before + 1))" ]
+}
+
 @test "wake interactive without --message records no synthetic message" {
   local stub_dir="$BATS_TEST_TMPDIR/stub-shell-no-message"
   local capture="$BATS_TEST_TMPDIR/shell-argv-no-message"
@@ -600,6 +615,45 @@ STUB
   ! grep -qx 'stale inherited message' "$capture"
   ! grep -qx -- '--headless' "$capture"
   ! grep -qx '' "$capture"
+}
+
+@test "wake interactive with --message passes initial prompt to persistent pi" {
+  local session_cwd="$BATS_TEST_TMPDIR/wake-message-cwd"
+  local expected_cwd
+  mkdir -p "$session_cwd"
+  expected_cwd=$(cd "$session_cwd" && pwd -P)
+
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  local updated_file="$BATS_TEST_TMPDIR/session-cwd-for-message.jsonl"
+  jq -c --arg cwd "$session_cwd" 'if .type == "session" then .cwd = $cwd else . end' "$src_file" > "$updated_file"
+  mv "$updated_file" "$src_file"
+
+  local stub_dir="$BATS_TEST_TMPDIR/stub-shell-pi-message"
+  local shell_capture="$BATS_TEST_TMPDIR/shell-argv-message"
+  local pi_argv_capture="$BATS_TEST_TMPDIR/pi-argv-message"
+  local pi_cwd_capture="$BATS_TEST_TMPDIR/pi-cwd-message"
+  stub_shell_exec_payload "$stub_dir" "$shell_capture"
+  stub_pi_capture_argv_cwd "$stub_dir" "$pi_argv_capture" "$pi_cwd_capture"
+
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" --background --model "openai-codex/gpt-5.5" --message "stay attached"
+  [ "$status" -eq 0 ]
+  [ -f "$shell_capture" ]
+  [ -f "$pi_argv_capture" ]
+  [ -f "$pi_cwd_capture" ]
+
+  grep -qx -- "--interactive" "$shell_capture"
+  [ "$(tail -1 "$shell_capture")" = "stay attached" ]
+
+  [ "$(cat "$pi_cwd_capture")" = "$expected_cwd" ]
+  grep -qx -- "--model" "$pi_argv_capture"
+  [ "$(awk '/^--model$/ { getline; print; exit }' "$pi_argv_capture")" = "openai-codex/gpt-5.5" ]
+  grep -qx -- "--session" "$pi_argv_capture"
+  [ "$(awk '/^--session$/ { getline; print; exit }' "$pi_argv_capture")" = "$src_file" ]
+  [ "$(tail -1 "$pi_argv_capture")" = "stay attached" ]
+
+  ! grep -qx -- "-p" "$pi_argv_capture"
+  ! grep -qx -- "--print" "$pi_argv_capture"
+  ! grep -qx -- "--mode" "$pi_argv_capture"
 }
 
 @test "wake interactive without --message executes nested run without a system prompt" {


### PR DESCRIPTION
## Summary

- add `sessions run --interactive` so a provided message can launch persistent interactive Pi instead of the print/one-turn path
- make `sessions wake --message` use that interactive path when `--headless` is not set
- reject interactive `--message` wakes for unsupported harnesses before mutating the session

Closes #104.

## Validation

- `mise run test` — 286/286
- `readme build --check`
- configured codebase lints: `mise-settings`, `gum-table`, `bats-test-helper`, `bats-test-task`, `mcr-scope`, `or-true`, `shellcheck`
- `git diff --check`
- `git pre-commit`
- `git pre-push` (WARN only: new branch had no upstream before push; existing unsigned merge commits on `main`)
- `/tmp/baby-joel.d/sessions-104-workbench`: `mise run smoke:interactive-message` and `mise run smoke:actual-persistence`
