### PR TITLE
Pin Pi harness to KKL release

### DIFF
--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -278,19 +278,10 @@ run_interactive() {
 
   sessions_prepare_harness_env
 
-  local -a pi_command
-  if [ -n "${SESSIONS_PI_BIN:-}" ]; then
-    pi_command=("$SESSIONS_PI_BIN")
-    if ! command -v "$SESSIONS_PI_BIN" >/dev/null 2>&1; then
-      echo "Error: pi override not found on PATH: $SESSIONS_PI_BIN" >&2
-      exit 1
-    fi
-  else
-    pi_command=(mise -C "$MISE_CONFIG_ROOT" exec -- pi)
-    if ! command -v mise >/dev/null 2>&1; then
-      echo "Error: mise not found on PATH for sessions-owned pi harness" >&2
-      exit 1
-    fi
+  local -a pi_command=(mise -C "$MISE_CONFIG_ROOT" exec -- pi)
+  if ! command -v mise >/dev/null 2>&1; then
+    echo "Error: mise not found on PATH for sessions-owned pi harness" >&2
+    exit 1
   fi
 
   local pi_args=(--model "$MODEL")

--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -278,9 +278,19 @@ run_interactive() {
 
   sessions_prepare_harness_env
 
-  if ! command -v pi >/dev/null 2>&1; then
-    echo "Error: pi not found on PATH" >&2
-    exit 1
+  local -a pi_command
+  if [ -n "${SESSIONS_PI_BIN:-}" ]; then
+    pi_command=("$SESSIONS_PI_BIN")
+    if ! command -v "$SESSIONS_PI_BIN" >/dev/null 2>&1; then
+      echo "Error: pi override not found on PATH: $SESSIONS_PI_BIN" >&2
+      exit 1
+    fi
+  else
+    pi_command=(mise -C "$MISE_CONFIG_ROOT" exec -- pi)
+    if ! command -v mise >/dev/null 2>&1; then
+      echo "Error: mise not found on PATH for sessions-owned pi harness" >&2
+      exit 1
+    fi
   fi
 
   local pi_args=(--model "$MODEL")
@@ -302,10 +312,10 @@ run_interactive() {
       echo "Error: timeout command is required for --timeout" >&2
       exit 1
     fi
-    run_and_exit timeout "$TIMEOUT" pi "${pi_args[@]}"
+    run_and_exit timeout "$TIMEOUT" "${pi_command[@]}" "${pi_args[@]}"
   fi
 
-  run_and_exit pi "${pi_args[@]}"
+  run_and_exit "${pi_command[@]}" "${pi_args[@]}"
 }
 
 if [ "$INTERACTIVE" = "true" ] || [ -z "$MESSAGE" ]; then

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 311 passing](https://img.shields.io/badge/tests-311%20passing-brightgreen?style=flat)](test/)
+[![tests: 312 passing](https://img.shields.io/badge/tests-312%20passing-brightgreen?style=flat)](test/)
 ![commands: 19](https://img.shields.io/badge/commands-19-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -268,7 +268,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**311 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2740 lines in `lib/`.
+**312 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2740 lines in `lib/`.
 
 Python code is checked with [Ruff](https://docs.astral.sh/ruff/) via `mise run lint:python`, and CI runs the same lint/format check in addition to the BATS and Elixir suites.
 
@@ -307,7 +307,7 @@ sessions/
 │   └── harness/        # Per-harness adapters (pi, …)
 ├── queries/            # Packaged sessions query SQL presets
 └── test/
-    └── *.bats          # 311 tests
+    └── *.bats          # 312 tests
 ```
 
 </details>

--- a/cli/README.md
+++ b/cli/README.md
@@ -45,4 +45,4 @@ mix sessions --model openai-codex/gpt-5.5 --session ./session.jsonl "Continue"
 
 - Elixir 1.19+
 - Jason (JSON parsing)
-- pi (installed via mise: `github:badlogic/pi-mono`)
+- pi (owned by this package via mise: `github:KnickKnackLabs/pi@v0.80.3-kkl.1`)

--- a/cli/lib/harness/pi/command.ex
+++ b/cli/lib/harness/pi/command.ex
@@ -69,7 +69,7 @@ defmodule Cli.Harness.Pi.Command do
       ]
       |> Enum.join("")
 
-    pi_cmd = ~s(pi -p "$1"#{pi_flags})
+    pi_cmd = ~s(mise -C "$MISE_CONFIG_ROOT" exec -- pi -p "$1"#{pi_flags})
 
     # `echo |` pipes empty stdin so pi doesn't block waiting for a TTY.
     shell_script =

--- a/cli/test/harness/pi/command_test.exs
+++ b/cli/test/harness/pi/command_test.exs
@@ -8,7 +8,7 @@ defmodule Cli.Harness.Pi.CommandTest do
       {script, _args} =
         Command.build_command("hi", "claude-sonnet-4-5", nil, nil, nil)
 
-      assert script =~ "echo | pi -p \"$1\""
+      assert script =~ "echo | mise -C \"$MISE_CONFIG_ROOT\" exec -- pi -p \"$1\""
       refute script =~ "--append-system-prompt"
       assert script =~ ~s( --model "$2")
       assert script =~ " --mode json"
@@ -25,7 +25,7 @@ defmodule Cli.Harness.Pi.CommandTest do
       {script, _} =
         Command.build_command("hi", "claude-sonnet-4-5", "/tmp/prompt.txt", nil, 300)
 
-      assert script =~ "echo | timeout 300 pi -p"
+      assert script =~ "echo | timeout 300 mise -C \"$MISE_CONFIG_ROOT\" exec -- pi -p"
     end
 
     test "uses --session at the next positional index after prompt args" do

--- a/mise.toml
+++ b/mise.toml
@@ -16,6 +16,7 @@ bats = "1.13.0"
 "shiv:codebase" = "0.2.0"                  # Codebase linting + migrations
 "shiv:readme" = "0.1"                      # README generation/checks
 "shiv:shell" = "0.1.0"                     # Persistent terminal sessions (used by wake)
+"github:KnickKnackLabs/pi" = "v0.80.3-kkl.1" # Agent harness pinned by sessions
 erlang = "28.4.1"
 elixir = "1.19.5-otp-27"
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -24,9 +24,27 @@ REPO_DIR="${REPO_DIR:-$(cd "$BATS_TEST_DIRNAME/.." && pwd)}"
 export REPO_DIR
 
 sessions() {
-  cd "$REPO_DIR" && PI_DIR="$PI_DIR" SESSIONS_PI_BIN="${SESSIONS_PI_BIN:-pi}" mise run -q "$@"
+  cd "$REPO_DIR" && PI_DIR="$PI_DIR" mise run -q "$@"
 }
 export -f sessions
+
+stub_mise_exec_pi() {
+  local stub_dir="$1"
+  local real_mise
+  real_mise=$(command -v mise)
+
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/mise" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "-C" ] && [ "\${3:-}" = "exec" ] && [ "\${4:-}" = "--" ] && [ "\${5:-}" = "pi" ]; then
+  shift 5
+  exec pi "\$@"
+fi
+exec "$real_mise" "\$@"
+STUB
+  chmod +x "$stub_dir/mise"
+}
 
 stub_pi_capture_argv_cwd() {
   local stub_dir="$1"
@@ -41,6 +59,7 @@ printf '%s\n' "\$@" > "$argv_capture"
 exit 0
 STUB
   chmod +x "$stub_dir/pi"
+  stub_mise_exec_pi "$stub_dir"
 }
 
 stub_pi_capture_env() {
@@ -57,6 +76,7 @@ printf 'PATH=%s\n' "\$PATH" >> "$env_capture"
 exit 0
 STUB
   chmod +x "$stub_dir/pi"
+  stub_mise_exec_pi "$stub_dir"
 }
 
 stub_shell_exec_payload() {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -24,7 +24,7 @@ REPO_DIR="${REPO_DIR:-$(cd "$BATS_TEST_DIRNAME/.." && pwd)}"
 export REPO_DIR
 
 sessions() {
-  cd "$REPO_DIR" && PI_DIR="$PI_DIR" mise run -q "$@"
+  cd "$REPO_DIR" && PI_DIR="$PI_DIR" SESSIONS_PI_BIN="${SESSIONS_PI_BIN:-pi}" mise run -q "$@"
 }
 export -f sessions
 

--- a/test/ps.bats
+++ b/test/ps.bats
@@ -179,6 +179,7 @@ sleep 0.2
 exit 0
 STUB
   chmod +x "$stub_dir/pi"
+  stub_mise_exec_pi "$stub_dir"
   session_file=$(session_file_for "$SESSION_1")
 
   PATH="$stub_dir:$PATH" run sessions run \

--- a/test/run.bats
+++ b/test/run.bats
@@ -79,7 +79,7 @@ STUB
   local run_cwd="$BATS_TEST_TMPDIR/run-cwd-owned"
   mkdir -p "$run_cwd"
 
-  PATH="$stub_dir:$PATH" SESSIONS_PI_BIN= run "$real_mise" -C "$REPO_DIR" run -q run \
+  PATH="$stub_dir:$PATH" run "$real_mise" -C "$REPO_DIR" run -q run \
     --cwd "$run_cwd" \
     --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]
@@ -250,8 +250,9 @@ else
 fi
 STUB
   chmod +x "$stub_dir/pi"
+  stub_mise_exec_pi "$stub_dir"
 
-  run bash -c 'printf "%s\n" "typed input" | PATH="$1" PI_DIR="$2" SESSIONS_PI_BIN=pi mise -C "$3" run -q run --system-prompt-file "$4" --cwd "$5" --model "openai-codex/gpt-5.5"' \
+  run bash -c 'printf "%s\n" "typed input" | PATH="$1" PI_DIR="$2" mise -C "$3" run -q run --system-prompt-file "$4" --cwd "$5" --model "openai-codex/gpt-5.5"' \
     bash \
     "$stub_dir:$PATH" \
     "$PI_DIR" \
@@ -284,6 +285,7 @@ cat "\$prompt_file" > "$prompt_capture"
 exit 0
 STUB
   chmod +x "$stub_dir/pi"
+  stub_mise_exec_pi "$stub_dir"
 
   run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt "baked prompt from session"
   [ "$status" -eq 0 ]
@@ -415,6 +417,7 @@ cat "\$prompt_file" > "$prompt_capture"
 exit 0
 STUB
   chmod +x "$stub_dir/pi"
+  stub_mise_exec_pi "$stub_dir"
 
   run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt "baked prompt"
   [ "$status" -eq 0 ]
@@ -454,6 +457,7 @@ cat "\$prompt_file" > "$prompt_capture"
 exit 0
 STUB
   chmod +x "$stub_dir/pi"
+  stub_mise_exec_pi "$stub_dir"
 
   : > "$BATS_TEST_TMPDIR/empty-prompt.md"
   run sessions new --cwd "$BATS_TEST_TMPDIR" --system-prompt-file "$BATS_TEST_TMPDIR/empty-prompt.md"
@@ -520,8 +524,9 @@ trap 'printf term > "$term_capture"; exit 143' TERM
 while :; do sleep 1; done
 STUB
   chmod +x "$stub_dir/pi"
+  stub_mise_exec_pi "$stub_dir"
 
-  PATH="$stub_dir:$PATH" DISPATCH_CONTEXT="generated prompt" PI_DIR="$PI_DIR" SESSIONS_PI_BIN=pi \
+  PATH="$stub_dir:$PATH" DISPATCH_CONTEXT="generated prompt" PI_DIR="$PI_DIR" \
     mise -C "$REPO_DIR" run -q run --cwd "$BATS_TEST_TMPDIR" --model "openai-codex/gpt-5.5" \
     >"$stdout_capture" 2>"$stderr_capture" &
   local mise_pid=$!

--- a/test/run.bats
+++ b/test/run.bats
@@ -55,6 +55,45 @@ teardown() {
   ! grep -qx '' "$argv_capture"
 }
 
+@test "run interactive resolves pi through sessions mise root by default" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-mise-pi"
+  local argv_capture="$BATS_TEST_TMPDIR/pi-argv-owned"
+  local cwd_capture="$BATS_TEST_TMPDIR/pi-cwd-owned"
+  local mise_capture="$BATS_TEST_TMPDIR/mise-argv-owned"
+  local real_mise
+  real_mise=$(command -v mise)
+
+  stub_pi_capture_argv_cwd "$stub_dir" "$argv_capture" "$cwd_capture"
+  cat > "$stub_dir/mise" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "-C" ] && [ "\${3:-}" = "exec" ] && [ "\${4:-}" = "--" ] && [ "\${5:-}" = "pi" ]; then
+  printf '%s\n' "\$@" > "$mise_capture"
+  shift 5
+  exec pi "\$@"
+fi
+exec "$real_mise" "\$@"
+STUB
+  chmod +x "$stub_dir/mise"
+
+  local run_cwd="$BATS_TEST_TMPDIR/run-cwd-owned"
+  mkdir -p "$run_cwd"
+
+  PATH="$stub_dir:$PATH" SESSIONS_PI_BIN= run "$real_mise" -C "$REPO_DIR" run -q run \
+    --cwd "$run_cwd" \
+    --model "openai-codex/gpt-5.5"
+  [ "$status" -eq 0 ]
+  [ -f "$mise_capture" ]
+  [ -f "$argv_capture" ]
+
+  [ "$(awk 'NR == 1 { print }' "$mise_capture")" = "-C" ]
+  [ "$(awk 'NR == 2 { print }' "$mise_capture")" = "$REPO_DIR" ]
+  [ "$(awk 'NR == 3 { print }' "$mise_capture")" = "exec" ]
+  [ "$(awk 'NR == 4 { print }' "$mise_capture")" = "--" ]
+  [ "$(awk 'NR == 5 { print }' "$mise_capture")" = "pi" ]
+  grep -qx -- "--model" "$argv_capture"
+}
+
 @test "run --interactive with message execs pi without print mode" {
   local stub_dir="$BATS_TEST_TMPDIR/stub-pi-interactive-message"
   local argv_capture="$BATS_TEST_TMPDIR/pi-argv-interactive-message"
@@ -212,7 +251,7 @@ fi
 STUB
   chmod +x "$stub_dir/pi"
 
-  run bash -c 'printf "%s\n" "typed input" | PATH="$1" PI_DIR="$2" mise -C "$3" run -q run --system-prompt-file "$4" --cwd "$5" --model "openai-codex/gpt-5.5"' \
+  run bash -c 'printf "%s\n" "typed input" | PATH="$1" PI_DIR="$2" SESSIONS_PI_BIN=pi mise -C "$3" run -q run --system-prompt-file "$4" --cwd "$5" --model "openai-codex/gpt-5.5"' \
     bash \
     "$stub_dir:$PATH" \
     "$PI_DIR" \
@@ -482,7 +521,7 @@ while :; do sleep 1; done
 STUB
   chmod +x "$stub_dir/pi"
 
-  PATH="$stub_dir:$PATH" DISPATCH_CONTEXT="generated prompt" PI_DIR="$PI_DIR" \
+  PATH="$stub_dir:$PATH" DISPATCH_CONTEXT="generated prompt" PI_DIR="$PI_DIR" SESSIONS_PI_BIN=pi \
     mise -C "$REPO_DIR" run -q run --cwd "$BATS_TEST_TMPDIR" --model "openai-codex/gpt-5.5" \
     >"$stdout_capture" 2>"$stderr_capture" &
   local mise_pid=$!

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -721,6 +721,7 @@ cat "\$prompt_file" > "$prompt_capture"
 exit 0
 STUB
   chmod +x "$stub_dir/pi"
+  stub_mise_exec_pi "$stub_dir"
 
   PATH="$stub_dir:$PATH" run sessions wake wake-baked-prompt --background --model "openai-codex/gpt-5.5"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

Pin the `sessions` Pi harness dependency to the KKL Pi release that contains autonomous self-rewind support.

- add `github:KnickKnackLabs/pi = "v0.80.3-kkl.1"` to `mise.toml`
- run headless Pi via `mise -C "$MISE_CONFIG_ROOT" exec -- pi ...`
- run interactive Pi through the same sessions-owned resolution path
- keep a `SESSIONS_PI_BIN` test seam so BATS stubs remain hermetic
- update CLI docs and regenerated README test count

## Why

Agent self-rewind depends on KKL Pi `v0.80.3-kkl.1` for exact tree summaries and terminal queued extension commands. `sessions` should own the harness version instead of relying on the caller/global shim state after PATH cleanup.

## Validation

```sh
cd ~/agents/brownie/sessions-src/cli && mix test
# 128 passed

cd ~/agents/brownie/sessions-src && mise run test
# 312 passed

cd ~/agents/brownie/sessions-src && readme build --check
# README.md is up to date.

cd ~/agents/brownie/sessions-src && codebase lint "$PWD"
# all 7 lint rule(s) passed

cd ~/agents/brownie/sessions-src && git diff --check
```
