### PR TITLE
Fix sessions query guard edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 294 passing](https://img.shields.io/badge/tests-294%20passing-brightgreen?style=flat)](test/)
+[![tests: 296 passing](https://img.shields.io/badge/tests-296%20passing-brightgreen?style=flat)](test/)
 ![commands: 18](https://img.shields.io/badge/commands-18-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -268,7 +268,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**294 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2535 lines in `lib/`.
+**296 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2560 lines in `lib/`.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -304,7 +304,7 @@ sessions/
 │   └── harness/        # Per-harness adapters (pi, …)
 ├── queries/            # Packaged sessions query SQL presets
 └── test/
-    └── *.bats          # 294 tests
+    └── *.bats          # 296 tests
 ```
 
 </details>

--- a/lib/query/cli.py
+++ b/lib/query/cli.py
@@ -29,19 +29,39 @@ def read_sql(args: argparse.Namespace) -> str | None:
     return args.sql
 
 
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than 0")
+    return parsed
+
+
+def non_negative_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be greater than or equal to 0")
+    return parsed
+
+
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Query local sessions through an ephemeral SQLite projection")
     parser.add_argument("session_ids", nargs="*", help="Optional session ID prefixes to query")
     parser.add_argument("--project", default="", help="Project substring filter when querying a corpus")
     parser.add_argument("--limit", type=int, default=20, help="Max sessions for corpus scope")
     parser.add_argument("--text", choices=["none", "commands", "compact", "full"], default="commands", help="Text columns to insert into the ephemeral DB")
-    parser.add_argument("--max-output-chars", type=int, default=4000, help="Output excerpt budget for --text compact")
-    parser.add_argument("--max-message-chars", type=int, default=2000, help="Message excerpt budget for --text compact")
+    parser.add_argument("--max-output-chars", type=positive_int, default=4000, help="Output excerpt budget for --text compact")
+    parser.add_argument("--max-message-chars", type=positive_int, default=2000, help="Message excerpt budget for --text compact")
     parser.add_argument("--sql", default="", help="SQL SELECT/WITH/PRAGMA query")
     parser.add_argument("--sql-file", default="", help="File containing SQL query")
     parser.add_argument("--format", choices=["table", "grid", "html", "tsv", "csv", "json", "jsonl"], default="table", help="Output format")
-    parser.add_argument("--max-col-width", type=int, default=80, help="Max display width per column for --format grid")
-    parser.add_argument("--max-cell-lines", type=int, default=12, help="Max wrapped lines per cell for --format grid; 0 means unlimited")
+    parser.add_argument("--max-col-width", type=positive_int, default=80, help="Max display width per column for --format grid")
+    parser.add_argument("--max-cell-lines", type=non_negative_int, default=12, help="Max wrapped lines per cell for --format grid; 0 means unlimited")
     parser.add_argument("--color", choices=["auto", "always", "never"], default="auto", help="Color mode for grid separators; auto dims separators on a TTY")
     parser.add_argument("--browser", action="store_true", help="Render results to temporary HTML and open in the default browser")
     parser.add_argument("--title", default="sessions query", help="HTML/browser result title")

--- a/lib/query/constants.py
+++ b/lib/query/constants.py
@@ -16,7 +16,10 @@ SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"github_pat_[A-Za-z0-9_]+"), "github_pat_[REDACTED]"),
     (re.compile(r"gh[pousr]_[A-Za-z0-9_]+"), "gh*_REDACTED"),
     (re.compile(r"sk-[A-Za-z0-9_-]{16,}"), "sk-[REDACTED]"),
-    (re.compile(r"(?i)(GITHUB_TOKEN|GH_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY|API_KEY|TOKEN|PASSWORD|SECRET)=([^\s'\"]+)"), r"\1=[REDACTED]"),
+    (re.compile(r"(?i)\b(GITHUB_TOKEN|GH_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY|API_KEY|TOKEN|PASSWORD|SECRET)=(['\"])[^'\"]*\2"), r"\1=\2[REDACTED]\2"),
+    (re.compile(r"(?i)\b(GITHUB_TOKEN|GH_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY|API_KEY|TOKEN|PASSWORD|SECRET)=([^\s'\"]+)"), r"\1=[REDACTED]"),
+    (re.compile(r"(?i)(Authorization:\s*(?:Bearer|Basic)\s+)[^'\"\s]+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(--(?:api-key|password|secret|token)\s+)[^'\"\s]+"), r"\1[REDACTED]"),
     (re.compile(r"-----BEGIN [^-]+-----.*?-----END [^-]+-----", re.DOTALL), "[REDACTED PEM BLOCK]"),
 ]
 

--- a/lib/query/util.py
+++ b/lib/query/util.py
@@ -91,6 +91,8 @@ def redact(text: str) -> str:
 
 def compact_text(text: str, *, max_chars: int) -> str:
     text = redact(text)
+    if max_chars <= 0:
+        return ""
     if len(text) <= max_chars:
         return text
     head_size = max_chars // 2

--- a/test/query.bats
+++ b/test/query.bats
@@ -46,6 +46,45 @@ assert rows == [{'n': 2}], rows
   echo "$output" | grep -q "Only read-only"
 }
 
+@test "query rejects non-positive display and text budgets" {
+  run sessions query "${SESSION_1:0:8}" --sql "select 'abc' as value" --format grid --max-col-width 0
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q -- "--max-col-width: must be greater than 0"
+
+  run sessions query "${SESSION_1:0:8}" --text compact --max-output-chars 0 --sql "select output_excerpt from bash_calls limit 1" --format json
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q -- "--max-output-chars: must be greater than 0"
+
+  run sessions query "${SESSION_1:0:8}" --format grid --max-cell-lines -1 --sql "select 'abc' as value"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q -- "--max-cell-lines: must be greater than or equal to 0"
+}
+
+@test "query redacts common secret command shapes" {
+  run python3 - <<'PY'
+import sys
+sys.path.insert(0, "lib")
+from query.util import compact_text, redact
+
+samples = [
+    "TOKEN=plain gh api user",
+    "TOKEN='quoted secret' gh api user",
+    'TOKEN="double quoted" gh api user',
+    "curl -H 'Authorization: Bearer bearer-secret' https://example.test",
+    "tool --password hunter2 --token tok123",
+]
+redacted = "\n".join(redact(sample) for sample in samples)
+assert "plain" not in redacted
+assert "quoted secret" not in redacted
+assert "double quoted" not in redacted
+assert "bearer-secret" not in redacted
+assert "hunter2" not in redacted
+assert "tok123" not in redacted
+assert compact_text("sensitive", max_chars=0) == ""
+PY
+  [ "$status" -eq 0 ]
+}
+
 @test "query default text mode exposes redacted bash commands but not messages or output" {
   run sessions query "${SESSION_1:0:8}" --sql "
 select


### PR DESCRIPTION
## Summary

Fix-it for `sessions#108` review findings:

- reject non-positive query budgets before rendering/compaction;
- fail `compact_text(..., max_chars <= 0)` closed;
- redact quoted token/password env assignments, Authorization headers, and common secret CLI flags in command text;
- add query regression tests and refresh generated README counts.

## Validation

- `python3 -m py_compile .mise/tasks/query lib/query_cli.py lib/query/*.py`
- `mise run test test/query.bats`
- `mise run test`
- configured codebase lints individually:
  - `mise-settings`
  - `gum-table`
  - `bats-test-helper`
  - `bats-test-task`
  - `mcr-scope`
  - `or-true`
  - `shellcheck`
- `mise exec -- readme build --check`
- `git diff --check origin/x1f9/session-query...HEAD`
