### PR TITLE
Add sessions query over ephemeral SQLite projections

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Run CLI tests
         run: cd cli && mix test
 
+      - name: Run Python lint
+        run: mise run lint:python
+
       - name: Run codebase lints
         run: |
           for target in \

--- a/.mise/tasks/lint/python
+++ b/.mise/tasks/lint/python
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#MISE description="Lint and format-check Python code with Ruff"
+set -euo pipefail
+
+check_targets=(
+  .mise/tasks/query
+  lib
+  test
+)
+
+format_targets=(
+  .mise/tasks/query
+  lib
+  test
+)
+
+ruff check "${check_targets[@]}"
+ruff format --check "${format_targets[@]}"

--- a/.mise/tasks/query
+++ b/.mise/tasks/query
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# fmt: off
 #MISE description="Query local sessions through an ephemeral SQLite projection"
 #USAGE arg "[session_ids]" var=#true default="" help="Optional session ID prefixes to query"
 #USAGE flag "--project <filter>" default="" help="Project substring filter when querying a corpus"
@@ -15,6 +16,7 @@
 #USAGE flag "--browser" default=#false help="Render results to temporary HTML and open in the default browser"
 #USAGE flag "--title <title>" default="sessions query" help="HTML/browser result title"
 #USAGE flag "--out <path>" default="" help="Write query output to a file"
+# fmt: on
 
 from __future__ import annotations
 

