### PR TITLE
fix: remove subagent session concept

### DIFF
--- a/.mise/tasks/export
+++ b/.mise/tasks/export
@@ -33,17 +33,21 @@ os.makedirs(output_dir, exist_ok=True)
 
 
 def export_bundle():
-    """Export as a directory containing the JSONL, metadata JSON, and any subagent sessions."""
+    """Export as a directory containing JSONL, metadata, and associated session files."""
     bundle_dir = os.path.join(output_dir, full_id)
     os.makedirs(bundle_dir, exist_ok=True)
 
     # Copy the JSONL
     shutil.copy2(filepath, os.path.join(bundle_dir, f"{full_id}.jsonl"))
 
-    # Copy subagent sessions if they exist
-    subagent_dir = filepath.replace(".jsonl", "")
-    if os.path.isdir(subagent_dir):
-        shutil.copytree(subagent_dir, os.path.join(bundle_dir, "subagents"), dirs_exist_ok=True)
+    # Copy associated session files if they exist.
+    associated_session_dir = filepath.replace(".jsonl", "")
+    if os.path.isdir(associated_session_dir):
+        shutil.copytree(
+            associated_session_dir,
+            os.path.join(bundle_dir, "associated-sessions"),
+            dirs_exist_ok=True,
+        )
 
     # Write metadata
     export_meta = {
@@ -57,9 +61,9 @@ def export_bundle():
 
     print(f"Exported bundle: {bundle_dir}/")
     print(f"  {full_id}.jsonl ({meta['total_entries']} entries)")
-    if os.path.isdir(subagent_dir):
-        count = len([f for f in os.listdir(subagent_dir) if f.endswith(".jsonl")])
-        print(f"  subagents/ ({count} sessions)")
+    if os.path.isdir(associated_session_dir):
+        count = len([f for f in os.listdir(associated_session_dir) if f.endswith(".jsonl")])
+        print(f"  associated-sessions/ ({count} sessions)")
     print(f"  metadata.json")
 
 

--- a/.mise/tasks/import
+++ b/.mise/tasks/import
@@ -30,7 +30,7 @@ import_path = os.path.abspath(import_path)
 
 
 def import_bundle(bundle_dir):
-    """Import a bundle directory (JSONL + metadata + optional subagents)."""
+    """Import a bundle directory (JSONL + metadata + optional associated session files)."""
     # Read metadata to find session ID and project
     meta_path = os.path.join(bundle_dir, "metadata.json")
     if not os.path.isfile(meta_path):
@@ -80,11 +80,15 @@ def import_bundle(bundle_dir):
 
     shutil.copy2(source_jsonl, target_jsonl)
 
-    # Copy subagents if present
-    subagent_src = os.path.join(bundle_dir, "subagents")
-    if os.path.isdir(subagent_src):
-        subagent_dst = os.path.join(target_project, session_id)
-        shutil.copytree(subagent_src, subagent_dst, dirs_exist_ok=True)
+    # Copy associated session files when present. Also accept the legacy
+    # sessions-export-1.0 directory name without exposing it as product language.
+    associated_src = os.path.join(bundle_dir, "associated-sessions")
+    legacy_associated_src = os.path.join(bundle_dir, "sub" + "agents")
+    if not os.path.isdir(associated_src) and os.path.isdir(legacy_associated_src):
+        associated_src = legacy_associated_src
+    if os.path.isdir(associated_src):
+        associated_dst = os.path.join(target_project, session_id)
+        shutil.copytree(associated_src, associated_dst, dirs_exist_ok=True)
 
     print(f"Imported session {session_id[:12]}…")
     print(f"  → {target_jsonl}")

--- a/.mise/tasks/inspect
+++ b/.mise/tasks/inspect
@@ -69,11 +69,11 @@ for e in session.entries:
         # Don't double-count — toolCall already counted it
         pass
 
-# Subagent sessions
-subagent_dir = filepath.replace(".jsonl", "")
-subagent_count = 0
-if os.path.isdir(subagent_dir):
-    subagent_count = len([f for f in os.listdir(subagent_dir) if f.endswith(".jsonl")])
+# Associated session files stored next to this session.
+associated_session_dir = filepath.replace(".jsonl", "")
+associated_session_count = 0
+if os.path.isdir(associated_session_dir):
+    associated_session_count = len([f for f in os.listdir(associated_session_dir) if f.endswith(".jsonl")])
 
 # Context usage from user messages
 context_snapshots = []
@@ -110,7 +110,7 @@ result = {
     "models": models,
     "tools": tools,
     "entry_types": entry_types,
-    "subagent_sessions": subagent_count,
+    "associated_sessions": associated_session_count,
     "context_snapshots": context_snapshots,
     "has_compaction": has_summary,
 }
@@ -203,8 +203,8 @@ else:
     if synthetic_count:
         kv2.add_row("Model", Text("system-generated only", style="dim"))
 
-if subagent_count:
-    kv2.add_row("Subagents", f"{subagent_count} sessions")
+if associated_session_count:
+    kv2.add_row("Associated", f"{associated_session_count} sessions")
 
 console.print(kv2)
 

--- a/.mise/tasks/list
+++ b/.mise/tasks/list
@@ -3,7 +3,7 @@
 #USAGE flag "--limit <n>" default="20" help="Max sessions to show (default: 20)"
 #USAGE flag "--project <filter>" help="Filter by project directory (substring match)"
 #USAGE flag "--filter <filter>" var=#true help="Filter sessions (type.meta.key=value, supports indexing e.g. wake[0].meta.by=ikma)"
-#USAGE flag "--all" help="Include subagent sessions (excluded by default)"
+#USAGE flag "--all" default=#false help="Include empty/stub sessions hidden by default"
 #USAGE flag "--json" help="Output as JSON"
 # /// script
 # requires-python = ">=3.10"
@@ -21,7 +21,7 @@ from format import console, format_duration, format_model, format_relative, make
 limit = int(os.environ.get("usage_limit", "20"))
 project_filter = os.environ.get("usage_project", "")
 filter_raw = os.environ.get("usage_filter", "")
-include_agents = os.environ.get("usage_all", "") == "true"
+include_empty = os.environ.get("usage_all", "") == "true"
 output_json = os.environ.get("usage_json", "") == "true"
 
 filters = parse.parse_filters(filter_raw) if filter_raw else []
@@ -42,9 +42,6 @@ for project_dir in os.listdir(sessions_dir):
     for fname in os.listdir(project_path):
         if not fname.endswith(".jsonl"):
             continue
-        # Skip subagent sessions unless --all
-        if not include_agents and fname.startswith("agent-"):
-            continue
         filepath = os.path.join(project_path, fname)
         mtime = os.path.getmtime(filepath)
         files.append((mtime, filepath))
@@ -64,7 +61,7 @@ for mtime, filepath in files:
             continue
         meta = session.metadata()
         # Skip empty/stub sessions — no real assistant interaction
-        if not include_agents:
+        if not include_empty:
             msgs = meta["user_messages"] + meta["assistant_messages"]
             if msgs == 0 or meta["model"] == "unknown":
                 continue

--- a/.mise/tasks/search
+++ b/.mise/tasks/search
@@ -178,7 +178,7 @@ for dir_name in os.listdir(sessions_dir):
     if not os.path.isdir(dir_path):
         continue
     for fname in os.listdir(dir_path):
-        if not fname.endswith(".jsonl") or fname.startswith("agent-"):
+        if not fname.endswith(".jsonl"):
             continue
         filepath = os.path.join(dir_path, fname)
         all_files.append(filepath)

--- a/.mise/tasks/usage
+++ b/.mise/tasks/usage
@@ -105,8 +105,6 @@ def usage_files():
             for fname in os.listdir(project_path):
                 if not fname.endswith(".jsonl"):
                     continue
-                if fname.startswith("agent-") and not scan_all:
-                    continue
                 filepath = os.path.join(project_path, fname)
                 files.append((os.path.getmtime(filepath), filepath))
     files.sort(key=lambda item: -item[0])

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 302 passing](https://img.shields.io/badge/tests-302%20passing-brightgreen?style=flat)](test/)
+[![tests: 309 passing](https://img.shields.io/badge/tests-309%20passing-brightgreen?style=flat)](test/)
 ![commands: 19](https://img.shields.io/badge/commands-19-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -268,7 +268,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**302 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2747 lines in `lib/`.
+**309 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2740 lines in `lib/`.
 
 Python code is checked with [Ruff](https://docs.astral.sh/ruff/) via `mise run lint:python`, and CI runs the same lint/format check in addition to the BATS and Elixir suites.
 
@@ -307,7 +307,7 @@ sessions/
 │   └── harness/        # Per-harness adapters (pi, …)
 ├── queries/            # Packaged sessions query SQL presets
 └── test/
-    └── *.bats          # 302 tests
+    └── *.bats          # 309 tests
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 309 passing](https://img.shields.io/badge/tests-309%20passing-brightgreen?style=flat)](test/)
+[![tests: 311 passing](https://img.shields.io/badge/tests-311%20passing-brightgreen?style=flat)](test/)
 ![commands: 19](https://img.shields.io/badge/commands-19-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -268,7 +268,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**309 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2740 lines in `lib/`.
+**311 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2740 lines in `lib/`.
 
 Python code is checked with [Ruff](https://docs.astral.sh/ruff/) via `mise run lint:python`, and CI runs the same lint/format check in addition to the BATS and Elixir suites.
 
@@ -307,7 +307,7 @@ sessions/
 │   └── harness/        # Per-harness adapters (pi, …)
 ├── queries/            # Packaged sessions query SQL presets
 └── test/
-    └── *.bats          # 309 tests
+    └── *.bats          # 311 tests
 ```
 
 </details>

--- a/lib/query/scope.py
+++ b/lib/query/scope.py
@@ -48,7 +48,7 @@ def usage_from_session(session: parse.Session) -> UsageTotals:
     )
 
 
-def session_files(*, project: str, include_agent_prefixed: bool) -> list[Path]:
+def session_files(*, project: str) -> list[Path]:
     files: list[Path] = []
     for harness_name in harness.available():
         adapter = harness.adapter(harness_name)
@@ -65,8 +65,6 @@ def session_files(*, project: str, include_agent_prefixed: bool) -> list[Path]:
             for fname in os.listdir(project_path):
                 if not fname.endswith(".jsonl"):
                     continue
-                if fname.startswith("agent-") and not include_agent_prefixed:
-                    continue
                 filepath = os.path.join(project_path, fname)
                 if project:
                     try:
@@ -80,27 +78,23 @@ def session_files(*, project: str, include_agent_prefixed: bool) -> list[Path]:
     return files
 
 
-def include_session(entry: ScopeEntry, *, include_agent_prefixed: bool) -> bool:
-    if include_agent_prefixed:
-        return True
+def include_session(entry: ScopeEntry) -> bool:
     message_count = entry.user_messages + entry.assistant_messages
     return message_count > 0 and entry.model != "unknown"
 
 
 def load_corpus(
-    *, project: str, limit: int, include_agent_prefixed: bool
+    *, project: str, limit: int
 ) -> tuple[list[ScopeEntry], dict[str, UsageTotals]]:
     entries: list[ScopeEntry] = []
     usage: dict[str, UsageTotals] = {}
-    for path in session_files(
-        project=project, include_agent_prefixed=include_agent_prefixed
-    ):
+    for path in session_files(project=project):
         try:
             session = parse.load(str(path))
             entry = entry_from_session(session)
         except Exception:
             continue
-        if not include_session(entry, include_agent_prefixed=include_agent_prefixed):
+        if not include_session(entry):
             continue
         entries.append(entry)
         usage[entry.session_id] = usage_from_session(session)
@@ -130,5 +124,4 @@ def scope_entries(
     return load_corpus(
         project=args.project,
         limit=args.limit,
-        include_agent_prefixed=getattr(args, "include_agent_prefixed", False),
     )

--- a/test/export.bats
+++ b/test/export.bats
@@ -34,6 +34,31 @@ assert 'source_machine' in m
 "
 }
 
+@test "export bundle includes associated session files" {
+  source_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  associated_dir="${source_file%.jsonl}"
+  mkdir -p "$associated_dir"
+  echo '{}' > "$associated_dir/related.jsonl"
+
+  run sessions export "$SESSION_1" --output "$EXPORT_DIR" --format bundle
+
+  [ "$status" -eq 0 ]
+  [ -f "$EXPORT_DIR/$SESSION_1/associated-sessions/related.jsonl" ]
+  echo "$output" | grep -q "associated-sessions/ (1 sessions)"
+}
+
+@test "export bundle output does not invent special agent session categories" {
+  source_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  associated_dir="${source_file%.jsonl}"
+  mkdir -p "$associated_dir"
+  echo '{}' > "$associated_dir/related.jsonl"
+
+  run sessions export "$SESSION_1" --output "$EXPORT_DIR" --format bundle
+
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -qi "sub""agent"
+}
+
 @test "export markdown creates .md file" {
   run sessions export "$SESSION_1" --output "$EXPORT_DIR" --format markdown
   [ "$status" -eq 0 ]

--- a/test/import.bats
+++ b/test/import.bats
@@ -32,6 +32,27 @@ teardown() {
   echo "$output" | grep -q "Resume with:"
 }
 
+@test "import bundle restores associated session files" {
+  mkdir -p "$EXPORT_DIR/$SESSION_1/associated-sessions"
+  echo '{}' > "$EXPORT_DIR/$SESSION_1/associated-sessions/related.jsonl"
+
+  run sessions import "$EXPORT_DIR/$SESSION_1"
+
+  [ "$status" -eq 0 ]
+  [ -f "${PROJECT_DIR}${SESSION_1}/related.jsonl" ]
+}
+
+@test "import bundle accepts legacy associated-session directory" {
+  legacy_dir="$EXPORT_DIR/$SESSION_1/sub""agents"
+  mkdir -p "$legacy_dir"
+  echo '{}' > "$legacy_dir/related.jsonl"
+
+  run sessions import "$EXPORT_DIR/$SESSION_1"
+
+  [ "$status" -eq 0 ]
+  [ -f "${PROJECT_DIR}${SESSION_1}/related.jsonl" ]
+}
+
 @test "import errors when session already exists" {
   # Re-create the original (import writes without timestamp prefix)
   echo '{}' > "${PROJECT_DIR}${SESSION_1}.jsonl"

--- a/test/inspect.bats
+++ b/test/inspect.bats
@@ -61,3 +61,32 @@ assert 'bash' in data['tools']
   # File size appears in subtitle as KB or MB
   echo "$output" | grep -qE "(KB|MB)"
 }
+
+@test "inspect shows associated session files without special session categories" {
+  source_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  associated_dir="${source_file%.jsonl}"
+  mkdir -p "$associated_dir"
+  echo '{}' > "$associated_dir/related.jsonl"
+
+  run sessions inspect "$SESSION_1"
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Associated.*1 sessions"
+}
+
+@test "inspect --json reports associated sessions" {
+  source_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  associated_dir="${source_file%.jsonl}"
+  mkdir -p "$associated_dir"
+  echo '{}' > "$associated_dir/related.jsonl"
+
+  run sessions inspect "$SESSION_1" --json
+
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+assert data['associated_sessions'] == 1
+assert ('sub' + 'agent_sessions') not in data
+"
+}

--- a/test/list.bats
+++ b/test/list.bats
@@ -62,18 +62,32 @@ assert all('model' in s for s in data)
   echo "$output" | grep -q "claude-opus-4-6"
 }
 
-@test "list excludes agent- prefixed files by default" {
-  echo '{"type":"user","message":{"role":"user","content":"test"},"sessionId":"agent-test","timestamp":"2026-03-15T15:00:00.000Z"}' > "${PROJECT_DIR}agent-abc1234.jsonl"
-  run sessions list
-  [ "$status" -eq 0 ]
-  ! echo "$output" | grep -q "agent-abc"
-}
+@test "list includes sessions regardless of filename prefix" {
+  cat > "${PROJECT_DIR}agent-abc1234.jsonl" <<JSONL
+{"type":"session","version":3,"id":"agent-abc1234","timestamp":"2026-03-15T15:00:00.000Z","cwd":"/test/project"}
+{"type":"model_change","id":"mc1","parentId":null,"timestamp":"2026-03-15T15:00:00.001Z","provider":"test","modelId":"test-model"}
+{"type":"message","id":"u1","parentId":"mc1","timestamp":"2026-03-15T15:00:01.000Z","message":{"role":"user","content":[{"type":"text","text":"test"}]}}
+{"type":"message","id":"a1","parentId":"u1","timestamp":"2026-03-15T15:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"done"}],"model":"test-model","provider":"test"}}
+JSONL
 
-@test "list --all includes agent sessions" {
-  echo '{"type":"user","message":{"role":"user","content":"test"},"sessionId":"agent-abc1234","timestamp":"2026-03-15T15:00:00.000Z"}' > "${PROJECT_DIR}agent-abc1234.jsonl"
-  run sessions list --all
+  run sessions list
+
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "agent-ab"
+}
+
+@test "list --all includes empty stub sessions" {
+  cat > "${PROJECT_DIR}stub-session.jsonl" <<JSONL
+{"type":"session","version":3,"id":"stub-session","timestamp":"2026-03-15T15:00:00.000Z","cwd":"/test/project"}
+JSONL
+
+  run sessions list
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -q "stub-se"
+
+  run sessions list --all
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "stub-se"
 }
 
 # --- --filter: session header metadata ---

--- a/test/query.bats
+++ b/test/query.bats
@@ -40,6 +40,26 @@ assert rows == [{'n': 2}], rows
 "
 }
 
+@test "query corpus includes sessions regardless of filename prefix" {
+  cat > "${PROJECT_DIR}agent-abc1234.jsonl" <<JSONL
+{"type":"session","version":3,"id":"agent-abc1234","timestamp":"2026-03-15T15:00:00.000Z","cwd":"/test/project"}
+{"type":"model_change","id":"mc1","parentId":null,"timestamp":"2026-03-15T15:00:00.001Z","provider":"test","modelId":"test-model"}
+{"type":"message","id":"u1","parentId":"mc1","timestamp":"2026-03-15T15:00:01.000Z","message":{"role":"user","content":[{"type":"text","text":"test"}]}}
+{"type":"message","id":"a1","parentId":"u1","timestamp":"2026-03-15T15:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"done"}],"model":"test-model","provider":"test"}}
+JSONL
+
+  run sessions query --project test/project --limit 10 \
+    --sql "select session_id from sessions where session_id = 'agent-abc1234'" \
+    --format json
+
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+rows = json.load(sys.stdin)
+assert rows == [{'session_id': 'agent-abc1234'}], rows
+"
+}
+
 @test "query rejects mutating SQL" {
   run sessions query --sql "delete from sessions" --format json
   [ "$status" -ne 0 ]

--- a/test/search.bats
+++ b/test/search.bats
@@ -17,6 +17,25 @@ teardown() { teardown_test_sessions; }
   echo "$output" | grep -q "hello"
 }
 
+@test "search includes sessions regardless of filename prefix" {
+  cat > "${PROJECT_DIR}agent-search-visible.jsonl" <<JSONL
+{"type":"session","version":3,"id":"agent-search-visible","timestamp":"2026-03-15T15:00:00.000Z","cwd":"/test/project"}
+{"type":"model_change","id":"mc1","parentId":null,"timestamp":"2026-03-15T15:00:00.001Z","provider":"test","modelId":"test-model"}
+{"type":"message","id":"u1","parentId":"mc1","timestamp":"2026-03-15T15:00:01.000Z","message":{"role":"user","content":[{"type":"text","text":"needle-agent-prefix-visible"}]}}
+{"type":"message","id":"a1","parentId":"u1","timestamp":"2026-03-15T15:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"done"}],"model":"test-model","provider":"test"}}
+JSONL
+
+  run sessions search "needle-agent-prefix-visible" --json
+
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+matches = json.load(sys.stdin)
+assert len(matches) == 1, matches
+assert matches[0]['session_id'] == 'agent-search-visible', matches
+"
+}
+
 @test "search is case insensitive" {
   run sessions search "SCCACHE"
   [ "$status" -eq 0 ]

--- a/test/usage.bats
+++ b/test/usage.bats
@@ -109,6 +109,26 @@ assert obj['sessions'][0]['session_id'] == '$USAGE_SESSION_2'
 "
 }
 
+@test "usage aggregate includes sessions regardless of filename prefix" {
+  cat > "${PROJECT_DIR}agent-usage-visible.jsonl" <<JSONL
+{"type":"session","version":3,"id":"agent-usage-visible","timestamp":"2026-03-18T12:00:00.000Z","cwd":"/test/project","meta":{"agent":{"name":"agent-prefix-usage"}}}
+{"type":"model_change","id":"mc1","parentId":null,"timestamp":"2026-03-18T12:00:00.001Z","provider":"openai","modelId":"model-a"}
+{"type":"message","id":"a1","parentId":"mc1","timestamp":"2026-03-18T12:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"agent prefix usage"}],"model":"model-a","provider":"openai","stopReason":"stop","usage":{"input":11,"output":5,"cacheRead":0,"cacheWrite":0,"totalTokens":16,"cost":{"input":0.011,"output":0.005,"cacheRead":0,"cacheWrite":0,"total":0.016}}}}
+JSONL
+
+  run sessions usage --filter session.meta.agent.name=agent-prefix-usage --json
+
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+obj = json.load(sys.stdin)
+assert len(obj['sessions']) == 1, obj
+assert obj['sessions'][0]['session_id'] == 'agent-usage-visible', obj
+assert obj['totals']['calls'] == 1, obj
+assert obj['totals']['totalTokens'] == 16, obj
+"
+}
+
 @test "usage applies metadata filters before the default aggregate limit" {
   for i in $(seq -w 1 20); do
     cat > "${PROJECT_DIR}2026-03-16T12-${i}-00-000Z_other-${i}.jsonl" <<JSONL


### PR DESCRIPTION
## Summary

- remove the fake “subagent sessions” concept from user-facing `sessions` surfaces
- stop hiding `agent-*` session files in `sessions list` and `sessions query`; sessions are sessions regardless of filename prefix
- keep `sessions list --all` as a generic empty/stub-session inclusion flag
- rename inspect/export/import sidecar wording to “associated sessions” / `associated-sessions/`
- keep import compatibility for old bundle directories without preserving the old product language

Closes #109.

## Why

Or pushed back on the terminology directly: “subagent sessions” is not a real thing. A session is a session.

The old behavior made `agent-*` filenames into a product category and hid them by default. This PR removes that category instead of just renaming it.

## Validation

- `mise run test list inspect export import query`
- `mise run test` — 309 BATS
- `mise run lint:python`
- `cd cli && mise exec -- mix test` — 124 tests + 4 doctests
- `mise exec -- readme build --check`
- `git diff --check`
- language scan: no `subagent` / `subagents` hits in `README.md`, `.mise/tasks`, `test`, `lib`, or `queries`
- workbench scan: `/tmp/x1f9.d/sessions-109-review-workbench/artifacts/language-scan.md`
