### PR TITLE
fix: include agent-prefixed sessions in search and usage

### DIFF
--- a/.mise/tasks/search
+++ b/.mise/tasks/search
@@ -178,7 +178,7 @@ for dir_name in os.listdir(sessions_dir):
     if not os.path.isdir(dir_path):
         continue
     for fname in os.listdir(dir_path):
-        if not fname.endswith(".jsonl") or fname.startswith("agent-"):
+        if not fname.endswith(".jsonl"):
             continue
         filepath = os.path.join(dir_path, fname)
         all_files.append(filepath)

--- a/.mise/tasks/usage
+++ b/.mise/tasks/usage
@@ -105,8 +105,6 @@ def usage_files():
             for fname in os.listdir(project_path):
                 if not fname.endswith(".jsonl"):
                     continue
-                if fname.startswith("agent-") and not scan_all:
-                    continue
                 filepath = os.path.join(project_path, fname)
                 files.append((os.path.getmtime(filepath), filepath))
     files.sort(key=lambda item: -item[0])

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 309 passing](https://img.shields.io/badge/tests-309%20passing-brightgreen?style=flat)](test/)
+[![tests: 311 passing](https://img.shields.io/badge/tests-311%20passing-brightgreen?style=flat)](test/)
 ![commands: 19](https://img.shields.io/badge/commands-19-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -268,7 +268,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**309 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2740 lines in `lib/`.
+**311 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2740 lines in `lib/`.
 
 Python code is checked with [Ruff](https://docs.astral.sh/ruff/) via `mise run lint:python`, and CI runs the same lint/format check in addition to the BATS and Elixir suites.
 
@@ -307,7 +307,7 @@ sessions/
 │   └── harness/        # Per-harness adapters (pi, …)
 ├── queries/            # Packaged sessions query SQL presets
 └── test/
-    └── *.bats          # 309 tests
+    └── *.bats          # 311 tests
 ```
 
 </details>

--- a/test/search.bats
+++ b/test/search.bats
@@ -17,6 +17,25 @@ teardown() { teardown_test_sessions; }
   echo "$output" | grep -q "hello"
 }
 
+@test "search includes sessions regardless of filename prefix" {
+  cat > "${PROJECT_DIR}agent-search-visible.jsonl" <<JSONL
+{"type":"session","version":3,"id":"agent-search-visible","timestamp":"2026-03-15T15:00:00.000Z","cwd":"/test/project"}
+{"type":"model_change","id":"mc1","parentId":null,"timestamp":"2026-03-15T15:00:00.001Z","provider":"test","modelId":"test-model"}
+{"type":"message","id":"u1","parentId":"mc1","timestamp":"2026-03-15T15:00:01.000Z","message":{"role":"user","content":[{"type":"text","text":"needle-agent-prefix-visible"}]}}
+{"type":"message","id":"a1","parentId":"u1","timestamp":"2026-03-15T15:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"done"}],"model":"test-model","provider":"test"}}
+JSONL
+
+  run sessions search "needle-agent-prefix-visible" --json
+
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+matches = json.load(sys.stdin)
+assert len(matches) == 1, matches
+assert matches[0]['session_id'] == 'agent-search-visible', matches
+"
+}
+
 @test "search is case insensitive" {
   run sessions search "SCCACHE"
   [ "$status" -eq 0 ]

--- a/test/usage.bats
+++ b/test/usage.bats
@@ -109,6 +109,26 @@ assert obj['sessions'][0]['session_id'] == '$USAGE_SESSION_2'
 "
 }
 
+@test "usage aggregate includes sessions regardless of filename prefix" {
+  cat > "${PROJECT_DIR}agent-usage-visible.jsonl" <<JSONL
+{"type":"session","version":3,"id":"agent-usage-visible","timestamp":"2026-03-18T12:00:00.000Z","cwd":"/test/project","meta":{"agent":{"name":"agent-prefix-usage"}}}
+{"type":"model_change","id":"mc1","parentId":null,"timestamp":"2026-03-18T12:00:00.001Z","provider":"openai","modelId":"model-a"}
+{"type":"message","id":"a1","parentId":"mc1","timestamp":"2026-03-18T12:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"agent prefix usage"}],"model":"model-a","provider":"openai","stopReason":"stop","usage":{"input":11,"output":5,"cacheRead":0,"cacheWrite":0,"totalTokens":16,"cost":{"input":0.011,"output":0.005,"cacheRead":0,"cacheWrite":0,"total":0.016}}}}
+JSONL
+
+  run sessions usage --filter session.meta.agent.name=agent-prefix-usage --json
+
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json, sys
+obj = json.load(sys.stdin)
+assert len(obj['sessions']) == 1, obj
+assert obj['sessions'][0]['session_id'] == 'agent-usage-visible', obj
+assert obj['totals']['calls'] == 1, obj
+assert obj['totals']['totalTokens'] == 16, obj
+"
+}
+
 @test "usage applies metadata filters before the default aggregate limit" {
   for i in $(seq -w 1 20); do
     cat > "${PROJECT_DIR}2026-03-16T12-${i}-00-000Z_other-${i}.jsonl" <<JSONL


### PR DESCRIPTION
## Summary

- include `agent-*.jsonl` files in `sessions search`
- include `agent-*.jsonl` files in aggregate `sessions usage`
- add regressions for both commands so filename prefixes no longer define a hidden session category
- regenerate README test count from 309 to 311

## Context

Fix-it for #114. The parent PR removes the fake “subagent sessions” product category, but review found two remaining user-facing code paths that still treated `agent-*` filenames specially.

## Validation

- `mise run test search usage` — 24/24
- `mise run test` — 311/311
- `mise run lint:python`
- `mise exec -- readme build --check`
- `git diff --check`
- residual behavior scan for `fname.startswith("agent-`) / `include_agent` / old subagent terms
