### PR TITLE
fix: verify sessions CLI deps before lazy return

### DIFF
--- a/.mise/tasks/cli/build
+++ b/.mise/tasks/cli/build
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #MISE description="Build the sessions CLI (install Elixir dependencies)"
-set -e
+set -euo pipefail
 
-CLI_DIR="$MISE_CONFIG_ROOT/cli"
+CLI_DIR="${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}/cli"
 
-cd "$CLI_DIR"
-mix local.hex --force --if-missing
-mix deps.get
+# shellcheck source=../../../lib/ensure-deps.sh
+source "$MISE_CONFIG_ROOT/lib/ensure-deps.sh"
+ensure_cli_deps "$CLI_DIR"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 299 passing](https://img.shields.io/badge/tests-299%20passing-brightgreen?style=flat)](test/)
+[![tests: 302 passing](https://img.shields.io/badge/tests-302%20passing-brightgreen?style=flat)](test/)
 ![commands: 19](https://img.shields.io/badge/commands-19-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -268,7 +268,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**299 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2747 lines in `lib/`.
+**302 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2747 lines in `lib/`.
 
 Python code is checked with [Ruff](https://docs.astral.sh/ruff/) via `mise run lint:python`, and CI runs the same lint/format check in addition to the BATS and Elixir suites.
 
@@ -307,7 +307,7 @@ sessions/
 │   └── harness/        # Per-harness adapters (pi, …)
 ├── queries/            # Packaged sessions query SQL presets
 └── test/
-    └── *.bats          # 299 tests
+    └── *.bats          # 302 tests
 ```
 
 </details>

--- a/lib/ensure-deps.sh
+++ b/lib/ensure-deps.sh
@@ -5,19 +5,44 @@
 # `cli/deps/` is empty and `mix sessions` refuses to start with an
 # 'Unchecked dependencies' error. On CI, a restored deps cache can also
 # exist before Hex has been installed in the runner's Mix home, which
-# makes Mix unable to resolve Hex-backed dependencies. This helper
-# installs Hex when needed, then fetches deps only when deps/ is empty.
+# makes Mix unable to resolve Hex-backed dependencies.
+#
+# This helper installs Hex when needed, then asks Mix whether dependency
+# load paths are usable. It fetches deps lazily only when that cheap
+# no-compile check fails.
 #
 # See KnickKnackLabs/sessions#53 and KnickKnackLabs/sessions#111 for the rationale.
+
+ensure_mix_hex() {
+  local cli_dir="$1"
+
+  if ! (
+    cd "$cli_dir" || exit 1
+    mix local.hex --force --if-missing >&2
+  ); then
+    echo "sessions: failed to install Hex package manager." >&2
+    echo "  try: mix local.hex --force --if-missing   (in $cli_dir)" >&2
+    return 1
+  fi
+}
+
+cli_deps_ready() {
+  local cli_dir="$1"
+
+  (
+    cd "$cli_dir" || exit 1
+    mix deps.loadpaths --no-compile >/dev/null 2>&1
+  )
+}
 
 # ensure_cli_deps <cli_dir>
 #
 # Returns:
-#   0 — deps are already populated, or were just fetched successfully.
-#   1 — fetch failed; an actionable hint is emitted to stderr.
+#   0 — deps are already usable, or were just fetched successfully.
+#   1 — setup/fetch/readiness failed; an actionable hint is emitted to stderr.
 #   2 — programmer error (missing arg, or <cli_dir> does not exist).
 ensure_cli_deps() {
-  local cli_dir="$1"
+  local cli_dir="${1:-}"
 
   if [ -z "$cli_dir" ]; then
     echo "ensure_cli_deps: cli_dir argument required" >&2
@@ -29,21 +54,9 @@ ensure_cli_deps() {
     return 2
   fi
 
-  if ! (
-    cd "$cli_dir" || exit 1
-    mix local.hex --force --if-missing >&2
-  ); then
-    echo "sessions: failed to install Hex package manager." >&2
-    echo "  try: mix local.hex --force --if-missing   (in $cli_dir)" >&2
-    return 1
-  fi
+  ensure_mix_hex "$cli_dir" || return 1
 
-  # Populated-deps check: if any entry exists under deps/, we assume
-  # deps have been fetched at least once. `mix` itself will handle
-  # version drift (it re-fetches on `mix.lock` change). In practice
-  # `mix deps.get` only creates subdirectories, but we check for any
-  # entry so the code matches what `ls -A` actually reports.
-  if [ -n "$(ls -A "$cli_dir/deps" 2>/dev/null)" ]; then
+  if cli_deps_ready "$cli_dir"; then
     return 0
   fi
 
@@ -56,6 +69,12 @@ ensure_cli_deps() {
     echo "  try: mise run cli:build   (in $cli_dir)" >&2
     return 1
   }
+
+  if ! cli_deps_ready "$cli_dir"; then
+    echo "sessions: dependencies were fetched but are still not loadable." >&2
+    echo "  try: mise run cli:build   (in $cli_dir)" >&2
+    return 1
+  fi
 
   return 0
 }

--- a/test/ensure-deps.bats
+++ b/test/ensure-deps.bats
@@ -14,7 +14,7 @@ setup() {
   CLI="$TMP/cli"
   mkdir -p "$CLI/deps"
 
-  # Minimal mix project so `mix deps.get` has something to read.
+  # Minimal mix project so real `mix deps.get` has something to read.
   cat > "$CLI/mix.exs" <<'EOF'
 defmodule EnsureDepsTest.MixProject do
   use Mix.Project
@@ -29,74 +29,98 @@ teardown() {
   rm -rf "$TMP"
 }
 
+write_fake_mix() {
+  fakebin="$TMP/fakebin"
+  mkdir -p "$fakebin"
+  MIX_LOG="$TMP/mix.log"
+  export MIX_LOG
+  cat > "$fakebin/mix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$MIX_LOG"
+case "$*" in
+  "local.hex --force --if-missing")
+    exit "${FAKE_MIX_HEX_STATUS:-0}"
+    ;;
+  "deps.loadpaths --no-compile")
+    count_file="$MIX_LOG.loadpaths-count"
+    count=0
+    if [ -f "$count_file" ]; then
+      count=$(cat "$count_file")
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$count_file"
+    if [ "$count" -eq 1 ]; then
+      exit "${FAKE_MIX_LOADPATHS_FIRST_STATUS:-0}"
+    fi
+    exit "${FAKE_MIX_LOADPATHS_NEXT_STATUS:-${FAKE_MIX_LOADPATHS_FIRST_STATUS:-0}}"
+    ;;
+  "deps.get")
+    exit "${FAKE_MIX_DEPS_GET_STATUS:-0}"
+    ;;
+esac
+exit 43
+EOF
+  chmod +x "$fakebin/mix"
+  export fakebin
+}
+
 # ----------------------------------------------------------------------------
 # Happy paths
 # ----------------------------------------------------------------------------
 
-@test "ensure_cli_deps: returns 0 when deps/ is already populated" {
-  # Simulate previously-fetched state by planting a dummy subdir.
-  mkdir -p "$CLI/deps/some_pkg"
-  run ensure_cli_deps "$CLI"
-  [ "$status" -eq 0 ]
-  # Should NOT emit the first-run notice when deps are present.
-  [[ "$output" != *"first-run setup"* ]]
-}
-
-@test "ensure_cli_deps: returns 0 without fetching deps when deps are populated" {
-  # Multiple subdirs, mimicking a real install.
-  mkdir -p "$CLI/deps/jason" "$CLI/deps/credo" "$CLI/deps/bunt"
-  run ensure_cli_deps "$CLI"
-  [ "$status" -eq 0 ]
-  # Directory unchanged.
-  [ -d "$CLI/deps/jason" ]
-  [ -d "$CLI/deps/credo" ]
-  [ -d "$CLI/deps/bunt" ]
-}
-
-@test "ensure_cli_deps: installs Hex even when deps are populated" {
-  mkdir -p "$CLI/deps/jason"
-  fakebin="$TMP/fakebin"
-  mkdir -p "$fakebin"
-  MIX_LOG="$TMP/mix.log"
-  export MIX_LOG
-  cat > "$fakebin/mix" <<'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$*" >> "$MIX_LOG"
-case "$*" in
-  "local.hex --force --if-missing") exit 0 ;;
-  "deps.get") exit 42 ;;
-esac
-exit 43
-EOF
-  chmod +x "$fakebin/mix"
+@test "ensure_cli_deps: returns 0 when Mix reports dependency load paths ready" {
+  write_fake_mix
+  export FAKE_MIX_LOADPATHS_FIRST_STATUS=0
+  export FAKE_MIX_DEPS_GET_STATUS=42
 
   PATH="$fakebin:$PATH" run ensure_cli_deps "$CLI"
+
   [ "$status" -eq 0 ]
-  grep -q '^local.hex --force --if-missing$' "$MIX_LOG"
+  [[ "$output" != *"first-run setup"* ]]
+  [ "$(sed -n '1p' "$MIX_LOG")" = "local.hex --force --if-missing" ]
+  [ "$(sed -n '2p' "$MIX_LOG")" = "deps.loadpaths --no-compile" ]
   ! grep -q '^deps.get$' "$MIX_LOG"
 }
 
-@test "ensure_cli_deps: returns 1 when Hex setup fails" {
-  mkdir -p "$CLI/deps/jason"
-  fakebin="$TMP/fakebin"
-  mkdir -p "$fakebin"
-  MIX_LOG="$TMP/mix.log"
-  export MIX_LOG
-  cat > "$fakebin/mix" <<'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$*" >> "$MIX_LOG"
-case "$*" in
-  "local.hex --force --if-missing") exit 17 ;;
-  "deps.get") exit 0 ;;
-esac
-exit 43
-EOF
-  chmod +x "$fakebin/mix"
+@test "ensure_cli_deps: fetches deps when load paths are not ready even if deps is populated" {
+  mkdir -p "$CLI/deps/some_pkg"
+  write_fake_mix
+  export FAKE_MIX_LOADPATHS_FIRST_STATUS=1
+  export FAKE_MIX_LOADPATHS_NEXT_STATUS=0
 
   PATH="$fakebin:$PATH" run ensure_cli_deps "$CLI"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"first-run setup"* ]]
+  [ "$(sed -n '1p' "$MIX_LOG")" = "local.hex --force --if-missing" ]
+  [ "$(sed -n '2p' "$MIX_LOG")" = "deps.loadpaths --no-compile" ]
+  [ "$(sed -n '3p' "$MIX_LOG")" = "deps.get" ]
+  [ "$(sed -n '4p' "$MIX_LOG")" = "deps.loadpaths --no-compile" ]
+}
+
+@test "ensure_cli_deps: installs Hex before checking dependency readiness" {
+  write_fake_mix
+  export FAKE_MIX_LOADPATHS_FIRST_STATUS=0
+
+  PATH="$fakebin:$PATH" run ensure_cli_deps "$CLI"
+
+  [ "$status" -eq 0 ]
+  [ "$(sed -n '1p' "$MIX_LOG")" = "local.hex --force --if-missing" ]
+  [ "$(sed -n '2p' "$MIX_LOG")" = "deps.loadpaths --no-compile" ]
+}
+
+@test "ensure_cli_deps: returns 1 when Hex setup fails" {
+  write_fake_mix
+  export FAKE_MIX_HEX_STATUS=17
+  export FAKE_MIX_LOADPATHS_FIRST_STATUS=0
+
+  PATH="$fakebin:$PATH" run ensure_cli_deps "$CLI"
+
   [ "$status" -eq 1 ]
   [[ "$output" == *"failed to install Hex package manager"* ]]
   grep -q '^local.hex --force --if-missing$' "$MIX_LOG"
+  ! grep -q '^deps.loadpaths --no-compile$' "$MIX_LOG"
   ! grep -q '^deps.get$' "$MIX_LOG"
 }
 
@@ -119,7 +143,7 @@ EOF
 }
 
 @test "ensure_cli_deps: fetches deps when deps/ does not exist at all" {
-  # Nuke the deps dir entirely — ls -A returns empty for a missing dir.
+  # Nuke the deps dir entirely — the Mix readiness check should fail closed.
   rm -rf "$CLI/deps"
 
   run ensure_cli_deps "$CLI"
@@ -135,8 +159,8 @@ EOF
 
 @test "ensure_cli_deps: returns 2 (programmer error) when cli_dir argument is missing" {
   # Tests the documented contract: return 2 for programmer errors,
-  # return 1 for runtime fetch failures. A future refactor that swaps
-  # these should fail here.
+  # return 1 for runtime setup/readiness failures. A future refactor that
+  # swaps these should fail here.
   run ensure_cli_deps
   [ "$status" -eq 2 ]
   [[ "$output" == *"cli_dir argument required"* ]]
@@ -149,26 +173,44 @@ EOF
 }
 
 @test "ensure_cli_deps: returns 1 (fetch failed) and emits hint when deps.get fails" {
-  fakebin="$TMP/fakebin"
-  mkdir -p "$fakebin"
-  MIX_LOG="$TMP/mix.log"
-  export MIX_LOG
-  cat > "$fakebin/mix" <<'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$*" >> "$MIX_LOG"
-case "$*" in
-  "local.hex --force --if-missing") exit 0 ;;
-  "deps.get") exit 18 ;;
-esac
-exit 43
-EOF
-  chmod +x "$fakebin/mix"
+  write_fake_mix
+  export FAKE_MIX_LOADPATHS_FIRST_STATUS=1
+  export FAKE_MIX_DEPS_GET_STATUS=18
 
   PATH="$fakebin:$PATH" run ensure_cli_deps "$CLI"
+
   [ "$status" -eq 1 ]
   [[ "$output" == *"first-run setup"* ]]
   [[ "$output" == *"failed to fetch dependencies"* ]]
   [[ "$output" == *"mise run cli:build"* ]]
   grep -q '^local.hex --force --if-missing$' "$MIX_LOG"
+  grep -q '^deps.loadpaths --no-compile$' "$MIX_LOG"
   grep -q '^deps.get$' "$MIX_LOG"
+}
+
+@test "ensure_cli_deps: returns 1 when deps remain unloadable after deps.get" {
+  write_fake_mix
+  export FAKE_MIX_LOADPATHS_FIRST_STATUS=1
+  export FAKE_MIX_LOADPATHS_NEXT_STATUS=1
+  export FAKE_MIX_DEPS_GET_STATUS=0
+
+  PATH="$fakebin:$PATH" run ensure_cli_deps "$CLI"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"dependencies were fetched but are still not loadable"* ]]
+  [ "$(grep -c '^deps.loadpaths --no-compile$' "$MIX_LOG")" -eq 2 ]
+  grep -q '^deps.get$' "$MIX_LOG"
+}
+
+@test "cli:build uses the shared readiness helper" {
+  write_fake_mix
+  export FAKE_MIX_LOADPATHS_FIRST_STATUS=0
+  export FAKE_MIX_DEPS_GET_STATUS=42
+
+  PATH="$fakebin:$PATH" run mise -C "$REPO_DIR" run -q cli:build
+
+  [ "$status" -eq 0 ]
+  [ "$(sed -n '1p' "$MIX_LOG")" = "local.hex --force --if-missing" ]
+  [ "$(sed -n '2p' "$MIX_LOG")" = "deps.loadpaths --no-compile" ]
+  ! grep -q '^deps.get$' "$MIX_LOG"
 }

--- a/test/run.bats
+++ b/test/run.bats
@@ -127,7 +127,7 @@ teardown() {
 #!/usr/bin/env bash
 set -euo pipefail
 case "\$*" in
-  "local.hex --force --if-missing"|"deps.get") exit 0 ;;
+  "local.hex --force --if-missing"|"deps.loadpaths --no-compile"|"deps.get") exit 0 ;;
 esac
 printf '%s\n' "\$@" > "$argv_capture"
 exit 0
@@ -144,6 +144,34 @@ STUB
   ! grep -qx -- "--system-prompt-file" "$argv_capture"
   grep -qx -- "--model" "$argv_capture"
   [ "$(awk '/^--model$/ { getline; print; exit }' "$argv_capture")" = "openai-codex/gpt-5.5" ]
+}
+
+@test "run with message prepares CLI deps before mix sessions" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-mix-readiness-order"
+  local command_log="$BATS_TEST_TMPDIR/mix-readiness-order.log"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/mix" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >> "$command_log"
+case "\$*" in
+  "local.hex --force --if-missing"|"deps.loadpaths --no-compile") exit 0 ;;
+  sessions*) exit 0 ;;
+esac
+exit 43
+STUB
+  chmod +x "$stub_dir/mix"
+
+  PATH="$stub_dir:$PATH" run sessions run \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5" \
+    "do work"
+
+  [ "$status" -eq 0 ]
+  [ "$(sed -n '1p' "$command_log")" = "local.hex --force --if-missing" ]
+  [ "$(sed -n '2p' "$command_log")" = "deps.loadpaths --no-compile" ]
+  [[ "$(sed -n '3p' "$command_log")" == sessions\ --cwd\ * ]]
+  ! grep -q '^deps.get$' "$command_log"
 }
 
 @test "run rejects a missing explicit system prompt file before launch" {
@@ -247,7 +275,7 @@ STUB
 #!/usr/bin/env bash
 set -euo pipefail
 case "\$*" in
-  "local.hex --force --if-missing"|"deps.get") exit 0 ;;
+  "local.hex --force --if-missing"|"deps.loadpaths --no-compile"|"deps.get") exit 0 ;;
 esac
 printf '%s\n' "\$@" > "$argv_capture"
 prompt_file=""
@@ -295,7 +323,7 @@ STUB
 #!/usr/bin/env bash
 set -euo pipefail
 case "\$*" in
-  "local.hex --force --if-missing"|"deps.get") exit 0 ;;
+  "local.hex --force --if-missing"|"deps.loadpaths --no-compile"|"deps.get") exit 0 ;;
 esac
 printf '%s\n' "\$@" > "$argv_capture"
 prompt_file=""


### PR DESCRIPTION
## Summary

Fix-it for KnickKnackLabs/sessions#112.

This keeps Junior's Hex-before-early-return fix, then tightens the readiness boundary:

- replace the `ls -A cli/deps` readiness shortcut with `mix deps.loadpaths --no-compile`;
- still fetch with `mix deps.get` lazily only when Mix says dependency load paths are not usable;
- verify deps are loadable after a fetch;
- make `cli:build` use the same shared readiness helper as `sessions run`;
- add coverage for populated-but-unusable deps, full `sessions run` preflight ordering, and `cli:build` helper reuse.

## Why

The old populated-directory check could return success for a restored/corrupt/stale `cli/deps` directory that did not contain the deps Mix actually needs. This PR asks Mix the cheap question instead: "can dependency load paths be loaded without compiling?"

## Validation

- `bash -n lib/ensure-deps.sh .mise/tasks/cli/build .mise/tasks/run`
- `mise run test ensure-deps`
- `mise run test run --filter 'CLI deps|with message works|headless with message'`
- `mise run test` — 302/302
- `mise run lint:python`
- `mise exec -- readme build --check`
- `git diff --check`
- `cd cli && mix test` — 124 tests + 4 doctests
- `env AGENT_HOME=/Users/rikonor/desks/brownie-fold113-rereview-20260619181011/home git pre-push`