--- a/.mise/tasks/query
+++ b/.mise/tasks/query
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+#MISE description="Query local sessions through an ephemeral SQLite projection"
+#USAGE arg "[session_ids]" var=#true default="" help="Optional session ID prefixes to query"
+#USAGE flag "--project <filter>" default="" help="Project substring filter when querying a corpus"
+#USAGE flag "--limit <n>" default="20" help="Max sessions for corpus scope"
+#USAGE flag "--text <mode>" default="commands" help="Text mode: none, commands, compact, or full"
+#USAGE flag "--max-output-chars <n>" default="4000" help="Output excerpt budget for --text compact"
+#USAGE flag "--max-message-chars <n>" default="2000" help="Message excerpt budget for --text compact"
+#USAGE flag "--sql <sql>" default="" help="SQL SELECT/WITH/PRAGMA query"
+#USAGE flag "--sql-file <file>" default="" help="File containing SQL query"
+#USAGE flag "--format <format>" default="table" help="Output format: table, grid, html, tsv, csv, json, or jsonl"
+#USAGE flag "--max-col-width <n>" default="80" help="Max display width per column for --format grid"
+#USAGE flag "--max-cell-lines <n>" default="12" help="Max wrapped lines per cell for --format grid; 0 means unlimited"
+#USAGE flag "--color <mode>" default="auto" help="Grid color mode: auto, always, or never"
+#USAGE flag "--browser" default=#false help="Render results to temporary HTML and open in the default browser"
+#USAGE flag "--title <title>" default="sessions query" help="HTML/browser result title"
+#USAGE flag "--out <path>" default="" help="Write query output to a file"
+
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+
+sys.path.insert(0, os.environ["MISE_CONFIG_ROOT"] + "/lib")
+from query.cli import main
+
+
+def add_value(argv: list[str], flag: str, value: str) -> None:
+    if value:
+        argv.extend([flag, value])
+
+
+def env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default)
+
+
+def build_argv() -> list[str]:
+    argv: list[str] = []
+    raw_session_ids = env("usage_session_ids")
+    if raw_session_ids:
+        argv.extend(item for item in shlex.split(raw_session_ids) if item)
+
+    add_value(argv, "--project", env("usage_project"))
+    add_value(argv, "--limit", env("usage_limit", "20"))
+
+    add_value(argv, "--text", env("usage_text", "commands"))
+    add_value(argv, "--max-output-chars", env("usage_max_output_chars", "4000"))
+    add_value(argv, "--max-message-chars", env("usage_max_message_chars", "2000"))
+    add_value(argv, "--sql", env("usage_sql"))
+    add_value(argv, "--sql-file", env("usage_sql_file"))
+    add_value(argv, "--format", env("usage_format", "table"))
+    add_value(argv, "--max-col-width", env("usage_max_col_width", "80"))
+    add_value(argv, "--max-cell-lines", env("usage_max_cell_lines", "12"))
+    add_value(argv, "--color", env("usage_color", "auto"))
+
+    if env("usage_browser", "false") == "true":
+        argv.append("--browser")
+
+    add_value(argv, "--title", env("usage_title", "sessions query"))
+    add_value(argv, "--out", env("usage_out"))
+    return argv
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(build_argv()))

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**294 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2540 lines in `lib/`.
+**294 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2535 lines in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 294 passing](https://img.shields.io/badge/tests-294%20passing-brightgreen?style=flat)](test/)
-![commands: 18](https://img.shields.io/badge/commands-18-blue?style=flat)
+[![tests: 295 passing](https://img.shields.io/badge/tests-295%20passing-brightgreen?style=flat)](test/)
+![commands: 19](https://img.shields.io/badge/commands-19-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
 </div>
@@ -268,7 +268,9 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**294 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2535 lines in `lib/`.
+**295 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2710 lines in `lib/`.
+
+Python code is checked with [Ruff](https://docs.astral.sh/ruff/) via `mise run lint:python`, and CI runs the same lint/format check in addition to the BATS and Elixir suites.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -291,6 +293,7 @@ sessions/
 │   ├── remove       # Remove sessions (kill shell + delete file)
 │   ├── run          # Hidden low-level executor used by wake
 │   ├── cli/build    # Build Elixir CLI dependencies
+│   ├── lint/python  # Ruff lint + format check for Python code
 │   ├── export       # Portable bundles (JSONL + metadata)
 │   └── import       # Import exported sessions
 ├── cli/             # Elixir execution engine (timeout, ABORT, usage)
@@ -304,7 +307,7 @@ sessions/
 │   └── harness/        # Per-harness adapters (pi, …)
 ├── queries/            # Packaged sessions query SQL presets
 └── test/
-    └── *.bats          # 294 tests
+    └── *.bats          # 295 tests
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 286 passing](https://img.shields.io/badge/tests-286%20passing-brightgreen?style=flat)](test/)
-![commands: 17](https://img.shields.io/badge/commands-17-blue?style=flat)
+[![tests: 294 passing](https://img.shields.io/badge/tests-294%20passing-brightgreen?style=flat)](test/)
+![commands: 18](https://img.shields.io/badge/commands-18-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
 </div>
@@ -66,6 +66,11 @@ sessions usage review/pr-50
 
 # Inspect forensic metadata
 sessions inspect e96bd43a
+
+# Query structured history without creating a durable DB
+sessions query --project junior/home --limit 30 \
+  --sql-file queries/bash-status.sql \
+  --format grid
 ```
 
 ## Session lifecycle
@@ -223,6 +228,38 @@ For existing sessions you want to work with elsewhere, `copy` duplicates a sessi
 sessions copy e96bd43a --context "continue the review"
 ```
 
+## Querying session history
+
+`sessions query` builds an ephemeral in-memory SQLite projection over local session JSONL files. JSONL remains the source of truth; no durable database is created. This is useful for ad hoc analysis across sessions, tools, messages, usage, and bash command status.
+
+Privacy defaults are conservative: the default `--text commands` mode inserts redacted bash commands, but not message text or tool output excerpts. Use `--text compact` only when you intentionally want bounded excerpts, and reserve `--text full` for explicitly scoped local analysis.
+
+```bash
+# Show the query schema and examples
+sessions query
+
+# Use a packaged SQL preset over a recent project slice
+sessions query --project junior/home --limit 30 \
+  --sql-file queries/bash-status.sql \
+  --format grid
+
+# Inspect failed bash commands for one session
+sessions query e96bd43a --sql '
+select call_seq, command_category, exit_status, output_lines, command
+from bash_calls
+where is_error = 1 or coalesce(exit_status, 0) != 0
+order by call_seq
+limit 20;
+' --format grid
+
+# Compact output excerpts require an explicit text mode
+sessions query e96bd43a --text compact \
+  --sql-file queries/bash-with-output.sql \
+  --format jsonl
+```
+
+Large result sets can be rendered as `--format html` or opened with `--browser` for a temporary local table with sticky headers and row filtering. Richer browser table controls are tracked separately so the first query surface can stay small.
+
 ## Development
 
 ```bash
@@ -231,7 +268,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**286 tests** across 20 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 826 lines in `lib/`.
+**294 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2540 lines in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -249,6 +286,7 @@ sessions/
 │   ├── usage        # Recorded token/cost aggregation
 │   ├── search       # Full-text regex across transcripts
 │   ├── inspect      # Forensic metadata (duration, tools, model)
+│   ├── query        # Ephemeral SQLite projection for ad hoc analysis
 │   ├── copy         # Duplicate sessions for handoff
 │   ├── remove       # Remove sessions (kill shell + delete file)
 │   ├── run          # Hidden low-level executor used by wake
@@ -262,9 +300,11 @@ sessions/
 │   ├── ensure-deps.sh  # First-run CLI deps self-heal
 │   ├── find.sh         # Back-compat shim → harness adapter
 │   ├── shell.sh        # Shell helpers
+│   ├── query/          # sessions query projection/rendering code
 │   └── harness/        # Per-harness adapters (pi, …)
+├── queries/            # Packaged sessions query SQL presets
 └── test/
-    └── *.bats          # 286 tests
+    └── *.bats          # 294 tests
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 294 passing](https://img.shields.io/badge/tests-294%20passing-brightgreen?style=flat)](test/)
+[![tests: 296 passing](https://img.shields.io/badge/tests-296%20passing-brightgreen?style=flat)](test/)
 ![commands: 18](https://img.shields.io/badge/commands-18-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -268,7 +268,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**294 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2535 lines in `lib/`.
+**296 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2560 lines in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -304,7 +304,7 @@ sessions/
 │   └── harness/        # Per-harness adapters (pi, …)
 ├── queries/            # Packaged sessions query SQL presets
 └── test/
-    └── *.bats          # 294 tests
+    └── *.bats          # 296 tests
 ```
 
 </details>

--- a/README.tsx
+++ b/README.tsx
@@ -451,6 +451,14 @@ mise run test`}</CodeBlock>
         {"."}
       </Paragraph>
 
+      <Paragraph>
+        {"Python code is checked with "}
+        <Link href="https://docs.astral.sh/ruff/">Ruff</Link>
+        {" via "}
+        <Code>mise run lint:python</Code>
+        {", and CI runs the same lint/format check in addition to the BATS and Elixir suites."}
+      </Paragraph>
+
       <Details summary="Project structure">
         <CodeBlock>{`sessions/
 ├── .mise/tasks/
@@ -469,6 +477,7 @@ mise run test`}</CodeBlock>
 │   ├── remove       # Remove sessions (kill shell + delete file)
 │   ├── run          # Hidden low-level executor used by wake
 │   ├── cli/build    # Build Elixir CLI dependencies
+│   ├── lint/python  # Ruff lint + format check for Python code
 │   ├── export       # Portable bundles (JSONL + metadata)
 │   └── import       # Import exported sessions
 ├── cli/             # Elixir execution engine (timeout, ABORT, usage)

--- a/README.tsx
+++ b/README.tsx
@@ -37,9 +37,16 @@ const batsVersion =
 
 // Count Python lib lines for the "how it works" credibility
 const libDir = join(ROOT, "lib");
-const libFiles = readdirSync(libDir).filter((f) => f.endsWith(".py"));
+function pythonFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return pythonFiles(path);
+    return entry.name.endsWith(".py") ? [path] : [];
+  });
+}
+const libFiles = pythonFiles(libDir);
 const libLines = libFiles.reduce(
-  (sum, f) => sum + readFileSync(join(libDir, f), "utf-8").split("\n").length,
+  (sum, f) => sum + readFileSync(f, "utf-8").split("\n").length,
   0
 );
 
@@ -157,7 +164,12 @@ sessions ps
 sessions usage review/pr-50
 
 # Inspect forensic metadata
-sessions inspect e96bd43a`}</CodeBlock>
+sessions inspect e96bd43a
+
+# Query structured history without creating a durable DB
+sessions query --project junior/home --limit 30 \\
+  --sql-file queries/bash-status.sql \\
+  --format grid`}</CodeBlock>
     </Section>
 
     <Section title="Session lifecycle">
@@ -376,6 +388,53 @@ sessions usage --after 2026-06-01 --json # machine-readable aggregate`}</CodeBlo
       <CodeBlock lang="bash">{`sessions copy e96bd43a --context "continue the review"`}</CodeBlock>
     </Section>
 
+    <Section title="Querying session history">
+      <Paragraph>
+        <Code>sessions query</Code>
+        {" builds an ephemeral in-memory SQLite projection over local session JSONL files. JSONL remains the source of truth; no durable database is created. This is useful for ad hoc analysis across sessions, tools, messages, usage, and bash command status."}
+      </Paragraph>
+
+      <Paragraph>
+        {"Privacy defaults are conservative: the default "}
+        <Code>--text commands</Code>
+        {" mode inserts redacted bash commands, but not message text or tool output excerpts. Use "}
+        <Code>--text compact</Code>
+        {" only when you intentionally want bounded excerpts, and reserve "}
+        <Code>--text full</Code>
+        {" for explicitly scoped local analysis."}
+      </Paragraph>
+
+      <CodeBlock lang="bash">{`# Show the query schema and examples
+sessions query
+
+# Use a packaged SQL preset over a recent project slice
+sessions query --project junior/home --limit 30 \\
+  --sql-file queries/bash-status.sql \\
+  --format grid
+
+# Inspect failed bash commands for one session
+sessions query e96bd43a --sql '
+select call_seq, command_category, exit_status, output_lines, command
+from bash_calls
+where is_error = 1 or coalesce(exit_status, 0) != 0
+order by call_seq
+limit 20;
+' --format grid
+
+# Compact output excerpts require an explicit text mode
+sessions query e96bd43a --text compact \\
+  --sql-file queries/bash-with-output.sql \\
+  --format jsonl`}</CodeBlock>
+
+      <Paragraph>
+        {"Large result sets can be rendered as "}
+        <Code>--format html</Code>
+        {" or opened with "}
+        <Code>--browser</Code>
+        {" for a temporary local table with sticky headers and row filtering. Richer browser table controls are tracked separately so the first query surface can stay small."}
+      </Paragraph>
+    </Section>
+
     <Section title="Development">
       <CodeBlock lang="bash">{`git clone https://github.com/KnickKnackLabs/sessions.git
 cd sessions && mise trust && mise install
@@ -405,6 +464,7 @@ mise run test`}</CodeBlock>
 │   ├── usage        # Recorded token/cost aggregation
 │   ├── search       # Full-text regex across transcripts
 │   ├── inspect      # Forensic metadata (duration, tools, model)
+│   ├── query        # Ephemeral SQLite projection for ad hoc analysis
 │   ├── copy         # Duplicate sessions for handoff
 │   ├── remove       # Remove sessions (kill shell + delete file)
 │   ├── run          # Hidden low-level executor used by wake
@@ -418,7 +478,9 @@ mise run test`}</CodeBlock>
 │   ├── ensure-deps.sh  # First-run CLI deps self-heal
 │   ├── find.sh         # Back-compat shim → harness adapter
 │   ├── shell.sh        # Shell helpers
+│   ├── query/          # sessions query projection/rendering code
 │   └── harness/        # Per-harness adapters (pi, …)
+├── queries/            # Packaged sessions query SQL presets
 └── test/
     └── *.bats          # ${testCount} tests`}</CodeBlock>
       </Details>

--- a/lib/harness/__init__.py
+++ b/lib/harness/__init__.py
@@ -44,11 +44,7 @@ class Unsupported(Exception):
     def __init__(self, op: str, harness: str = ""):
         self.op = op
         self.harness = harness
-        message = (
-            f"'{harness}' harness does not support '{op}' yet"
-            if harness
-            else op
-        )
+        message = f"'{harness}' harness does not support '{op}' yet" if harness else op
         super().__init__(message)
 
 
@@ -67,6 +63,7 @@ def exit_unsupported(harness: str, op: str) -> None:
 
 
 # --- Registry ---
+
 
 def available() -> list:
     """List adapter names present in this package, sorted."""
@@ -87,6 +84,7 @@ def _load(name: str):
 
 
 # --- Resolver inputs ---
+
 
 def _from_entries(entries: list):
     """Scan entries in reverse; return the most recent harness-declaration name."""
@@ -132,6 +130,7 @@ def _from_path(filepath: str):
 
 # --- Resolver ---
 
+
 def resolve(*, filepath: str = None, entries: list = None, name: str = None):
     """Resolve the harness for a session. Returns the adapter module.
 
@@ -154,6 +153,7 @@ def resolve(*, filepath: str = None, entries: list = None, name: str = None):
 
 
 # --- Convenience for non-session callers ---
+
 
 def adapter(name: str):
     """Load an adapter module by name. Prefer `resolve()` when you have a session."""

--- a/lib/harness/claude.py
+++ b/lib/harness/claude.py
@@ -14,6 +14,7 @@ from harness import Unsupported
 
 # --- Entry-level schema ---
 
+
 def is_message_entry(entry: dict) -> bool:
     raise Unsupported("is_message_entry", harness="claude")
 
@@ -67,6 +68,7 @@ def usage_records(entries: list) -> list:
 
 
 # --- Location / lookup ---
+
 
 def sessions_dir() -> str:
     raise Unsupported("sessions_dir", harness="claude")

--- a/lib/harness/pi.py
+++ b/lib/harness/pi.py
@@ -20,16 +20,16 @@ at the bottom.
 
 import json
 import os
-import sys
 
 
 # --- Entry-level schema ---
 
+
 def is_message_entry(entry: dict) -> bool:
     """True if `entry` is a pi user/assistant message."""
-    return (
-        entry.get("type") == "message"
-        and entry.get("message", {}).get("role") in ("user", "assistant")
+    return entry.get("type") == "message" and entry.get("message", {}).get("role") in (
+        "user",
+        "assistant",
     )
 
 
@@ -120,24 +120,26 @@ def usage_records(entries: list) -> list:
             continue
 
         cost = usage.get("cost") if isinstance(usage.get("cost"), dict) else {}
-        records.append({
-            "index": idx,
-            "timestamp": entry.get("timestamp", ""),
-            "provider": msg.get("provider") or current_provider or "",
-            "model": msg.get("model") or current_model or "unknown",
-            "input": _number(usage.get("input")),
-            "output": _number(usage.get("output")),
-            "cacheRead": _number(usage.get("cacheRead")),
-            "cacheWrite": _number(usage.get("cacheWrite")),
-            "totalTokens": _number(usage.get("totalTokens")),
-            "cost": {
-                "input": _float(cost.get("input")),
-                "output": _float(cost.get("output")),
-                "cacheRead": _float(cost.get("cacheRead")),
-                "cacheWrite": _float(cost.get("cacheWrite")),
-                "total": _float(cost.get("total")),
-            },
-        })
+        records.append(
+            {
+                "index": idx,
+                "timestamp": entry.get("timestamp", ""),
+                "provider": msg.get("provider") or current_provider or "",
+                "model": msg.get("model") or current_model or "unknown",
+                "input": _number(usage.get("input")),
+                "output": _number(usage.get("output")),
+                "cacheRead": _number(usage.get("cacheRead")),
+                "cacheWrite": _number(usage.get("cacheWrite")),
+                "totalTokens": _number(usage.get("totalTokens")),
+                "cost": {
+                    "input": _float(cost.get("input")),
+                    "output": _float(cost.get("output")),
+                    "cacheRead": _float(cost.get("cacheRead")),
+                    "cacheWrite": _float(cost.get("cacheWrite")),
+                    "total": _float(cost.get("total")),
+                },
+            }
+        )
 
     return records
 
@@ -206,6 +208,7 @@ def message_counts(entries: list) -> tuple[int, int]:
 
 # --- Text rendering ---
 
+
 def text_messages(entries: list) -> list:
     """
     Render pi's JSONL entries into (index, role, timestamp, text) tuples.
@@ -238,7 +241,8 @@ def text_messages(entries: list) -> list:
             preview = _extract_tool_result_preview(content)
             text = (
                 f"[tool_result: {tool_name}: {preview}]"
-                if preview else f"[tool_result: {tool_name}]"
+                if preview
+                else f"[tool_result: {tool_name}]"
             )
             results.append((i, "user", ts, text))
 
@@ -313,6 +317,7 @@ def _extract_tool_result_preview(content) -> str:
 
 
 # --- Location / lookup ---
+
 
 def sessions_dir() -> str:
     """Pi sessions root. Honours $PI_DIR for tests; defaults to ~/.pi."""

--- a/lib/parse.py
+++ b/lib/parse.py
@@ -108,6 +108,7 @@ class Session:
 
 # --- Generic helpers (harness-agnostic) ---
 
+
 def dict_contains(haystack: dict, needle: dict) -> bool:
     """Check if haystack contains all keys/values from needle (recursive)."""
     for key, value in needle.items():
@@ -143,10 +144,13 @@ def parse_meta_filter(raw: str) -> dict:
         except json.JSONDecodeError:
             # Try evaluating via jq for jq-syntax (e.g., unquoted keys)
             import subprocess
+
             try:
                 result = subprocess.run(
                     ["jq", "-nc", raw],
-                    capture_output=True, text=True, timeout=5,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
                 )
                 if result.returncode == 0:
                     return json.loads(result.stdout.strip())
@@ -180,6 +184,7 @@ class Filter:
     path: dotted path within the entry (e.g., 'meta.agent.name')
     value: expected value
     """
+
     entry_type: str
     index: object  # int or None
     path: str
@@ -197,6 +202,7 @@ def parse_filters(raw: str) -> list:
         wake[-1].meta.by.agent.name=brownie
     """
     import shlex
+
     filters = []
     if not raw.strip():
         return filters
@@ -220,8 +226,8 @@ def parse_filters(raw: str) -> list:
         index = None
         if "[" in lhs.split(".")[0]:
             type_part = lhs.split(".")[0]
-            entry_type = type_part[:type_part.index("[")]
-            idx_str = type_part[type_part.index("[") + 1:type_part.index("]")]
+            entry_type = type_part[: type_part.index("[")]
+            idx_str = type_part[type_part.index("[") + 1 : type_part.index("]")]
             try:
                 index = int(idx_str)
             except ValueError:
@@ -231,7 +237,9 @@ def parse_filters(raw: str) -> list:
             entry_type = lhs.split(".")[0]
             path = ".".join(lhs.split(".")[1:])
 
-        filters.append(Filter(entry_type=entry_type, index=index, path=path, value=value))
+        filters.append(
+            Filter(entry_type=entry_type, index=index, path=path, value=value)
+        )
 
     return filters
 
@@ -254,7 +262,7 @@ def _entry_matches_filter(entry: dict, f: Filter) -> bool:
     return str(val) == f.value
 
 
-def session_matches_filters(session: 'Session', filters: list) -> bool:
+def session_matches_filters(session: "Session", filters: list) -> bool:
     """Check if a session matches ALL filters."""
     for f in filters:
         typed_entries = [e for e in session.entries if e.get("type") == f.entry_type]
@@ -294,6 +302,7 @@ def load(filepath: str) -> Session:
 # all available harnesses and merges the results. Today pi is the only
 # adapter, so the iteration has one iteration — the shape is ready for
 # when claude (or another adapter) lands.
+
 
 def discover_sessions_dir() -> str:
     """Return the default harness's sessions root.

--- a/lib/processes.py
+++ b/lib/processes.py
@@ -45,10 +45,12 @@ class ProcessRow:
             "headless": self.start.get("headless", False),
         }
         if self.exit is not None:
-            result.update({
-                "exited_at": self.exit.get("timestamp", ""),
-                "exit_code": self.exit.get("exit_code"),
-            })
+            result.update(
+                {
+                    "exited_at": self.exit.get("timestamp", ""),
+                    "exit_code": self.exit.get("exit_code"),
+                }
+            )
         return result
 
 
@@ -137,7 +139,11 @@ def session_process_rows(
 ) -> list[ProcessRow]:
     session = parse.load(filepath)
     meta = session.metadata()
-    if project_filter and project_filter not in meta["project"] and project_filter not in filepath:
+    if (
+        project_filter
+        and project_filter not in meta["project"]
+        and project_filter not in filepath
+    ):
         return []
 
     starts: list[dict] = []
@@ -162,13 +168,15 @@ def session_process_rows(
             status = "dead"
 
         if include_all or status == "live":
-            rows.append(ProcessRow(
-                session=session,
-                filepath=filepath,
-                start=start,
-                exit=exit_entry,
-                status=status,
-            ))
+            rows.append(
+                ProcessRow(
+                    session=session,
+                    filepath=filepath,
+                    start=start,
+                    exit=exit_entry,
+                    status=status,
+                )
+            )
     return rows
 
 
@@ -181,11 +189,13 @@ def collect_process_rows(
     rows: list[ProcessRow] = []
     for filepath in iter_session_files():
         try:
-            rows.extend(session_process_rows(
-                filepath,
-                project_filter=project_filter,
-                include_all=include_all,
-            ))
+            rows.extend(
+                session_process_rows(
+                    filepath,
+                    project_filter=project_filter,
+                    include_all=include_all,
+                )
+            )
         except Exception:
             continue
 

--- a/lib/query/__init__.py
+++ b/lib/query/__init__.py
@@ -1,0 +1,1 @@
+"""Session query prototype support package."""

--- a/lib/query/browser.py
+++ b/lib/query/browser.py
@@ -28,7 +28,9 @@ def _cell_html(value: object) -> str:
     return escaped
 
 
-def render_html(names: list[str], rows: list[sqlite3.Row], out: TextIO, *, title: str) -> None:
+def render_html(
+    names: list[str], rows: list[sqlite3.Row], out: TextIO, *, title: str
+) -> None:
     safe_title = html.escape(title)
     out.write(
         "<!doctype html>\n"
@@ -87,9 +89,13 @@ def render_html(names: list[str], rows: list[sqlite3.Row], out: TextIO, *, title
     )
 
 
-def write_html_file(names: list[str], rows: list[sqlite3.Row], *, title: str, output: Path | None = None) -> Path:
+def write_html_file(
+    names: list[str], rows: list[sqlite3.Row], *, title: str, output: Path | None = None
+) -> Path:
     if output is None:
-        handle = tempfile.NamedTemporaryFile(prefix="sessions-query-", suffix=".html", delete=False, mode="w")
+        handle = tempfile.NamedTemporaryFile(
+            prefix="sessions-query-", suffix=".html", delete=False, mode="w"
+        )
         path = Path(handle.name)
         with handle:
             render_html(names, rows, handle, title=title)

--- a/lib/query/browser.py
+++ b/lib/query/browser.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import html
+import sqlite3
+import tempfile
+import webbrowser
+from pathlib import Path
+from typing import TextIO
+
+
+def _value(value: object) -> str:
+    return "" if value is None else str(value)
+
+
+def _summary(text: str, limit: int = 96) -> str:
+    one_line = " ".join(text.split())
+    if len(one_line) <= limit:
+        return one_line or "—"
+    return one_line[: limit - 1] + "…"
+
+
+def _cell_html(value: object) -> str:
+    text = _value(value)
+    escaped = html.escape(text)
+    if "\n" in text or len(text) > 140:
+        summary = html.escape(_summary(text))
+        return f"<details><summary>{summary}</summary><pre>{escaped}</pre></details>"
+    return escaped
+
+
+def render_html(names: list[str], rows: list[sqlite3.Row], out: TextIO, *, title: str) -> None:
+    safe_title = html.escape(title)
+    out.write(
+        "<!doctype html>\n"
+        "<meta charset='utf-8'>\n"
+        f"<title>{safe_title}</title>\n"
+        "<style>\n"
+        ":root { color-scheme: light dark; --border: #6666; --muted: #888; }\n"
+        "body { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; margin: 1rem; }\n"
+        "h1 { font-size: 1.1rem; margin: 0 0 .75rem; }\n"
+        ".controls { position: sticky; top: 0; z-index: 3; padding: .5rem 0; background: Canvas; }\n"
+        "input { font: inherit; width: min(60rem, 95vw); padding: .35rem .5rem; }\n"
+        ".meta { color: var(--muted); margin: .4rem 0 .8rem; }\n"
+        ".wrap { overflow: auto; max-height: 82vh; border: 1px solid var(--border); }\n"
+        "table { border-collapse: collapse; width: max-content; min-width: 100%; }\n"
+        "th, td { border: 1px solid var(--border); padding: .3rem .45rem; vertical-align: top; max-width: 44rem; }\n"
+        "th { position: sticky; top: 0; z-index: 2; background: Canvas; text-align: left; }\n"
+        "tr:nth-child(even) td { background: color-mix(in srgb, CanvasText 4%, Canvas); }\n"
+        "pre { white-space: pre-wrap; margin: .35rem 0 0; }\n"
+        "summary { cursor: pointer; color: LinkText; }\n"
+        ".num { text-align: right; }\n"
+        "</style>\n"
+        "<div class='controls'>\n"
+        f"<h1>{safe_title}</h1>\n"
+        "<input id='filter' placeholder='filter rows…' autofocus>\n"
+        f"<div class='meta'><span id='shown'>{len(rows)}</span> / {len(rows)} rows</div>\n"
+        "</div>\n"
+        "<div class='wrap'>\n<table id='results'>\n<thead><tr>"
+    )
+    for name in names:
+        out.write(f"<th>{html.escape(name)}</th>")
+    out.write("</tr></thead>\n<tbody>\n")
+    for row in rows:
+        out.write("<tr>")
+        for name in names:
+            value = row[name]
+            cls = " class='num'" if isinstance(value, (int, float)) else ""
+            out.write(f"<td{cls}>{_cell_html(value)}</td>")
+        out.write("</tr>\n")
+    out.write(
+        "</tbody>\n</table>\n</div>\n"
+        "<script>\n"
+        "const filter = document.getElementById('filter');\n"
+        "const shown = document.getElementById('shown');\n"
+        "const rows = Array.from(document.querySelectorAll('#results tbody tr'));\n"
+        "filter.addEventListener('input', () => {\n"
+        "  const q = filter.value.toLowerCase();\n"
+        "  let n = 0;\n"
+        "  for (const row of rows) {\n"
+        "    const ok = row.innerText.toLowerCase().includes(q);\n"
+        "    row.style.display = ok ? '' : 'none';\n"
+        "    if (ok) n++;\n"
+        "  }\n"
+        "  shown.textContent = n;\n"
+        "});\n"
+        "</script>\n"
+    )
+
+
+def write_html_file(names: list[str], rows: list[sqlite3.Row], *, title: str, output: Path | None = None) -> Path:
+    if output is None:
+        handle = tempfile.NamedTemporaryFile(prefix="sessions-query-", suffix=".html", delete=False, mode="w")
+        path = Path(handle.name)
+        with handle:
+            render_html(names, rows, handle, title=title)
+        return path
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w") as f:
+        render_html(names, rows, f, title=title)
+    return output
+
+
+def open_html(path: Path) -> bool:
+    return webbrowser.open(path.resolve().as_uri())

--- a/lib/query/cli.py
+++ b/lib/query/cli.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .browser import open_html, render_html, write_html_file
+from .db import build_db
+from .help import schema_text
+from .query import rows_for_query
+from .render import render
+from .util import resolve_path
+
+
+def resolve_sql_file(value: str) -> Path:
+    requested = Path(value).expanduser()
+    path = resolve_path(requested)
+    if path.exists() or requested.is_absolute():
+        return path
+    package_path = Path(__file__).resolve().parents[2] / requested
+    if package_path.exists():
+        return package_path
+    return path
+
+
+def read_sql(args: argparse.Namespace) -> str | None:
+    if args.sql_file:
+        return resolve_sql_file(args.sql_file).read_text()
+    return args.sql
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Query local sessions through an ephemeral SQLite projection")
+    parser.add_argument("session_ids", nargs="*", help="Optional session ID prefixes to query")
+    parser.add_argument("--project", default="", help="Project substring filter when querying a corpus")
+    parser.add_argument("--limit", type=int, default=20, help="Max sessions for corpus scope")
+    parser.add_argument("--text", choices=["none", "commands", "compact", "full"], default="commands", help="Text columns to insert into the ephemeral DB")
+    parser.add_argument("--max-output-chars", type=int, default=4000, help="Output excerpt budget for --text compact")
+    parser.add_argument("--max-message-chars", type=int, default=2000, help="Message excerpt budget for --text compact")
+    parser.add_argument("--sql", default="", help="SQL SELECT/WITH/PRAGMA query")
+    parser.add_argument("--sql-file", default="", help="File containing SQL query")
+    parser.add_argument("--format", choices=["table", "grid", "html", "tsv", "csv", "json", "jsonl"], default="table", help="Output format")
+    parser.add_argument("--max-col-width", type=int, default=80, help="Max display width per column for --format grid")
+    parser.add_argument("--max-cell-lines", type=int, default=12, help="Max wrapped lines per cell for --format grid; 0 means unlimited")
+    parser.add_argument("--color", choices=["auto", "always", "never"], default="auto", help="Color mode for grid separators; auto dims separators on a TTY")
+    parser.add_argument("--browser", action="store_true", help="Render results to temporary HTML and open in the default browser")
+    parser.add_argument("--title", default="sessions query", help="HTML/browser result title")
+    parser.add_argument("--out", default="", help="Write query output to a file")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    sql = read_sql(args)
+    if not sql:
+        print(schema_text())
+        return 0
+    conn = build_db(args)
+    names, rows = rows_for_query(conn, sql)
+    output = resolve_path(args.out) if args.out else None
+    if args.browser:
+        html_path = write_html_file(names, rows, title=args.title, output=output)
+        open_html(html_path)
+        print(html_path)
+        return 0
+    if args.format == "html":
+        if output:
+            write_html_file(names, rows, title=args.title, output=output)
+        else:
+            render_html(names, rows, sys.stdout, title=args.title)
+        return 0
+    render(
+        names,
+        rows,
+        fmt=args.format,
+        output=output,
+        max_col_width=args.max_col_width,
+        max_cell_lines=args.max_cell_lines,
+        color=args.color,
+    )
+    return 0

--- a/lib/query/cli.py
+++ b/lib/query/cli.py
@@ -30,21 +30,70 @@ def read_sql(args: argparse.Namespace) -> str | None:
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Query local sessions through an ephemeral SQLite projection")
-    parser.add_argument("session_ids", nargs="*", help="Optional session ID prefixes to query")
-    parser.add_argument("--project", default="", help="Project substring filter when querying a corpus")
-    parser.add_argument("--limit", type=int, default=20, help="Max sessions for corpus scope")
-    parser.add_argument("--text", choices=["none", "commands", "compact", "full"], default="commands", help="Text columns to insert into the ephemeral DB")
-    parser.add_argument("--max-output-chars", type=int, default=4000, help="Output excerpt budget for --text compact")
-    parser.add_argument("--max-message-chars", type=int, default=2000, help="Message excerpt budget for --text compact")
+    parser = argparse.ArgumentParser(
+        description="Query local sessions through an ephemeral SQLite projection"
+    )
+    parser.add_argument(
+        "session_ids", nargs="*", help="Optional session ID prefixes to query"
+    )
+    parser.add_argument(
+        "--project", default="", help="Project substring filter when querying a corpus"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=20, help="Max sessions for corpus scope"
+    )
+    parser.add_argument(
+        "--text",
+        choices=["none", "commands", "compact", "full"],
+        default="commands",
+        help="Text columns to insert into the ephemeral DB",
+    )
+    parser.add_argument(
+        "--max-output-chars",
+        type=int,
+        default=4000,
+        help="Output excerpt budget for --text compact",
+    )
+    parser.add_argument(
+        "--max-message-chars",
+        type=int,
+        default=2000,
+        help="Message excerpt budget for --text compact",
+    )
     parser.add_argument("--sql", default="", help="SQL SELECT/WITH/PRAGMA query")
     parser.add_argument("--sql-file", default="", help="File containing SQL query")
-    parser.add_argument("--format", choices=["table", "grid", "html", "tsv", "csv", "json", "jsonl"], default="table", help="Output format")
-    parser.add_argument("--max-col-width", type=int, default=80, help="Max display width per column for --format grid")
-    parser.add_argument("--max-cell-lines", type=int, default=12, help="Max wrapped lines per cell for --format grid; 0 means unlimited")
-    parser.add_argument("--color", choices=["auto", "always", "never"], default="auto", help="Color mode for grid separators; auto dims separators on a TTY")
-    parser.add_argument("--browser", action="store_true", help="Render results to temporary HTML and open in the default browser")
-    parser.add_argument("--title", default="sessions query", help="HTML/browser result title")
+    parser.add_argument(
+        "--format",
+        choices=["table", "grid", "html", "tsv", "csv", "json", "jsonl"],
+        default="table",
+        help="Output format",
+    )
+    parser.add_argument(
+        "--max-col-width",
+        type=int,
+        default=80,
+        help="Max display width per column for --format grid",
+    )
+    parser.add_argument(
+        "--max-cell-lines",
+        type=int,
+        default=12,
+        help="Max wrapped lines per cell for --format grid; 0 means unlimited",
+    )
+    parser.add_argument(
+        "--color",
+        choices=["auto", "always", "never"],
+        default="auto",
+        help="Color mode for grid separators; auto dims separators on a TTY",
+    )
+    parser.add_argument(
+        "--browser",
+        action="store_true",
+        help="Render results to temporary HTML and open in the default browser",
+    )
+    parser.add_argument(
+        "--title", default="sessions query", help="HTML/browser result title"
+    )
     parser.add_argument("--out", default="", help="Write query output to a file")
     return parser.parse_args(argv)
 

--- a/lib/query/cli.py
+++ b/lib/query/cli.py
@@ -29,19 +29,39 @@ def read_sql(args: argparse.Namespace) -> str | None:
     return args.sql
 
 
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than 0")
+    return parsed
+
+
+def non_negative_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be greater than or equal to 0")
+    return parsed
+
+
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Query local sessions through an ephemeral SQLite projection")
     parser.add_argument("session_ids", nargs="*", help="Optional session ID prefixes to query")
     parser.add_argument("--project", default="", help="Project substring filter when querying a corpus")
     parser.add_argument("--limit", type=int, default=20, help="Max sessions for corpus scope")
     parser.add_argument("--text", choices=["none", "commands", "compact", "full"], default="commands", help="Text columns to insert into the ephemeral DB")
-    parser.add_argument("--max-output-chars", type=int, default=4000, help="Output excerpt budget for --text compact")
-    parser.add_argument("--max-message-chars", type=int, default=2000, help="Message excerpt budget for --text compact")
+    parser.add_argument("--max-output-chars", type=positive_int, default=4000, help="Output excerpt budget for --text compact")
+    parser.add_argument("--max-message-chars", type=positive_int, default=2000, help="Message excerpt budget for --text compact")
     parser.add_argument("--sql", default="", help="SQL SELECT/WITH/PRAGMA query")
     parser.add_argument("--sql-file", default="", help="File containing SQL query")
     parser.add_argument("--format", choices=["table", "grid", "html", "tsv", "csv", "json", "jsonl"], default="table", help="Output format")
-    parser.add_argument("--max-col-width", type=int, default=80, help="Max display width per column for --format grid")
-    parser.add_argument("--max-cell-lines", type=int, default=12, help="Max wrapped lines per cell for --format grid; 0 means unlimited")
+    parser.add_argument("--max-col-width", type=positive_int, default=80, help="Max display width per column for --format grid")
+    parser.add_argument("--max-cell-lines", type=non_negative_int, default=12, help="Max wrapped lines per cell for --format grid; 0 means unlimited")
     parser.add_argument("--color", choices=["auto", "always", "never"], default="auto", help="Color mode for grid separators; auto dims separators on a TTY")
     parser.add_argument("--browser", action="store_true", help="Render results to temporary HTML and open in the default browser")
     parser.add_argument("--title", default="sessions query", help="HTML/browser result title")

--- a/lib/query/constants.py
+++ b/lib/query/constants.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import re
 
-from pathlib import Path
-from typing import Any, Iterable
 
 FAILURE_MARKERS = (
     "Command exited with code ",
@@ -16,16 +14,36 @@ SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"github_pat_[A-Za-z0-9_]+"), "github_pat_[REDACTED]"),
     (re.compile(r"gh[pousr]_[A-Za-z0-9_]+"), "gh*_REDACTED"),
     (re.compile(r"sk-[A-Za-z0-9_-]{16,}"), "sk-[REDACTED]"),
-    (re.compile(r"(?i)(GITHUB_TOKEN|GH_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY|API_KEY|TOKEN|PASSWORD|SECRET)=([^\s'\"]+)"), r"\1=[REDACTED]"),
-    (re.compile(r"-----BEGIN [^-]+-----.*?-----END [^-]+-----", re.DOTALL), "[REDACTED PEM BLOCK]"),
+    (
+        re.compile(
+            r"(?i)(GITHUB_TOKEN|GH_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY|API_KEY|TOKEN|PASSWORD|SECRET)=([^\s'\"]+)"
+        ),
+        r"\1=[REDACTED]",
+    ),
+    (
+        re.compile(r"-----BEGIN [^-]+-----.*?-----END [^-]+-----", re.DOTALL),
+        "[REDACTED PEM BLOCK]",
+    ),
 ]
 
-TEST_RE = re.compile(r"\b(mise\s+run\s+(?:-q\s+)?test|bats\b|mix\s+test|bun\s+test|cargo\s+test|pytest\b|npm\s+test)\b")
-LINT_RE = re.compile(r"\b(codebase\s+lint|shellcheck\b|actionlint\b|git\s+diff\s+--check|bash\s+-n|readme\s+build\s+--check|cargo\s+fmt|mix\s+format|pre-commit|pre-push)\b")
-GIT_GH_RE = re.compile(r"^\s*(git|gh)\b|\bgh\s+(pr|issue|api|run)\b|\bgit\s+(status|diff|log|show|fetch|pull|push|commit|checkout|switch|merge|rev-parse)\b")
+TEST_RE = re.compile(
+    r"\b(mise\s+run\s+(?:-q\s+)?test|bats\b|mix\s+test|bun\s+test|cargo\s+test|pytest\b|npm\s+test)\b"
+)
+LINT_RE = re.compile(
+    r"\b(codebase\s+lint|shellcheck\b|actionlint\b|git\s+diff\s+--check|bash\s+-n|readme\s+build\s+--check|cargo\s+fmt|mix\s+format|pre-commit|pre-push)\b"
+)
+GIT_GH_RE = re.compile(
+    r"^\s*(git|gh)\b|\bgh\s+(pr|issue|api|run)\b|\bgit\s+(status|diff|log|show|fetch|pull|push|commit|checkout|switch|merge|rev-parse)\b"
+)
 SEARCH_RE = re.compile(r"^\s*(rg|grep|find|ls|wc|jq)\b|\b(rg|grep|find)\b")
-INSTALL_RE = re.compile(r"\b(mise\s+(trust|install|x|exec)|npm\s+install|bun\s+install|cargo\s+build|mix\s+deps|get)\b")
-SESSION_RE = re.compile(r"\b(sessions|sphincters|shimmer|shell\s+(status|wait|attach))\b")
-FILE_RE = re.compile(r"^\s*(cp|mv|rm|mkdir|chmod|touch|tee|cat)\b|\b(chmod|mkdir|rm\s+-rf)\b")
+INSTALL_RE = re.compile(
+    r"\b(mise\s+(trust|install|x|exec)|npm\s+install|bun\s+install|cargo\s+build|mix\s+deps|get)\b"
+)
+SESSION_RE = re.compile(
+    r"\b(sessions|sphincters|shimmer|shell\s+(status|wait|attach))\b"
+)
+FILE_RE = re.compile(
+    r"^\s*(cp|mv|rm|mkdir|chmod|touch|tee|cat)\b|\b(chmod|mkdir|rm\s+-rf)\b"
+)
 SCRIPT_RE = re.compile(r"^\s*(python3?|node|bun|ruby|perl)\b|<<'?(PY|EOF|JS|SH)'?")
 EXIT_RE = re.compile(r"Command exited with code (\d+)")

--- a/lib/query/constants.py
+++ b/lib/query/constants.py
@@ -29,4 +29,3 @@ SESSION_RE = re.compile(r"\b(sessions|sphincters|shimmer|shell\s+(status|wait|at
 FILE_RE = re.compile(r"^\s*(cp|mv|rm|mkdir|chmod|touch|tee|cat)\b|\b(chmod|mkdir|rm\s+-rf)\b")
 SCRIPT_RE = re.compile(r"^\s*(python3?|node|bun|ruby|perl)\b|<<'?(PY|EOF|JS|SH)'?")
 EXIT_RE = re.compile(r"Command exited with code (\d+)")
-

--- a/lib/query/constants.py
+++ b/lib/query/constants.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import re
+
+from pathlib import Path
+from typing import Any, Iterable
+
+FAILURE_MARKERS = (
+    "Command exited with code ",
+    "Command timed out",
+    "ERROR task failed",
+    "timed out after",
+)
+
+SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"github_pat_[A-Za-z0-9_]+"), "github_pat_[REDACTED]"),
+    (re.compile(r"gh[pousr]_[A-Za-z0-9_]+"), "gh*_REDACTED"),
+    (re.compile(r"sk-[A-Za-z0-9_-]{16,}"), "sk-[REDACTED]"),
+    (re.compile(r"(?i)(GITHUB_TOKEN|GH_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY|API_KEY|TOKEN|PASSWORD|SECRET)=([^\s'\"]+)"), r"\1=[REDACTED]"),
+    (re.compile(r"-----BEGIN [^-]+-----.*?-----END [^-]+-----", re.DOTALL), "[REDACTED PEM BLOCK]"),
+]
+
+TEST_RE = re.compile(r"\b(mise\s+run\s+(?:-q\s+)?test|bats\b|mix\s+test|bun\s+test|cargo\s+test|pytest\b|npm\s+test)\b")
+LINT_RE = re.compile(r"\b(codebase\s+lint|shellcheck\b|actionlint\b|git\s+diff\s+--check|bash\s+-n|readme\s+build\s+--check|cargo\s+fmt|mix\s+format|pre-commit|pre-push)\b")
+GIT_GH_RE = re.compile(r"^\s*(git|gh)\b|\bgh\s+(pr|issue|api|run)\b|\bgit\s+(status|diff|log|show|fetch|pull|push|commit|checkout|switch|merge|rev-parse)\b")
+SEARCH_RE = re.compile(r"^\s*(rg|grep|find|ls|wc|jq)\b|\b(rg|grep|find)\b")
+INSTALL_RE = re.compile(r"\b(mise\s+(trust|install|x|exec)|npm\s+install|bun\s+install|cargo\s+build|mix\s+deps|get)\b")
+SESSION_RE = re.compile(r"\b(sessions|sphincters|shimmer|shell\s+(status|wait|attach))\b")
+FILE_RE = re.compile(r"^\s*(cp|mv|rm|mkdir|chmod|touch|tee|cat)\b|\b(chmod|mkdir|rm\s+-rf)\b")
+SCRIPT_RE = re.compile(r"^\s*(python3?|node|bun|ruby|perl)\b|<<'?(PY|EOF|JS|SH)'?")
+EXIT_RE = re.compile(r"Command exited with code (\d+)")
+

--- a/lib/query/constants.py
+++ b/lib/query/constants.py
@@ -16,7 +16,10 @@ SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"github_pat_[A-Za-z0-9_]+"), "github_pat_[REDACTED]"),
     (re.compile(r"gh[pousr]_[A-Za-z0-9_]+"), "gh*_REDACTED"),
     (re.compile(r"sk-[A-Za-z0-9_-]{16,}"), "sk-[REDACTED]"),
-    (re.compile(r"(?i)(GITHUB_TOKEN|GH_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY|API_KEY|TOKEN|PASSWORD|SECRET)=([^\s'\"]+)"), r"\1=[REDACTED]"),
+    (re.compile(r"(?i)\b(GITHUB_TOKEN|GH_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY|API_KEY|TOKEN|PASSWORD|SECRET)=(['\"])[^'\"]*\2"), r"\1=\2[REDACTED]\2"),
+    (re.compile(r"(?i)\b(GITHUB_TOKEN|GH_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY|API_KEY|TOKEN|PASSWORD|SECRET)=([^\s'\"]+)"), r"\1=[REDACTED]"),
+    (re.compile(r"(?i)(Authorization:\s*(?:Bearer|Basic)\s+)[^'\"\s]+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(--(?:api-key|password|secret|token)\s+)[^'\"\s]+"), r"\1[REDACTED]"),
     (re.compile(r"-----BEGIN [^-]+-----.*?-----END [^-]+-----", re.DOTALL), "[REDACTED PEM BLOCK]"),
 ]
 

--- a/lib/query/db.py
+++ b/lib/query/db.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+
+from .model import ScopeEntry, ToolCallRecord, ToolResultRecord, UsageTotals
+from .scope import scope_entries
+from .util import (
+    collect_text_blocks,
+    command_category,
+    compact_text,
+    duration_ms,
+    duration_session_ms,
+    output_status,
+    redact,
+)
+
+
+def create_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        create table sessions (
+          session_id text primary key,
+          runtime text,
+          project text,
+          name text,
+          slug text,
+          model text,
+          first_timestamp text,
+          last_timestamp text,
+          duration_ms integer,
+          total_entries integer,
+          user_messages integer,
+          assistant_messages integer,
+          filepath text,
+          calls integer,
+          input_tokens integer,
+          output_tokens integer,
+          cache_read_tokens integer,
+          cache_write_tokens integer,
+          total_tokens integer,
+          cost_total real
+        );
+
+        create table events (
+          session_id text,
+          seq integer,
+          timestamp text,
+          type text,
+          role text,
+          primary key (session_id, seq)
+        );
+
+        create table messages (
+          session_id text,
+          seq integer,
+          timestamp text,
+          role text,
+          text_chars integer,
+          text_excerpt text,
+          has_usage integer,
+          primary key (session_id, seq)
+        );
+
+        create table tool_calls (
+          session_id text,
+          seq integer,
+          timestamp text,
+          tool_call_id text,
+          tool_name text,
+          command text,
+          command_category text,
+          primary key (session_id, seq, tool_call_id)
+        );
+
+        create table tool_results (
+          session_id text,
+          seq integer,
+          timestamp text,
+          tool_call_id text,
+          tool_name text,
+          is_error integer,
+          exit_status integer,
+          output_bytes integer,
+          output_lines integer,
+          output_excerpt text,
+          primary key (session_id, seq, tool_call_id)
+        );
+
+        create table tool_pairs (
+          session_id text,
+          call_seq integer,
+          result_seq integer,
+          start_timestamp text,
+          end_timestamp text,
+          duration_ms integer,
+          tool_call_id text,
+          tool_name text,
+          command text,
+          command_category text,
+          is_error integer,
+          exit_status integer,
+          output_bytes integer,
+          output_lines integer,
+          output_excerpt text,
+          primary key (session_id, call_seq, tool_call_id)
+        );
+
+        create view bash_calls as
+          select * from tool_pairs where tool_name = 'bash';
+        """
+    )
+
+
+def insert_session(conn: sqlite3.Connection, entry: ScopeEntry, usage: UsageTotals) -> None:
+    conn.execute(
+        """
+        insert into sessions values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            entry.session_id,
+            entry.runtime,
+            entry.project,
+            entry.name,
+            entry.slug,
+            entry.model,
+            entry.first_timestamp,
+            entry.last_timestamp,
+            duration_session_ms(entry),
+            entry.total_entries,
+            entry.user_messages,
+            entry.assistant_messages,
+            entry.filepath,
+            usage.calls,
+            usage.input_tokens,
+            usage.output_tokens,
+            usage.cache_read_tokens,
+            usage.cache_write_tokens,
+            usage.total_tokens,
+            usage.cost_total,
+        ),
+    )
+
+
+def text_allowed(text_mode: str, kind: str) -> bool:
+    if text_mode == "full":
+        return True
+    if text_mode == "compact":
+        return True
+    if text_mode == "commands" and kind == "command":
+        return True
+    return False
+
+
+def ingest_session(conn: sqlite3.Connection, entry: ScopeEntry, usage: UsageTotals, *, text_mode: str, max_output_chars: int, max_message_chars: int) -> None:
+    insert_session(conn, entry, usage)
+    filepath = Path(entry.filepath)
+    if not filepath.exists():
+        return
+
+    tool_calls: list[ToolCallRecord] = []
+    tool_results: dict[str, ToolResultRecord] = {}
+
+    with filepath.open() as f:
+        for seq, line in enumerate(f, start=1):
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            timestamp = str(obj.get("timestamp") or "")
+            event_type = str(obj.get("type") or "")
+            message = obj.get("message") if isinstance(obj.get("message"), dict) else {}
+            role = str(message.get("role") or "") if message else ""
+            conn.execute("insert into events values (?, ?, ?, ?, ?)", (entry.session_id, seq, timestamp, event_type, role))
+
+            if event_type != "message":
+                continue
+
+            text = collect_text_blocks(message.get("content"))
+            text_excerpt = None
+            if text and text_allowed(text_mode, "message"):
+                text_excerpt = compact_text(text, max_chars=max_message_chars if text_mode == "compact" else max(len(text), max_message_chars))
+            conn.execute(
+                "insert into messages values (?, ?, ?, ?, ?, ?, ?)",
+                (entry.session_id, seq, timestamp, role, len(text), text_excerpt, int(bool(message.get("usage")))),
+            )
+
+            if role == "assistant":
+                blocks = message.get("content") if isinstance(message.get("content"), list) else []
+                for block in blocks:
+                    if not isinstance(block, dict) or block.get("type") != "toolCall":
+                        continue
+                    tool_name = str(block.get("name") or "<unknown>")
+                    args = block.get("arguments") if isinstance(block.get("arguments"), dict) else {}
+                    command = None
+                    category = None
+                    if tool_name == "bash":
+                        raw_command = str(args.get("command") or "")
+                        category = command_category(raw_command)
+                        if text_allowed(text_mode, "command"):
+                            command = redact(raw_command)
+                    call = ToolCallRecord(
+                        session_id=entry.session_id,
+                        call_seq=seq,
+                        call_id=str(block.get("id") or ""),
+                        timestamp=timestamp,
+                        tool_name=tool_name,
+                        command=command,
+                        command_category=category,
+                    )
+                    tool_calls.append(call)
+                    conn.execute(
+                        "insert into tool_calls values (?, ?, ?, ?, ?, ?, ?)",
+                        (call.session_id, call.call_seq, call.timestamp, call.call_id, call.tool_name, call.command, call.command_category),
+                    )
+
+            if role == "toolResult":
+                tool_name = str(message.get("toolName") or "<unknown>")
+                content_text = collect_text_blocks(message.get("content"))
+                is_error = bool(message.get("isError"))
+                exit_status, status_error = output_status(content_text, is_error)
+                is_error = bool(is_error or status_error)
+                output_excerpt = None
+                if text_allowed(text_mode, "output"):
+                    output_excerpt = compact_text(content_text, max_chars=max_output_chars if text_mode == "compact" else max(len(content_text), max_output_chars))
+                result = ToolResultRecord(
+                    session_id=entry.session_id,
+                    result_seq=seq,
+                    tool_call_id=str(message.get("toolCallId") or ""),
+                    timestamp=timestamp,
+                    tool_name=tool_name,
+                    is_error=int(is_error),
+                    exit_status=exit_status,
+                    output_bytes=len(content_text.encode("utf-8", errors="replace")),
+                    output_lines=len(content_text.splitlines()) if content_text else 0,
+                    output_excerpt=output_excerpt,
+                )
+                tool_results[result.tool_call_id] = result
+                conn.execute(
+                    "insert into tool_results values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        result.session_id,
+                        result.result_seq,
+                        result.timestamp,
+                        result.tool_call_id,
+                        result.tool_name,
+                        result.is_error,
+                        result.exit_status,
+                        result.output_bytes,
+                        result.output_lines,
+                        result.output_excerpt,
+                    ),
+                )
+
+    for call in tool_calls:
+        result = tool_results.get(call.call_id)
+        conn.execute(
+            "insert into tool_pairs values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                call.session_id,
+                call.call_seq,
+                result.result_seq if result else None,
+                call.timestamp,
+                result.timestamp if result else None,
+                duration_ms(call.timestamp, result.timestamp) if result else None,
+                call.call_id,
+                call.tool_name,
+                call.command,
+                call.command_category,
+                result.is_error if result else None,
+                result.exit_status if result else None,
+                result.output_bytes if result else None,
+                result.output_lines if result else None,
+                result.output_excerpt if result else None,
+            ),
+        )
+
+
+def build_db(args: argparse.Namespace) -> sqlite3.Connection:
+    entries, usage = scope_entries(args)
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    create_schema(conn)
+    with conn:
+        for entry in entries:
+            ingest_session(
+                conn,
+                entry,
+                usage.get(entry.session_id, UsageTotals()),
+                text_mode=args.text,
+                max_output_chars=args.max_output_chars,
+                max_message_chars=args.max_message_chars,
+            )
+    return conn
+

--- a/lib/query/db.py
+++ b/lib/query/db.py
@@ -294,4 +294,3 @@ def build_db(args: argparse.Namespace) -> sqlite3.Connection:
                 max_message_chars=args.max_message_chars,
             )
     return conn
-

--- a/lib/query/db.py
+++ b/lib/query/db.py
@@ -114,7 +114,9 @@ def create_schema(conn: sqlite3.Connection) -> None:
     )
 
 
-def insert_session(conn: sqlite3.Connection, entry: ScopeEntry, usage: UsageTotals) -> None:
+def insert_session(
+    conn: sqlite3.Connection, entry: ScopeEntry, usage: UsageTotals
+) -> None:
     conn.execute(
         """
         insert into sessions values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -154,7 +156,15 @@ def text_allowed(text_mode: str, kind: str) -> bool:
     return False
 
 
-def ingest_session(conn: sqlite3.Connection, entry: ScopeEntry, usage: UsageTotals, *, text_mode: str, max_output_chars: int, max_message_chars: int) -> None:
+def ingest_session(
+    conn: sqlite3.Connection,
+    entry: ScopeEntry,
+    usage: UsageTotals,
+    *,
+    text_mode: str,
+    max_output_chars: int,
+    max_message_chars: int,
+) -> None:
     insert_session(conn, entry, usage)
     filepath = Path(entry.filepath)
     if not filepath.exists():
@@ -173,7 +183,10 @@ def ingest_session(conn: sqlite3.Connection, entry: ScopeEntry, usage: UsageTota
             event_type = str(obj.get("type") or "")
             message = obj.get("message") if isinstance(obj.get("message"), dict) else {}
             role = str(message.get("role") or "") if message else ""
-            conn.execute("insert into events values (?, ?, ?, ?, ?)", (entry.session_id, seq, timestamp, event_type, role))
+            conn.execute(
+                "insert into events values (?, ?, ?, ?, ?)",
+                (entry.session_id, seq, timestamp, event_type, role),
+            )
 
             if event_type != "message":
                 continue
@@ -181,19 +194,40 @@ def ingest_session(conn: sqlite3.Connection, entry: ScopeEntry, usage: UsageTota
             text = collect_text_blocks(message.get("content"))
             text_excerpt = None
             if text and text_allowed(text_mode, "message"):
-                text_excerpt = compact_text(text, max_chars=max_message_chars if text_mode == "compact" else max(len(text), max_message_chars))
+                text_excerpt = compact_text(
+                    text,
+                    max_chars=max_message_chars
+                    if text_mode == "compact"
+                    else max(len(text), max_message_chars),
+                )
             conn.execute(
                 "insert into messages values (?, ?, ?, ?, ?, ?, ?)",
-                (entry.session_id, seq, timestamp, role, len(text), text_excerpt, int(bool(message.get("usage")))),
+                (
+                    entry.session_id,
+                    seq,
+                    timestamp,
+                    role,
+                    len(text),
+                    text_excerpt,
+                    int(bool(message.get("usage"))),
+                ),
             )
 
             if role == "assistant":
-                blocks = message.get("content") if isinstance(message.get("content"), list) else []
+                blocks = (
+                    message.get("content")
+                    if isinstance(message.get("content"), list)
+                    else []
+                )
                 for block in blocks:
                     if not isinstance(block, dict) or block.get("type") != "toolCall":
                         continue
                     tool_name = str(block.get("name") or "<unknown>")
-                    args = block.get("arguments") if isinstance(block.get("arguments"), dict) else {}
+                    args = (
+                        block.get("arguments")
+                        if isinstance(block.get("arguments"), dict)
+                        else {}
+                    )
                     command = None
                     category = None
                     if tool_name == "bash":
@@ -213,7 +247,15 @@ def ingest_session(conn: sqlite3.Connection, entry: ScopeEntry, usage: UsageTota
                     tool_calls.append(call)
                     conn.execute(
                         "insert into tool_calls values (?, ?, ?, ?, ?, ?, ?)",
-                        (call.session_id, call.call_seq, call.timestamp, call.call_id, call.tool_name, call.command, call.command_category),
+                        (
+                            call.session_id,
+                            call.call_seq,
+                            call.timestamp,
+                            call.call_id,
+                            call.tool_name,
+                            call.command,
+                            call.command_category,
+                        ),
                     )
 
             if role == "toolResult":
@@ -224,7 +266,12 @@ def ingest_session(conn: sqlite3.Connection, entry: ScopeEntry, usage: UsageTota
                 is_error = bool(is_error or status_error)
                 output_excerpt = None
                 if text_allowed(text_mode, "output"):
-                    output_excerpt = compact_text(content_text, max_chars=max_output_chars if text_mode == "compact" else max(len(content_text), max_output_chars))
+                    output_excerpt = compact_text(
+                        content_text,
+                        max_chars=max_output_chars
+                        if text_mode == "compact"
+                        else max(len(content_text), max_output_chars),
+                    )
                 result = ToolResultRecord(
                     session_id=entry.session_id,
                     result_seq=seq,

--- a/lib/query/help.py
+++ b/lib/query/help.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+
+def schema_text() -> str:
+    return """# sessions query
+
+Build an ephemeral SQLite projection over local session JSONL files. The JSONL
+session store remains the source of truth; no durable DB is required.
+
+Default text mode is `commands`: bash command text is redacted and queryable, but
+message text and tool output text are not inserted. Use `--text none` for fully
+structural queries, `--text compact` for compacted excerpts, or `--text full`
+only with explicit local privacy approval.
+
+Tables/views:
+
+- `sessions(session_id, runtime, project, name, model, first_timestamp,
+  last_timestamp, duration_ms, total_entries, user_messages,
+  assistant_messages, filepath, calls, *_tokens, cost_total)`
+- `events(session_id, seq, timestamp, type, role)`
+- `messages(session_id, seq, timestamp, role, text_chars, text_excerpt,
+  has_usage)`
+- `tool_calls(session_id, seq, timestamp, tool_call_id, tool_name, command,
+  command_category)`
+- `tool_results(session_id, seq, timestamp, tool_call_id, tool_name, is_error,
+  exit_status, output_bytes, output_lines, output_excerpt)`
+- `tool_pairs(session_id, call_seq, result_seq, start_timestamp, end_timestamp,
+  duration_ms, tool_call_id, tool_name, command, command_category, is_error,
+  exit_status, output_bytes, output_lines, output_excerpt)`
+- `bash_calls` view over `tool_pairs where tool_name = 'bash'`
+
+Examples:
+
+```sh
+sessions query --project junior/home --limit 30 --sql-file queries/bash-status.sql --format grid
+sessions query 019ed94e --sql 'select * from bash_calls where is_error = 1 limit 20' --format grid
+sessions query --text compact --sql-file queries/bash-with-output.sql --format jsonl
+sessions query --project junior/home --limit 30 --sql-file queries/bash-status.sql --browser
+```
+"""

--- a/lib/query/model.py
+++ b/lib/query/model.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ScopeEntry:
+    session_id: str
+    name: str = ""
+    project: str = ""
+    slug: str = ""
+    model: str = ""
+    first_timestamp: str = ""
+    last_timestamp: str = ""
+    total_entries: int = 0
+    user_messages: int = 0
+    assistant_messages: int = 0
+    filepath: str = ""
+    runtime: str = "pi"
+
+
+@dataclass
+class UsageTotals:
+    calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    total_tokens: int = 0
+    cost_total: float = 0.0
+
+
+@dataclass
+class ToolCallRecord:
+    session_id: str
+    call_seq: int
+    call_id: str
+    timestamp: str
+    tool_name: str
+    command: str | None
+    command_category: str | None
+
+
+@dataclass
+class ToolResultRecord:
+    session_id: str
+    result_seq: int
+    tool_call_id: str
+    timestamp: str
+    tool_name: str
+    is_error: int
+    exit_status: int | None
+    output_bytes: int
+    output_lines: int
+    output_excerpt: str | None
+

--- a/lib/query/model.py
+++ b/lib/query/model.py
@@ -53,4 +53,3 @@ class ToolResultRecord:
     output_bytes: int
     output_lines: int
     output_excerpt: str | None
-

--- a/lib/query/query.py
+++ b/lib/query/query.py
@@ -15,7 +15,9 @@ def safe_sql(sql: str) -> str:
     return stripped
 
 
-def rows_for_query(conn: sqlite3.Connection, sql: str) -> tuple[list[str], list[sqlite3.Row]]:
+def rows_for_query(
+    conn: sqlite3.Connection, sql: str
+) -> tuple[list[str], list[sqlite3.Row]]:
     conn.execute("pragma query_only = on")
     cursor = conn.execute(safe_sql(sql))
     names = [description[0] for description in cursor.description or []]

--- a/lib/query/query.py
+++ b/lib/query/query.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import sqlite3
+
+
+def safe_sql(sql: str) -> str:
+    stripped = sql.strip()
+    if not stripped:
+        raise SystemExit("Missing SQL")
+    lowered = stripped.lower()
+    if not lowered.startswith(("select", "with", "pragma")):
+        raise SystemExit("Only read-only SELECT/WITH/PRAGMA queries are supported")
+    if lowered.startswith("pragma") and "=" in lowered:
+        raise SystemExit("Only read-only PRAGMA queries are supported")
+    return stripped
+
+
+def rows_for_query(conn: sqlite3.Connection, sql: str) -> tuple[list[str], list[sqlite3.Row]]:
+    conn.execute("pragma query_only = on")
+    cursor = conn.execute(safe_sql(sql))
+    names = [description[0] for description in cursor.description or []]
+    return names, cursor.fetchall()

--- a/lib/query/render.py
+++ b/lib/query/render.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def render_tsv(names: list[str], rows: list[sqlite3.Row], out: io.TextIOBase) -> None:
+    writer = csv.writer(out, delimiter="\t", lineterminator="\n")
+    writer.writerow(names)
+    for row in rows:
+        writer.writerow([row[name] for name in names])
+
+
+def render_csv(names: list[str], rows: list[sqlite3.Row], out: io.TextIOBase) -> None:
+    writer = csv.writer(out, lineterminator="\n")
+    writer.writerow(names)
+    for row in rows:
+        writer.writerow([row[name] for name in names])
+
+
+def render_json(names: list[str], rows: list[sqlite3.Row], out: io.TextIOBase) -> None:
+    json.dump([{name: row[name] for name in names} for row in rows], out, indent=2)
+    out.write("\n")
+
+
+def render_jsonl(names: list[str], rows: list[sqlite3.Row], out: io.TextIOBase) -> None:
+    for row in rows:
+        out.write(json.dumps({name: row[name] for name in names}, sort_keys=True) + "\n")
+
+
+def render_table(names: list[str], rows: list[sqlite3.Row], out: io.TextIOBase) -> None:
+    values = [["" if row[name] is None else str(row[name]) for name in names] for row in rows]
+    widths = [len(name) for name in names]
+    for row in values:
+        for idx, value in enumerate(row):
+            widths[idx] = min(80, max(widths[idx], len(value)))
+
+    def trim(value: str, width: int) -> str:
+        return value if len(value) <= width else value[: max(0, width - 1)] + "…"
+
+    out.write("  ".join(name.ljust(widths[idx]) for idx, name in enumerate(names)) + "\n")
+    out.write("  ".join("-" * width for width in widths) + "\n")
+    for row in values:
+        out.write("  ".join(trim(value, widths[idx]).ljust(widths[idx]) for idx, value in enumerate(row)) + "\n")
+
+
+def wrap_grid_cell(value: Any, *, width: int, max_lines: int) -> list[str]:
+    text = "" if value is None else str(value)
+    raw_lines = text.splitlines() or [""]
+    wrapped: list[str] = []
+    for line in raw_lines:
+        if not line:
+            wrapped.append("")
+            continue
+        remaining = line
+        while len(remaining) > width:
+            wrapped.append(remaining[:width])
+            remaining = remaining[width:]
+        wrapped.append(remaining)
+    if max_lines > 0 and len(wrapped) > max_lines:
+        omitted = len(wrapped) - max_lines + 1
+        wrapped = wrapped[: max_lines - 1] + [f"… ({omitted} lines omitted)"]
+    return wrapped
+
+
+def render_grid(
+    names: list[str],
+    rows: list[sqlite3.Row],
+    out: io.TextIOBase,
+    *,
+    max_col_width: int,
+    max_cell_lines: int,
+    color: str,
+) -> None:
+    raw_values = [["" if row[name] is None else str(row[name]) for name in names] for row in rows]
+    widths = [min(max_col_width, len(name)) for name in names]
+    for row in raw_values:
+        for idx, value in enumerate(row):
+            line_width = max((len(line) for line in value.splitlines()), default=0)
+            widths[idx] = min(max_col_width, max(widths[idx], line_width))
+
+    use_dim = color == "always" or (color == "auto" and out.isatty())
+
+    def sep(text: str) -> str:
+        if not use_dim:
+            return text
+        return f"\033[2m{text}\033[0m"
+
+    def border(left: str, middle: str, right: str) -> str:
+        line = left + middle.join("─" * (width + 2) for width in widths) + right
+        return sep(line) + "\n"
+
+    def render_row(cells: list[Any], *, header: bool = False) -> None:
+        wrapped_cells = [
+            wrap_grid_cell(cell, width=widths[idx], max_lines=max_cell_lines)
+            for idx, cell in enumerate(cells)
+        ]
+        row_height = max(len(cell_lines) for cell_lines in wrapped_cells) if wrapped_cells else 1
+        for line_idx in range(row_height):
+            parts = []
+            for col_idx, cell_lines in enumerate(wrapped_cells):
+                text = cell_lines[line_idx] if line_idx < len(cell_lines) else ""
+                parts.append(" " + text.ljust(widths[col_idx]) + " ")
+            out.write(sep("│") + sep("│").join(parts) + sep("│") + "\n")
+        if header:
+            out.write(border("├", "┼", "┤"))
+
+    out.write(border("┌", "┬", "┐"))
+    render_row(names, header=True)
+    for idx, row in enumerate(raw_values):
+        render_row(row)
+        if idx != len(raw_values) - 1:
+            out.write(border("├", "┼", "┤"))
+    out.write(border("└", "┴", "┘"))
+
+
+def render(
+    names: list[str],
+    rows: list[sqlite3.Row],
+    *,
+    fmt: str,
+    output: Path | None,
+    max_col_width: int,
+    max_cell_lines: int,
+    color: str,
+) -> None:
+    out: io.TextIOBase
+    should_close = False
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        out = output.open("w")
+        should_close = True
+    else:
+        out = sys.stdout
+    try:
+        if fmt == "tsv":
+            render_tsv(names, rows, out)
+        elif fmt == "csv":
+            render_csv(names, rows, out)
+        elif fmt == "json":
+            render_json(names, rows, out)
+        elif fmt == "jsonl":
+            render_jsonl(names, rows, out)
+        elif fmt == "grid":
+            render_grid(
+                names,
+                rows,
+                out,
+                max_col_width=max_col_width,
+                max_cell_lines=max_cell_lines,
+                color=color,
+            )
+        else:
+            render_table(names, rows, out)
+    finally:
+        if should_close:
+            out.close()
+

--- a/lib/query/render.py
+++ b/lib/query/render.py
@@ -160,4 +160,3 @@ def render(
     finally:
         if should_close:
             out.close()
-

--- a/lib/query/render.py
+++ b/lib/query/render.py
@@ -30,11 +30,15 @@ def render_json(names: list[str], rows: list[sqlite3.Row], out: io.TextIOBase) -
 
 def render_jsonl(names: list[str], rows: list[sqlite3.Row], out: io.TextIOBase) -> None:
     for row in rows:
-        out.write(json.dumps({name: row[name] for name in names}, sort_keys=True) + "\n")
+        out.write(
+            json.dumps({name: row[name] for name in names}, sort_keys=True) + "\n"
+        )
 
 
 def render_table(names: list[str], rows: list[sqlite3.Row], out: io.TextIOBase) -> None:
-    values = [["" if row[name] is None else str(row[name]) for name in names] for row in rows]
+    values = [
+        ["" if row[name] is None else str(row[name]) for name in names] for row in rows
+    ]
     widths = [len(name) for name in names]
     for row in values:
         for idx, value in enumerate(row):
@@ -43,10 +47,18 @@ def render_table(names: list[str], rows: list[sqlite3.Row], out: io.TextIOBase) 
     def trim(value: str, width: int) -> str:
         return value if len(value) <= width else value[: max(0, width - 1)] + "…"
 
-    out.write("  ".join(name.ljust(widths[idx]) for idx, name in enumerate(names)) + "\n")
+    out.write(
+        "  ".join(name.ljust(widths[idx]) for idx, name in enumerate(names)) + "\n"
+    )
     out.write("  ".join("-" * width for width in widths) + "\n")
     for row in values:
-        out.write("  ".join(trim(value, widths[idx]).ljust(widths[idx]) for idx, value in enumerate(row)) + "\n")
+        out.write(
+            "  ".join(
+                trim(value, widths[idx]).ljust(widths[idx])
+                for idx, value in enumerate(row)
+            )
+            + "\n"
+        )
 
 
 def wrap_grid_cell(value: Any, *, width: int, max_lines: int) -> list[str]:
@@ -77,7 +89,9 @@ def render_grid(
     max_cell_lines: int,
     color: str,
 ) -> None:
-    raw_values = [["" if row[name] is None else str(row[name]) for name in names] for row in rows]
+    raw_values = [
+        ["" if row[name] is None else str(row[name]) for name in names] for row in rows
+    ]
     widths = [min(max_col_width, len(name)) for name in names]
     for row in raw_values:
         for idx, value in enumerate(row):
@@ -100,7 +114,9 @@ def render_grid(
             wrap_grid_cell(cell, width=widths[idx], max_lines=max_cell_lines)
             for idx, cell in enumerate(cells)
         ]
-        row_height = max(len(cell_lines) for cell_lines in wrapped_cells) if wrapped_cells else 1
+        row_height = (
+            max(len(cell_lines) for cell_lines in wrapped_cells) if wrapped_cells else 1
+        )
         for line_idx in range(row_height):
             parts = []
             for col_idx, cell_lines in enumerate(wrapped_cells):

--- a/lib/query/scope.py
+++ b/lib/query/scope.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import harness
+import parse
+from usage import aggregate
+
+from .model import ScopeEntry, UsageTotals
+from .util import safe_float, safe_int
+
+
+def entry_from_session(session: parse.Session) -> ScopeEntry:
+    meta = session.metadata()
+    adapter = harness.resolve(filepath=session.filepath, entries=session.entries)
+    return ScopeEntry(
+        session_id=str(meta.get("session_id") or ""),
+        name=str(meta.get("name") or ""),
+        project=str(meta.get("project") or ""),
+        slug=str(meta.get("slug") or ""),
+        model=str(meta.get("model") or ""),
+        first_timestamp=str(meta.get("first_timestamp") or ""),
+        last_timestamp=str(meta.get("last_timestamp") or ""),
+        total_entries=safe_int(meta.get("total_entries")),
+        user_messages=safe_int(meta.get("user_messages")),
+        assistant_messages=safe_int(meta.get("assistant_messages")),
+        filepath=str(meta.get("filepath") or session.filepath),
+        runtime=adapter.__name__.split(".")[-1],
+    )
+
+
+def usage_from_session(session: parse.Session) -> UsageTotals:
+    try:
+        totals = aggregate(session.usage_records())
+    except harness.Unsupported:
+        totals = aggregate([])
+    cost = totals.get("cost") or {}
+    return UsageTotals(
+        calls=safe_int(totals.get("calls")),
+        input_tokens=safe_int(totals.get("input")),
+        output_tokens=safe_int(totals.get("output")),
+        cache_read_tokens=safe_int(totals.get("cacheRead")),
+        cache_write_tokens=safe_int(totals.get("cacheWrite")),
+        total_tokens=safe_int(totals.get("totalTokens")),
+        cost_total=safe_float(cost.get("total")),
+    )
+
+
+def session_files(*, project: str, include_agent_prefixed: bool) -> list[Path]:
+    files: list[Path] = []
+    for harness_name in harness.available():
+        adapter = harness.adapter(harness_name)
+        try:
+            root = adapter.sessions_dir()
+        except harness.Unsupported:
+            continue
+        if not os.path.isdir(root):
+            continue
+        for project_dir in os.listdir(root):
+            project_path = os.path.join(root, project_dir)
+            if not os.path.isdir(project_path):
+                continue
+            for fname in os.listdir(project_path):
+                if not fname.endswith(".jsonl"):
+                    continue
+                if fname.startswith("agent-") and not include_agent_prefixed:
+                    continue
+                filepath = os.path.join(project_path, fname)
+                if project:
+                    try:
+                        decoded_project = adapter.project(filepath)
+                    except harness.Unsupported:
+                        decoded_project = project_dir
+                    if project not in decoded_project and project not in project_dir:
+                        continue
+                files.append(Path(filepath))
+    files.sort(key=lambda path: -path.stat().st_mtime)
+    return files
+
+
+def include_session(entry: ScopeEntry, *, include_agent_prefixed: bool) -> bool:
+    if include_agent_prefixed:
+        return True
+    message_count = entry.user_messages + entry.assistant_messages
+    return message_count > 0 and entry.model != "unknown"
+
+
+def load_corpus(*, project: str, limit: int, include_agent_prefixed: bool) -> tuple[list[ScopeEntry], dict[str, UsageTotals]]:
+    entries: list[ScopeEntry] = []
+    usage: dict[str, UsageTotals] = {}
+    for path in session_files(project=project, include_agent_prefixed=include_agent_prefixed):
+        try:
+            session = parse.load(str(path))
+            entry = entry_from_session(session)
+        except Exception:
+            continue
+        if not include_session(entry, include_agent_prefixed=include_agent_prefixed):
+            continue
+        entries.append(entry)
+        usage[entry.session_id] = usage_from_session(session)
+        if limit > 0 and len(entries) >= limit:
+            break
+    return entries, usage
+
+
+def load_selected(session_ids: list[str]) -> tuple[list[ScopeEntry], dict[str, UsageTotals]]:
+    entries: list[ScopeEntry] = []
+    usage: dict[str, UsageTotals] = {}
+    for requested in session_ids:
+        session = parse.load(parse.find_session(requested))
+        entry = entry_from_session(session)
+        entries.append(entry)
+        usage[entry.session_id] = usage_from_session(session)
+    return entries, usage
+
+
+def scope_entries(args: argparse.Namespace) -> tuple[list[ScopeEntry], dict[str, UsageTotals]]:
+    if args.session_ids:
+        return load_selected(args.session_ids)
+    return load_corpus(
+        project=args.project,
+        limit=args.limit,
+        include_agent_prefixed=getattr(args, "include_agent_prefixed", False),
+    )

--- a/lib/query/scope.py
+++ b/lib/query/scope.py
@@ -87,10 +87,14 @@ def include_session(entry: ScopeEntry, *, include_agent_prefixed: bool) -> bool:
     return message_count > 0 and entry.model != "unknown"
 
 
-def load_corpus(*, project: str, limit: int, include_agent_prefixed: bool) -> tuple[list[ScopeEntry], dict[str, UsageTotals]]:
+def load_corpus(
+    *, project: str, limit: int, include_agent_prefixed: bool
+) -> tuple[list[ScopeEntry], dict[str, UsageTotals]]:
     entries: list[ScopeEntry] = []
     usage: dict[str, UsageTotals] = {}
-    for path in session_files(project=project, include_agent_prefixed=include_agent_prefixed):
+    for path in session_files(
+        project=project, include_agent_prefixed=include_agent_prefixed
+    ):
         try:
             session = parse.load(str(path))
             entry = entry_from_session(session)
@@ -105,7 +109,9 @@ def load_corpus(*, project: str, limit: int, include_agent_prefixed: bool) -> tu
     return entries, usage
 
 
-def load_selected(session_ids: list[str]) -> tuple[list[ScopeEntry], dict[str, UsageTotals]]:
+def load_selected(
+    session_ids: list[str],
+) -> tuple[list[ScopeEntry], dict[str, UsageTotals]]:
     entries: list[ScopeEntry] = []
     usage: dict[str, UsageTotals] = {}
     for requested in session_ids:
@@ -116,7 +122,9 @@ def load_selected(session_ids: list[str]) -> tuple[list[ScopeEntry], dict[str, U
     return entries, usage
 
 
-def scope_entries(args: argparse.Namespace) -> tuple[list[ScopeEntry], dict[str, UsageTotals]]:
+def scope_entries(
+    args: argparse.Namespace,
+) -> tuple[list[ScopeEntry], dict[str, UsageTotals]]:
     if args.session_ids:
         return load_selected(args.session_ids)
     return load_corpus(

--- a/lib/query/util.py
+++ b/lib/query/util.py
@@ -136,4 +136,3 @@ def output_status(text: str, is_error: bool) -> tuple[int | None, int]:
     if match:
         return int(match.group(1)), 1
     return (1 if is_error else None), int(is_error)
-

--- a/lib/query/util.py
+++ b/lib/query/util.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from .constants import (
     EXIT_RE,
-    FAILURE_MARKERS,
     FILE_RE,
     GIT_GH_RE,
     INSTALL_RE,
@@ -96,7 +95,11 @@ def compact_text(text: str, *, max_chars: int) -> str:
     head_size = max_chars // 2
     tail_size = max_chars - head_size
     omitted = len(text) - max_chars
-    return text[:head_size] + f"\n[... compacted {omitted:,} chars ...]\n" + text[-tail_size:]
+    return (
+        text[:head_size]
+        + f"\n[... compacted {omitted:,} chars ...]\n"
+        + text[-tail_size:]
+    )
 
 
 def collect_text_blocks(content: Any) -> str:

--- a/lib/query/util.py
+++ b/lib/query/util.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .constants import (
+    EXIT_RE,
+    FAILURE_MARKERS,
+    FILE_RE,
+    GIT_GH_RE,
+    INSTALL_RE,
+    LINT_RE,
+    SCRIPT_RE,
+    SEARCH_RE,
+    SECRET_PATTERNS,
+    SESSION_RE,
+    TEST_RE,
+)
+from .model import ScopeEntry
+
+
+def resolve_path(value: str | Path) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        caller = os.environ.get("SESSIONS_CALLER_PWD") or ""
+        base = Path(caller) if caller else Path.cwd()
+        path = base / path
+    return path.resolve()
+
+
+def load_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    with path.open() as f:
+        return json.load(f)
+
+
+def parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def duration_ms(start: str | None, end: str | None) -> int | None:
+    first = parse_ts(start)
+    second = parse_ts(end)
+    if first is None or second is None:
+        return None
+    return int(max(0.0, (second - first).total_seconds()) * 1000)
+
+
+def duration_session_ms(entry: ScopeEntry) -> int:
+    return duration_ms(entry.first_timestamp, entry.last_timestamp) or 0
+
+
+def safe_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return 0
+
+
+def safe_float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def run_json(args: list[str]) -> Any:
+    completed = subprocess.run(args, check=True, text=True, capture_output=True)
+    return json.loads(completed.stdout)
+
+
+def redact(text: str) -> str:
+    redacted = text
+    for pattern, replacement in SECRET_PATTERNS:
+        redacted = pattern.sub(replacement, redacted)
+    return redacted
+
+
+def compact_text(text: str, *, max_chars: int) -> str:
+    text = redact(text)
+    if len(text) <= max_chars:
+        return text
+    head_size = max_chars // 2
+    tail_size = max_chars - head_size
+    omitted = len(text) - max_chars
+    return text[:head_size] + f"\n[... compacted {omitted:,} chars ...]\n" + text[-tail_size:]
+
+
+def collect_text_blocks(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    blocks = content if isinstance(content, list) else []
+    texts: list[str] = []
+    for block in blocks:
+        if isinstance(block, dict) and isinstance(block.get("text"), str):
+            texts.append(block["text"])
+    return "\n".join(texts)
+
+
+def command_category(command: str) -> str:
+    lower = command.lower().strip()
+    if TEST_RE.search(lower):
+        return "test"
+    if LINT_RE.search(lower):
+        return "lint/validation"
+    if GIT_GH_RE.search(lower):
+        return "git/gh"
+    if SESSION_RE.search(lower):
+        return "sessions/drone"
+    if INSTALL_RE.search(lower):
+        return "install/build"
+    if SEARCH_RE.search(lower):
+        return "search/list"
+    if FILE_RE.search(lower):
+        return "file-op"
+    if SCRIPT_RE.search(lower):
+        return "script"
+    return "other"
+
+
+def output_status(text: str, is_error: bool) -> tuple[int | None, int]:
+    match = EXIT_RE.search(text)
+    if match:
+        return int(match.group(1)), 1
+    return (1 if is_error else None), int(is_error)
+

--- a/lib/query/util.py
+++ b/lib/query/util.py
@@ -91,6 +91,8 @@ def redact(text: str) -> str:
 
 def compact_text(text: str, *, max_chars: int) -> str:
     text = redact(text)
+    if max_chars <= 0:
+        return ""
     if len(text) <= max_chars:
         return text
     head_size = max_chars // 2

--- a/lib/query_cli.py
+++ b/lib/query_cli.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+
+from query.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,7 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 [tools]
 usage = "latest"
 uv = "latest"
+ruff = "0.15.18"
 bats = "1.13.0"
 "shiv:codebase" = "0.2.0"                  # Codebase linting + migrations
 "shiv:readme" = "0.1"                      # README generation/checks

--- a/queries/bash-command-shapes.sql
+++ b/queries/bash-command-shapes.sql
@@ -1,0 +1,33 @@
+with shaped as (
+  select
+    session_id,
+    call_seq,
+    tool_call_id,
+    command_category,
+    length(command) as chars,
+    1 + length(command) - length(replace(command, char(10), '')) as lines,
+    output_lines,
+    output_bytes,
+    round(duration_ms / 1000.0, 3) as duration_s,
+    exit_status,
+    is_error,
+    command
+  from bash_calls
+  where command is not null
+)
+select
+  session_id,
+  call_seq,
+  tool_call_id,
+  command_category,
+  chars,
+  lines,
+  case when lines = 1 then 'single-line' else 'multi-line' end as shape,
+  duration_s,
+  exit_status,
+  is_error,
+  output_lines,
+  output_bytes,
+  command
+from shaped
+order by chars desc, lines desc, session_id, call_seq;

--- a/queries/bash-commands.sql
+++ b/queries/bash-commands.sql
@@ -1,0 +1,7 @@
+select
+  session_id,
+  call_seq as seq,
+  tool_call_id,
+  command
+from bash_calls
+order by session_id, call_seq, tool_call_id;

--- a/queries/bash-failures.sql
+++ b/queries/bash-failures.sql
@@ -1,0 +1,14 @@
+select
+  session_id,
+  call_seq as seq,
+  tool_call_id,
+  command_category,
+  exit_status,
+  round(duration_ms / 1000.0, 3) as duration_s,
+  output_lines,
+  output_bytes,
+  command,
+  output_excerpt
+from bash_calls
+where is_error = 1 or coalesce(exit_status, 0) != 0
+order by session_id, call_seq, tool_call_id;

--- a/queries/bash-long-single-line.sql
+++ b/queries/bash-long-single-line.sql
@@ -1,0 +1,30 @@
+with shaped as (
+  select
+    session_id,
+    call_seq,
+    tool_call_id,
+    command_category,
+    length(command) as chars,
+    1 + length(command) - length(replace(command, char(10), '')) as lines,
+    round(duration_ms / 1000.0, 3) as duration_s,
+    exit_status,
+    is_error,
+    output_lines,
+    command
+  from bash_calls
+  where command is not null
+)
+select
+  session_id,
+  call_seq,
+  tool_call_id,
+  command_category,
+  chars,
+  duration_s,
+  exit_status,
+  is_error,
+  output_lines,
+  command
+from shaped
+where lines = 1 and chars >= 200
+order by chars desc, session_id, call_seq;

--- a/queries/bash-multiline-large.sql
+++ b/queries/bash-multiline-large.sql
@@ -1,0 +1,31 @@
+with shaped as (
+  select
+    session_id,
+    call_seq,
+    tool_call_id,
+    command_category,
+    length(command) as chars,
+    1 + length(command) - length(replace(command, char(10), '')) as lines,
+    round(duration_ms / 1000.0, 3) as duration_s,
+    exit_status,
+    is_error,
+    output_lines,
+    command
+  from bash_calls
+  where command is not null
+)
+select
+  session_id,
+  call_seq,
+  tool_call_id,
+  command_category,
+  chars,
+  lines,
+  duration_s,
+  exit_status,
+  is_error,
+  output_lines,
+  command
+from shaped
+where lines >= 8 or chars >= 500
+order by chars desc, lines desc, session_id, call_seq;

--- a/queries/bash-status.sql
+++ b/queries/bash-status.sql
@@ -1,0 +1,13 @@
+select
+  session_id,
+  call_seq as seq,
+  tool_call_id,
+  command_category,
+  exit_status,
+  is_error,
+  round(duration_ms / 1000.0, 3) as duration_s,
+  output_lines,
+  output_bytes,
+  command
+from bash_calls
+order by session_id, call_seq, tool_call_id;

--- a/queries/bash-with-output.sql
+++ b/queries/bash-with-output.sql
@@ -1,0 +1,14 @@
+select
+  session_id,
+  call_seq as seq,
+  tool_call_id,
+  command_category,
+  exit_status,
+  is_error,
+  round(duration_ms / 1000.0, 3) as duration_s,
+  output_lines,
+  output_bytes,
+  command,
+  output_excerpt
+from bash_calls
+order by session_id, call_seq, tool_call_id;

--- a/queries/slow-tools.sql
+++ b/queries/slow-tools.sql
@@ -1,0 +1,13 @@
+select
+  session_id,
+  tool_name,
+  command_category,
+  count(*) as calls,
+  round(avg(duration_ms) / 1000.0, 3) as avg_s,
+  round(max(duration_ms) / 1000.0, 3) as max_s,
+  sum(case when is_error = 1 then 1 else 0 end) as errors
+from tool_pairs
+where duration_ms is not null
+group by session_id, tool_name, command_category
+order by max(duration_ms) desc
+limit 100;

--- a/test/lint.bats
+++ b/test/lint.bats
@@ -2,6 +2,14 @@
 
 load helpers
 
+@test "Python lint passes" {
+  run bash -c 'cd "$1" && mise run lint:python' bash "$REPO_DIR"
+  if [ "$status" -ne 0 ]; then
+    echo "$output"
+    return 1
+  fi
+}
+
 @test "configured codebase lints pass" {
   local lints
   lints=$(python3 - "$REPO_DIR/mise.toml" <<'PY'

--- a/test/query.bats
+++ b/test/query.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+
+load helpers
+
+setup() { setup_test_sessions; }
+teardown() { teardown_test_sessions; }
+
+@test "query with no SQL shows schema without scanning sessions" {
+  rm -rf "$PI_DIR"
+  run sessions query
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "# sessions query"
+  echo "$output" | grep -q "bash_calls"
+}
+
+@test "query supports single-session prefix scope" {
+  run sessions query "${SESSION_1:0:8}" \
+    --sql "select session_id, project, total_entries from sessions" \
+    --format json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+rows = json.load(sys.stdin)
+assert len(rows) == 1, rows
+assert rows[0]['session_id'] == '${SESSION_1}'
+assert rows[0]['project'] == 'test/project'
+assert rows[0]['total_entries'] > 0
+"
+}
+
+@test "query supports project and limit corpus scope" {
+  run sessions query --project test/project --limit 2 \
+    --sql "select count(*) as n from sessions" \
+    --format json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+rows = json.load(sys.stdin)
+assert rows == [{'n': 2}], rows
+"
+}
+
+@test "query rejects mutating SQL" {
+  run sessions query --sql "delete from sessions" --format json
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "Only read-only"
+}
+
+@test "query default text mode exposes redacted bash commands but not messages or output" {
+  run sessions query "${SESSION_1:0:8}" --sql "
+select
+  b.command,
+  b.output_excerpt,
+  (select text_excerpt from messages where role = 'user' limit 1) as message_excerpt
+from bash_calls b
+limit 1
+" --format json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+rows = json.load(sys.stdin)
+assert len(rows) == 1, rows
+row = rows[0]
+assert row['command'] == 'cat ~/.config/sccache/config', row
+assert row['output_excerpt'] is None, row
+assert row['message_excerpt'] is None, row
+"
+}
+
+@test "query compact text mode exposes bounded output excerpts" {
+  run sessions query "${SESSION_1:0:8}" --text compact --sql "
+select command, output_excerpt
+from bash_calls
+limit 1
+" --format json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+rows = json.load(sys.stdin)
+assert len(rows) == 1, rows
+row = rows[0]
+assert row['command'] == 'cat ~/.config/sccache/config', row
+assert '[cache]' in row['output_excerpt'], row
+"
+}
+
+@test "query bash status fixture includes bash call metadata" {
+  run sessions query "${SESSION_1:0:8}" --sql "
+select command_category, exit_status, is_error, output_lines
+from bash_calls
+limit 1
+" --format json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+rows = json.load(sys.stdin)
+assert rows == [{
+    'command_category': 'file-op',
+    'exit_status': None,
+    'is_error': 0,
+    'output_lines': 2,
+}], rows
+"
+}
+
+@test "query can read packaged SQL presets when caller cwd differs" {
+  run env SESSIONS_CALLER_PWD="$BATS_TEST_TMPDIR" PI_DIR="$PI_DIR" \
+    bash -c "cd '$REPO_DIR' && mise run -q query -- '${SESSION_1:0:8}' --sql-file queries/bash-status.sql --format json"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+rows = json.load(sys.stdin)
+assert len(rows) == 1, rows
+assert rows[0]['command'] == 'cat ~/.config/sccache/config', rows
+"
+}

--- a/test/query.bats
+++ b/test/query.bats
@@ -46,6 +46,45 @@ assert rows == [{'n': 2}], rows
   echo "$output" | grep -q "Only read-only"
 }
 
+@test "query rejects non-positive display and text budgets" {
+  run sessions query "${SESSION_1:0:8}" --sql "select 'abc' as value" --format grid --max-col-width 0
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q -- "--max-col-width: must be greater than 0"
+
+  run sessions query "${SESSION_1:0:8}" --text compact --max-output-chars 0 --sql "select output_excerpt from bash_calls limit 1" --format json
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q -- "--max-output-chars: must be greater than 0"
+
+  run sessions query "${SESSION_1:0:8}" --format grid --max-cell-lines -1 --sql "select 'abc' as value"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q -- "--max-cell-lines: must be greater than or equal to 0"
+}
+
+@test "query redacts common secret command shapes" {
+  run python3 - <<'PY'
+import sys
+sys.path.insert(0, "lib")
+from query.util import compact_text, redact
+
+samples = [
+    "TOKEN=plain gh api user",
+    "TOKEN='quoted secret' gh api user",
+    'TOKEN="double quoted" gh api user',
+    "curl -H 'Authorization: Bearer bearer-secret' https://example.test",
+    "tool --password hunter2 --token tok123",
+]
+redacted = "\n".join(redact(sample) for sample in samples)
+assert "plain" not in redacted
+assert "quoted secret" not in redacted
+assert "double quoted" not in redacted
+assert "bearer-secret" not in redacted
+assert "hunter2" not in redacted
+assert "tok123" not in redacted
+assert compact_text("sensitive", max_chars=0) == ""
+PY
+  [ "$status" -eq 0 ]
+}
+
 @test "query default text mode exposes redacted bash commands but not messages or output" {
   run sessions query "${SESSION_1:0:8}" --sql "
 select

--- a/test/setup_suite.bash
+++ b/test/setup_suite.bash
@@ -12,5 +12,9 @@ setup_suite() {
     export MISE_TRUSTED_CONFIG_PATHS="$REPO_DIR"
   fi
 
+  bats_libexec="${BATS_LIBEXEC:-}"
   eval "$(cd "$REPO_DIR" && mise env)"
+  if [ -n "$bats_libexec" ]; then
+    export PATH="$bats_libexec:$PATH"
+  fi
 }


### PR DESCRIPTION
## Summary

Adds `sessions query`: an ephemeral, read-only SQLite projection over local session JSONL files.

- keeps JSONL as the source of truth; no durable database is created
- starts with the Pi session adapter while preserving `runtime` fields for future adapters
- exposes queryable tables for sessions, events, messages, tool calls/results/pairs, and bash calls
- ships packaged SQL presets under `queries/*.sql`
- keeps privacy-safe defaults: default `--text commands` exposes redacted bash commands but omits message text and tool output; compact/full text require explicit flags
- supports table/grid/html/tsv/csv/json/jsonl output and optional local `--browser` HTML browsing
- adds Ruff lint/format enforcement for Python code via `mise run lint:python` and CI
- rejects non-positive query budgets and strengthens default command redaction for common secret shapes

Closes #106.

## Notes

This is intentionally conservative: queryable projections and saved SQL examples, not a new durable session database and not a pile of hardcoded modes.

Richer browser table controls are left for #107. For future performance inspiration, `jhspetersson/fselect` is worth studying, but it is not part of this first PR.

This PR also avoids adding any new agent-prefixed-session inclusion flag; existing terminology cleanup should happen separately.

## Validation

- `python3 -m py_compile .mise/tasks/query lib/query_cli.py lib/query/*.py`
- `mise exec -- readme build --check`
- `mise run test test/query.bats` (8/8)
- `mise run lint:python`
- `mise run test` (297/297)
- `cd cli && mise exec -- mix test` (124 tests + 4 doctests)
- configured codebase lints individually via `mise exec codebase -- codebase lint:<name> "$PWD"`:
  - `mise-settings`
  - `gum-table`
  - `bats-test-helper`
  - `bats-test-task`
  - `mcr-scope`
  - `or-true`
  - `shellcheck`
- `git diff --check origin/main...HEAD`


