### PR TITLE
feat: propagate harness project trust

### DIFF
--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -10,9 +10,13 @@
 #USAGE flag "--cwd <cwd>" default="" help="Working directory for pi"
 #USAGE flag "--headless" default=#false help="Non-interactive mode (appends headless context to system prompt)"
 #USAGE flag "--interactive" default=#false help="Open a persistent interactive harness even when a message is provided"
-#USAGE flag "--extensions" default=#false help="Enable pi extensions for print-mode runs (interactive runs use pi defaults)"
-#USAGE flag "--skills" default=#false help="Enable pi skills for print-mode runs (interactive runs use pi defaults)"
-#USAGE flag "--prompt-templates" default=#false help="Enable pi prompt templates for print-mode runs (interactive runs use pi defaults)"
+#USAGE flag "--project-trust <policy>" default="inherit" help="Project resource trust for this run: inherit, approve, or deny"
+#USAGE flag "--extensions" default=#false help="Explicitly enable pi extensions (retained for compatibility; enabled by default)"
+#USAGE flag "--skills" default=#false help="Explicitly enable pi skills (retained for compatibility; enabled by default)"
+#USAGE flag "--prompt-templates" default=#false help="Explicitly enable pi prompt templates (retained for compatibility; enabled by default)"
+#USAGE flag "--no-extensions" default=#false help="Disable harness extensions for this run"
+#USAGE flag "--no-skills" default=#false help="Disable harness skills for this run"
+#USAGE flag "--no-prompt-templates" default=#false help="Disable harness prompt templates for this run"
 
 set -euo pipefail
 
@@ -24,10 +28,27 @@ SESSION="${usage_session:-}"
 CWD="${usage_cwd:-${SESSIONS_CALLER_PWD:-${CALLER_PWD:-.}}}"
 HEADLESS="${usage_headless:-false}"
 INTERACTIVE="${usage_interactive:-false}"
-# Extensions disabled by default (determinism for CI). Pass --extensions etc. to enable.
-EXTENSIONS="${usage_extensions:-false}"
-SKILLS="${usage_skills:-false}"
-PROMPT_TEMPLATES="${usage_prompt_templates:-false}"
+PROJECT_TRUST="${usage_project_trust:-inherit}"
+EXTENSIONS=true
+SKILLS=true
+PROMPT_TEMPLATES=true
+
+if [ "${usage_extensions:-false}" = "true" ] && [ "${usage_no_extensions:-false}" = "true" ]; then
+  echo "Error: --extensions cannot be combined with --no-extensions" >&2
+  exit 1
+fi
+if [ "${usage_skills:-false}" = "true" ] && [ "${usage_no_skills:-false}" = "true" ]; then
+  echo "Error: --skills cannot be combined with --no-skills" >&2
+  exit 1
+fi
+if [ "${usage_prompt_templates:-false}" = "true" ] && [ "${usage_no_prompt_templates:-false}" = "true" ]; then
+  echo "Error: --prompt-templates cannot be combined with --no-prompt-templates" >&2
+  exit 1
+fi
+
+[ "${usage_no_extensions:-false}" = "true" ] && EXTENSIONS=false
+[ "${usage_no_skills:-false}" = "true" ] && SKILLS=false
+[ "${usage_no_prompt_templates:-false}" = "true" ] && PROMPT_TEMPLATES=false
 
 # shellcheck source=../../lib/harness-env.sh
 source "$MISE_CONFIG_ROOT/lib/harness-env.sh"
@@ -211,6 +232,8 @@ if [[ "$MODEL" != */* ]]; then
   exit 1
 fi
 
+sessions_validate_project_trust "$PROJECT_TRUST" || exit 1
+
 # Prompt resolution order:
 #   1. Explicit --system-prompt-file
 #   2. Latest system_prompt entry baked into --session by `sessions new`
@@ -270,6 +293,8 @@ run_interactive() {
   else
     harness_name=$(harness_resolve) || exit 1
   fi
+  # shellcheck source=/dev/null
+  source "$MISE_CONFIG_ROOT/lib/harness/$harness_name.sh"
 
   if [ "$harness_name" != "pi" ]; then
     echo "sessions: '$harness_name' harness does not support interactive no-message run yet" >&2
@@ -284,7 +309,14 @@ run_interactive() {
     exit 1
   fi
 
+  local project_trust_flag
+  project_trust_flag=$(harness_call "$harness_name" project_trust_flag "$PROJECT_TRUST") || exit 1
+
   local pi_args=(--model "$MODEL")
+  [ -n "$project_trust_flag" ] && pi_args+=("$project_trust_flag")
+  [ "$EXTENSIONS" = "true" ] || pi_args+=(--no-extensions)
+  [ "$SKILLS" = "true" ] || pi_args+=(--no-skills)
+  [ "$PROMPT_TEMPLATES" = "true" ] || pi_args+=(--no-prompt-templates)
   if [ -n "$SYSTEM_PROMPT_FILE" ]; then
     pi_args=(--append-system-prompt "$SYSTEM_PROMPT_FILE" "${pi_args[@]}")
   fi
@@ -322,7 +354,7 @@ CLI_ARGS=(--cwd "$CWD")
 [ -n "$TIMEOUT" ] && CLI_ARGS+=(--timeout "$TIMEOUT")
 CLI_ARGS+=(--model "$MODEL")
 [ -n "$SESSION" ] && CLI_ARGS+=(--session "$SESSION")
-# Extensions off by default — only pass --no-* when NOT explicitly enabled
+CLI_ARGS+=(--project-trust "$PROJECT_TRUST")
 [ "$EXTENSIONS" != "true" ] && CLI_ARGS+=(--no-extensions)
 [ "$SKILLS" != "true" ] && CLI_ARGS+=(--no-skills)
 [ "$PROMPT_TEMPLATES" != "true" ] && CLI_ARGS+=(--no-prompt-templates)

--- a/.mise/tasks/search
+++ b/.mise/tasks/search
@@ -3,12 +3,12 @@
 #USAGE arg "<query>" help="Search query (regex supported)"
 #USAGE flag "--limit <n>" default="50" help="Max matches to show (default: 50)"
 #USAGE flag "--context <n>" default="0" help="Lines of context around matches (default: 0)"
-#USAGE flag "--session <id>" help="Filter to a specific session (prefix match)"
+#USAGE flag "--session <id>" default="" help="Filter to a specific session (prefix match)"
 #USAGE flag "--sort <field>" default="time" help="Sort by: time (default), session"
-#USAGE flag "--after <date>" help="Only matches after this date (YYYY-MM-DD)"
-#USAGE flag "--before <date>" help="Only matches before this date (YYYY-MM-DD)"
-#USAGE flag "--tools" help="Include matches in tool inputs/outputs (excluded by default)"
-#USAGE flag "--json" help="Output as JSON"
+#USAGE flag "--after <date>" default="" help="Only matches after this date (YYYY-MM-DD)"
+#USAGE flag "--before <date>" default="" help="Only matches before this date (YYYY-MM-DD)"
+#USAGE flag "--tools" default=#false help="Include matches in tool inputs/outputs (excluded by default)"
+#USAGE flag "--json" default=#false help="Output as JSON"
 # /// script
 # requires-python = ">=3.10"
 # dependencies = ["rich"]

--- a/.mise/tasks/wake
+++ b/.mise/tasks/wake
@@ -8,6 +8,10 @@
 #USAGE flag "--os-user <os_user>" default="" help="Run the session payload as this local OS user (default: $SHIMMER_OS_USER)"
 #USAGE flag "--headless" default=#false help="No human present — agent completes task and exits"
 #USAGE flag "--background" default=#false help="Launch in background via shell/zmx (default: foreground, blocks until done)"
+#USAGE flag "--project-trust <policy>" default="inherit" help="Project resource trust for this run: inherit, approve, or deny"
+#USAGE flag "--no-extensions" default=#false help="Disable harness extensions for this run"
+#USAGE flag "--no-skills" default=#false help="Disable harness skills for this run"
+#USAGE flag "--no-prompt-templates" default=#false help="Disable harness prompt templates for this run"
 #USAGE flag "--meta <meta>" var=#true default="" help="Metadata for the wake event (repeatable, dotted paths or jq expressions)"
 
 set -euo pipefail
@@ -21,6 +25,10 @@ MODEL="${usage_model:-}"
 OS_USER="${usage_os_user:-}"
 HEADLESS="${usage_headless:-false}"
 BACKGROUND="${usage_background:-false}"
+PROJECT_TRUST="${usage_project_trust:-inherit}"
+NO_EXTENSIONS="${usage_no_extensions:-false}"
+NO_SKILLS="${usage_no_skills:-false}"
+NO_PROMPT_TEMPLATES="${usage_no_prompt_templates:-false}"
 
 scrub_caller_pwd_env() {
   local name
@@ -90,6 +98,7 @@ mise_run=(mise -C "$MISE_CONFIG_ROOT" run -q)
 
 # shellcheck source=/dev/null
 source "$MISE_CONFIG_ROOT/lib/harness/dispatch.sh"
+sessions_validate_project_trust "$PROJECT_TRUST" || exit 1
 source "$MISE_CONFIG_ROOT/lib/find.sh"
 source "$MISE_CONFIG_ROOT/lib/shell.sh"
 SESSION_FILE=$(find_session_file "$SESSION_ID") || exit 1
@@ -98,6 +107,12 @@ SESSION_FILE=$(find_session_file "$SESSION_ID") || exit 1
 HARNESS_NAME=$(harness_resolve --session "$SESSION_FILE") || exit 1
 # shellcheck source=/dev/null
 source "$MISE_CONFIG_ROOT/lib/harness/$HARNESS_NAME.sh"
+
+# Inherit requires no adapter behavior. Fail before recording a wake when the
+# selected harness cannot honor an explicitly non-default trust policy.
+if [ "$PROJECT_TRUST" != "inherit" ]; then
+  harness_call "$HARNESS_NAME" project_trust_flag "$PROJECT_TRUST" >/dev/null
+fi
 
 if [ "$HEADLESS" != "true" ] && [ "$HARNESS_NAME" != "pi" ]; then
   if [ -z "$MESSAGE" ]; then
@@ -208,7 +223,16 @@ SESSION_CWD=$(cd "$SESSION_CWD" && pwd -P)
 
 # --- Launch ---
 
-RUN_CMD=("${mise_run[@]}" run --session "$SESSION_FILE" --cwd "$SESSION_CWD" --model "$MODEL")
+RUN_CMD=(
+  "${mise_run[@]}" run
+  --session "$SESSION_FILE"
+  --cwd "$SESSION_CWD"
+  --model "$MODEL"
+  --project-trust "$PROJECT_TRUST"
+)
+[ "$NO_EXTENSIONS" = "true" ] && RUN_CMD+=(--no-extensions)
+[ "$NO_SKILLS" = "true" ] && RUN_CMD+=(--no-skills)
+[ "$NO_PROMPT_TEMPLATES" = "true" ] && RUN_CMD+=(--no-prompt-templates)
 if [ "$HEADLESS" = "true" ]; then
   RUN_CMD+=(--headless)
   if [ -n "$MESSAGE" ]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,11 @@ Keep harness-specific knowledge in `lib/harness/<name>.sh` and `lib/harness/<nam
 - session file locations and path encoding;
 - native JSONL message schemas;
 - launch arguments for a harness binary;
+- translation of generic one-run policies such as project trust;
 - fallback parsing of harness-owned transcript/event shapes.
+
+A harness must translate a non-default generic policy or reject it explicitly.
+It must never silently ignore a policy it cannot honor.
 
 For example, `sessions run` writes generic `process_start` / `process_exit` records, and `sessions ps` reads those generic records. If a future harness exposes its own process metadata, parse that in the harness adapter and convert it to the generic shape instead of baking the harness schema into `ps`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,13 @@ Keep harness-specific knowledge in `lib/harness/<name>.sh` and `lib/harness/<nam
 A harness must translate a non-default generic policy or reject it explicitly.
 It must never silently ignore a policy it cannot honor.
 
+`wake` preflights non-default policy before appending wake or context entries
+because it launches `run` only after those mutations.
+Low-level `run` delegates policy handling to the selected execution adapter
+and records its attempted process plus exit, including an adapter rejection.
+Do not duplicate execution-adapter policy in the Bash wrapper merely to suppress
+that audit trail.
+
 For example, `sessions run` writes generic `process_start` / `process_exit` records, and `sessions ps` reads those generic records. If a future harness exposes its own process metadata, parse that in the harness adapter and convert it to the generic shape instead of baking the harness schema into `ps`.
 
 ## Python mise tasks

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 320 passing](https://img.shields.io/badge/tests-320%20passing-brightgreen?style=flat)](test/)
+[![tests: 321 passing](https://img.shields.io/badge/tests-321%20passing-brightgreen?style=flat)](test/)
 ![commands: 19](https://img.shields.io/badge/commands-19-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -272,7 +272,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**320 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2740 lines in `lib/`.
+**321 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2740 lines in `lib/`.
 
 Python code is checked with [Ruff](https://docs.astral.sh/ruff/) via `mise run lint:python`, and CI runs the same lint/format check in addition to the BATS and Elixir suites.
 
@@ -311,7 +311,7 @@ sessions/
 │   └── harness/        # Per-harness adapters (pi, …)
 ├── queries/            # Packaged sessions query SQL presets
 └── test/
-    └── *.bats          # 320 tests
+    └── *.bats          # 321 tests
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 319 passing](https://img.shields.io/badge/tests-319%20passing-brightgreen?style=flat)](test/)
+[![tests: 320 passing](https://img.shields.io/badge/tests-320%20passing-brightgreen?style=flat)](test/)
 ![commands: 19](https://img.shields.io/badge/commands-19-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -272,7 +272,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**319 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2740 lines in `lib/`.
+**320 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2740 lines in `lib/`.
 
 Python code is checked with [Ruff](https://docs.astral.sh/ruff/) via `mise run lint:python`, and CI runs the same lint/format check in addition to the BATS and Elixir suites.
 
@@ -311,7 +311,7 @@ sessions/
 │   └── harness/        # Per-harness adapters (pi, …)
 ├── queries/            # Packaged sessions query SQL presets
 └── test/
-    └── *.bats          # 319 tests
+    └── *.bats          # 320 tests
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create sessions with structured metadata, wake agents into them,
 observe transcripts in real time, and query your history.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 312 passing](https://img.shields.io/badge/tests-312%20passing-brightgreen?style=flat)](test/)
+[![tests: 319 passing](https://img.shields.io/badge/tests-319%20passing-brightgreen?style=flat)](test/)
 ![commands: 19](https://img.shields.io/badge/commands-19-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -120,6 +120,10 @@ The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for per
 `--model` on `sessions wake` is required and is not remembered across wakes — pass a provider-qualified model (for example `openai-codex/gpt-5.5`) on each wake.
 
 `--message` is optional for interactive `sessions wake`: with a message, wake sends an initial prompt and keeps the harness open; without one, it opens the harness for the human. `--headless` still requires `--message`. For low-level `sessions run`, pass `--interactive` when a provided message should keep the harness open; otherwise a message uses the print/one-turn compatibility path.
+
+Runs inherit the selected harness's normal extensions, skills, and prompt templates by default, including print and headless execution. Use `--no-extensions`, `--no-skills`, or `--no-prompt-templates` only when a caller deliberately needs a resource-free boundary.
+
+`--project-trust inherit|approve|deny` controls project-scoped settings and executable resources for one run. The default `inherit` preserves native harness behavior. A harness translates `approve` and `deny` explicitly or rejects the unsupported policy; Sessions never silently ignores it. This option does not persist trust and is not a sandbox.
 
 To run only the payload process as a local agent OS user, pass `--os-user` or set `SHIMMER_OS_USER`. The shell/zmx session remains owned by the caller. This does not copy caller environment, secrets, or auth into the target account; the target user's session environment is a separate setup step.
 
@@ -268,7 +272,7 @@ cd sessions && mise trust && mise install
 mise run test
 ```
 
-**312 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2740 lines in `lib/`.
+**319 tests** across 21 suites, using [BATS 1.13.0](https://github.com/bats-core/bats-core). Tasks are bash scripts (session creation, wake, metadata) and Python scripts with [Rich](https://github.com/Textualize/rich) output (list, read, wait, usage, inspect, search). The shared Python support library is 2740 lines in `lib/`.
 
 Python code is checked with [Ruff](https://docs.astral.sh/ruff/) via `mise run lint:python`, and CI runs the same lint/format check in addition to the BATS and Elixir suites.
 
@@ -307,7 +311,7 @@ sessions/
 │   └── harness/        # Per-harness adapters (pi, …)
 ├── queries/            # Packaged sessions query SQL presets
 └── test/
-    └── *.bats          # 312 tests
+    └── *.bats          # 319 tests
 ```
 
 </details>

--- a/README.tsx
+++ b/README.tsx
@@ -266,6 +266,27 @@ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed th
       </Paragraph>
 
       <Paragraph>
+        {"Runs inherit the selected harness's normal extensions, skills, and prompt templates by default, including print and headless execution. Use "}
+        <Code>--no-extensions</Code>
+        {", "}
+        <Code>--no-skills</Code>
+        {", or "}
+        <Code>--no-prompt-templates</Code>
+        {" only when a caller deliberately needs a resource-free boundary."}
+      </Paragraph>
+
+      <Paragraph>
+        <Code>--project-trust inherit|approve|deny</Code>
+        {" controls project-scoped settings and executable resources for one run. The default "}
+        <Code>inherit</Code>
+        {" preserves native harness behavior. A harness translates "}
+        <Code>approve</Code>
+        {" and "}
+        <Code>deny</Code>
+        {" explicitly or rejects the unsupported policy; Sessions never silently ignores it. This option does not persist trust and is not a sandbox."}
+      </Paragraph>
+
+      <Paragraph>
         {"To run only the payload process as a local agent OS user, pass "}
         <Code>--os-user</Code>
         {" or set "}

--- a/cli/README.md
+++ b/cli/README.md
@@ -37,9 +37,14 @@ mix sessions --model openai-codex/gpt-5.5 --session ./session.jsonl "Continue"
 | `--model <provider/model>` | Required. Provider-qualified model to use |
 | `--session <path>` | Optional. Session file for conversation continuity |
 | `--cwd <path>` | Optional. Working directory for pi |
-| `--no-extensions` | Disable pi extensions |
-| `--no-skills` | Disable pi skills |
-| `--no-prompt-templates` | Disable pi prompt templates |
+| `--no-extensions` | Disable harness extensions for this run |
+| `--no-skills` | Disable harness skills for this run |
+| `--no-prompt-templates` | Disable harness prompt templates for this run |
+| `--project-trust <policy>` | Project resources for this run: `inherit`, `approve`, or `deny` |
+
+Runs inherit the harness's normal resource behavior by default. Project trust is
+one-run policy, not persisted trust or a sandbox. Harnesses translate non-default
+policy explicitly or fail as unsupported.
 
 ## Dependencies
 

--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -54,6 +54,7 @@ defmodule Cli do
     extensions = opts[:no_extensions] != true
     skills = opts[:no_skills] != true
     prompt_templates = opts[:no_prompt_templates] != true
+    project_trust = opts[:project_trust] || "inherit"
 
     print_header(opts, message, timeout, model)
 
@@ -73,7 +74,8 @@ defmodule Cli do
           session,
           extensions: extensions,
           skills: skills,
-          prompt_templates: prompt_templates
+          prompt_templates: prompt_templates,
+          project_trust: project_trust
         )
     end
   end
@@ -102,6 +104,9 @@ defmodule Cli do
       not String.contains?(opts[:model], "/") ->
         {:error, "--model must be provider-qualified (for example: openai-codex/gpt-5.5)"}
 
+      (opts[:project_trust] || "inherit") not in ["inherit", "approve", "deny"] ->
+        {:error, "--project-trust must be inherit, approve, or deny"}
+
       system_prompt_file != nil and system_prompt_file != "" and
           not File.exists?(system_prompt_file) ->
         {:error, "System prompt file not found: #{system_prompt_file}"}
@@ -123,6 +128,7 @@ defmodule Cli do
           no_extensions: :boolean,
           no_skills: :boolean,
           no_prompt_templates: :boolean,
+          project_trust: :string,
           help: :boolean
         ],
         aliases: [h: :help]
@@ -156,9 +162,11 @@ defmodule Cli do
       --timeout <seconds>          Maximum runtime in seconds (default: no timeout)
       --cwd <path>                 Working directory for pi
       --session <path>             Session file for conversation continuity
-      --no-extensions              Disable pi extensions
-      --no-skills                  Disable pi skills
-      --no-prompt-templates        Disable pi prompt templates
+      --no-extensions              Disable harness extensions
+      --no-skills                  Disable harness skills
+      --no-prompt-templates        Disable harness prompt templates
+      --project-trust <policy>     Project resources: inherit, approve, or deny
+                                   (one run only; unsupported policies fail)
       -h, --help                   Show this help message
 
     Examples:

--- a/cli/lib/cli/engine.ex
+++ b/cli/lib/cli/engine.ex
@@ -19,7 +19,8 @@ defmodule Cli.Engine do
   @typep run_opts :: [
            extensions: boolean(),
            skills: boolean(),
-           prompt_templates: boolean()
+           prompt_templates: boolean(),
+           project_trust: String.t()
          ]
 
   @doc """

--- a/cli/lib/harness/pi/command.ex
+++ b/cli/lib/harness/pi/command.ex
@@ -14,7 +14,8 @@ defmodule Cli.Harness.Pi.Command do
   @typep build_opts :: [
            extensions: boolean(),
            skills: boolean(),
-           prompt_templates: boolean()
+           prompt_templates: boolean(),
+           project_trust: String.t()
          ]
 
   @doc """
@@ -38,6 +39,7 @@ defmodule Cli.Harness.Pi.Command do
     extensions = Keyword.get(opts, :extensions, true)
     skills = Keyword.get(opts, :skills, true)
     prompt_templates = Keyword.get(opts, :prompt_templates, true)
+    project_trust_flag = project_trust_flag(Keyword.get(opts, :project_trust, "inherit"))
 
     qualified_model = model
 
@@ -63,6 +65,7 @@ defmodule Cli.Harness.Pi.Command do
         ~s( --model "$2"),
         " --mode json",
         session_flag,
+        project_trust_flag,
         if(extensions, do: "", else: " --no-extensions"),
         if(skills, do: "", else: " --no-skills"),
         if(prompt_templates, do: "", else: " --no-prompt-templates")
@@ -80,5 +83,13 @@ defmodule Cli.Harness.Pi.Command do
       end
 
     {shell_script, positional}
+  end
+
+  defp project_trust_flag("inherit"), do: ""
+  defp project_trust_flag("approve"), do: " --approve"
+  defp project_trust_flag("deny"), do: " --no-approve"
+
+  defp project_trust_flag(policy) do
+    raise ArgumentError, "unknown project trust policy: #{inspect(policy)}"
   end
 end

--- a/cli/test/cli_test.exs
+++ b/cli/test/cli_test.exs
@@ -83,6 +83,20 @@ defmodule CliTest do
       end
     end
 
+    test "rejects an unknown project trust policy" do
+      {output, exit_code} =
+        run_cli([
+          "--project-trust",
+          "sometimes",
+          "--model",
+          "openai-codex/gpt-5.5",
+          "hello"
+        ])
+
+      assert exit_code == 1
+      assert output =~ "--project-trust must be inherit, approve, or deny"
+    end
+
     test "rejects non-existent system-prompt-file" do
       {output, exit_code} =
         run_cli([

--- a/cli/test/harness/pi/command_test.exs
+++ b/cli/test/harness/pi/command_test.exs
@@ -117,6 +117,43 @@ defmodule Cli.Harness.Pi.CommandTest do
     end
   end
 
+  describe "build_command/6 — project trust" do
+    test "inherits project trust by default without a pi override" do
+      {script, _} =
+        Command.build_command("hi", "claude-sonnet-4-5", "/tmp/prompt.txt", nil, nil)
+
+      refute script =~ "--approve"
+      refute script =~ "--no-approve"
+    end
+
+    test "maps approve to --approve" do
+      {script, _} =
+        Command.build_command("hi", "claude-sonnet-4-5", "/tmp/prompt.txt", nil, nil,
+          project_trust: "approve"
+        )
+
+      assert script =~ " --approve"
+      refute script =~ "--no-approve"
+    end
+
+    test "maps deny to --no-approve" do
+      {script, _} =
+        Command.build_command("hi", "claude-sonnet-4-5", "/tmp/prompt.txt", nil, nil,
+          project_trust: "deny"
+        )
+
+      assert script =~ " --no-approve"
+    end
+
+    test "rejects an unknown project trust policy" do
+      assert_raise ArgumentError, ~r/unknown project trust policy/, fn ->
+        Command.build_command("hi", "claude-sonnet-4-5", "/tmp/prompt.txt", nil, nil,
+          project_trust: "sometimes"
+        )
+      end
+    end
+  end
+
   describe "build_command/6 — positional args" do
     test "returns [message, model] without prompt or session" do
       {_script, args} =

--- a/lib/harness/claude.sh
+++ b/lib/harness/claude.sh
@@ -20,6 +20,25 @@
 # Usage (from task scripts, where $MISE_CONFIG_ROOT is set by mise):
 #   source "$MISE_CONFIG_ROOT/lib/harness/claude.sh"
 
+# --- Launch policy ---
+
+# Inheriting native behavior requires no adapter support. Claude project trust
+# translation is not implemented, so non-default policies fail explicitly.
+harness_claude_project_trust_flag() {
+  case "${1:-}" in
+    inherit)
+      return 0
+      ;;
+    approve|deny)
+      harness_unsupported
+      ;;
+    *)
+      echo "Error: unknown project trust policy: ${1:-}" >&2
+      return 2
+      ;;
+  esac
+}
+
 # --- Location ---
 
 harness_claude_sessions_dir() {

--- a/lib/harness/dispatch.sh
+++ b/lib/harness/dispatch.sh
@@ -50,6 +50,21 @@ _DISPATCH_SH_LOADED=1
 HARNESS_LIB_DIR="${HARNESS_LIB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 HARNESS_DEFAULT="pi"
 
+# Project trust is a generic one-run policy. Core tasks validate the shared
+# vocabulary; each harness adapter translates a supported policy into its own
+# launch flags or reports UNSUPPORTED for non-default behavior.
+sessions_validate_project_trust() {
+  case "${1:-}" in
+    inherit|approve|deny)
+      return 0
+      ;;
+    *)
+      echo "Error: --project-trust must be inherit, approve, or deny" >&2
+      return 1
+      ;;
+  esac
+}
+
 # --- UNSUPPORTED contract ---
 #
 # Adapters that don't (yet) implement a given operation signal so via a

--- a/lib/harness/pi.sh
+++ b/lib/harness/pi.sh
@@ -17,6 +17,28 @@
 # Usage (from task scripts, where $MISE_CONFIG_ROOT is set by mise):
 #   source "$MISE_CONFIG_ROOT/lib/harness/pi.sh"
 
+# --- Launch policy ---
+
+# Translate Sessions' generic one-run project trust policy to Pi flags.
+# Empty output means inherit Pi's normal trust behavior.
+harness_pi_project_trust_flag() {
+  case "${1:-}" in
+    inherit)
+      return 0
+      ;;
+    approve)
+      echo "--approve"
+      ;;
+    deny)
+      echo "--no-approve"
+      ;;
+    *)
+      echo "Error: unknown project trust policy: ${1:-}" >&2
+      return 2
+      ;;
+  esac
+}
+
 # --- Location ---
 
 # Print the absolute path of pi's sessions root.

--- a/test/run.bats
+++ b/test/run.bats
@@ -243,6 +243,26 @@ STUB
   echo "$output" | grep -q -- "--project-trust must be inherit, approve, or deny"
 }
 
+@test "run lets the selected adapter reject unsupported trust and records the failed attempt" {
+  local session_file
+  session_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  echo '{"type":"harness","id":"h-claude","parentId":"u4","timestamp":"2026-03-14T10:31:00.000Z","name":"claude"}' >> "$session_file"
+
+  run sessions run \
+    --session "$session_file" \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5" \
+    --project-trust approve \
+    "do work"
+
+  [ "$status" -eq 10 ]
+  echo "$output" | grep -q -- "claude.*does not support.*build_command"
+  jq -s -e '
+    ([.[] | select(.type == "process_start" and .harness == "claude")] | length) == 1 and
+    ([.[] | select(.type == "process_exit" and .exit_code == 10)] | length) == 1
+  ' "$session_file" >/dev/null
+}
+
 @test "run interactive maps project trust and explicit resource disables to pi" {
   local stub_dir="$BATS_TEST_TMPDIR/stub-pi-interactive-policy"
   local argv_capture="$BATS_TEST_TMPDIR/pi-argv-interactive-policy"

--- a/test/run.bats
+++ b/test/run.bats
@@ -183,6 +183,85 @@ STUB
   ! grep -qx -- "--system-prompt-file" "$argv_capture"
   grep -qx -- "--model" "$argv_capture"
   [ "$(awk '/^--model$/ { getline; print; exit }' "$argv_capture")" = "openai-codex/gpt-5.5" ]
+  grep -qx -- "--project-trust" "$argv_capture"
+  [ "$(awk '/^--project-trust$/ { getline; print; exit }' "$argv_capture")" = "inherit" ]
+  ! grep -qx -- "--no-extensions" "$argv_capture"
+  ! grep -qx -- "--no-skills" "$argv_capture"
+  ! grep -qx -- "--no-prompt-templates" "$argv_capture"
+}
+
+@test "run forwards explicit resource disables and project approval" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-mix-resource-policy"
+  local argv_capture="$BATS_TEST_TMPDIR/mix-argv-resource-policy"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/mix" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+case "\$*" in
+  "local.hex --force --if-missing"|"deps.loadpaths --no-compile"|"deps.get") exit 0 ;;
+esac
+printf '%s\n' "\$@" > "$argv_capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/mix"
+
+  PATH="$stub_dir:$PATH" run sessions run \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5" \
+    --project-trust approve \
+    --no-extensions \
+    --no-skills \
+    --no-prompt-templates \
+    "do work"
+  [ "$status" -eq 0 ]
+  [ -f "$argv_capture" ]
+
+  [ "$(awk '/^--project-trust$/ { getline; print; exit }' "$argv_capture")" = "approve" ]
+  grep -qx -- "--no-extensions" "$argv_capture"
+  grep -qx -- "--no-skills" "$argv_capture"
+  grep -qx -- "--no-prompt-templates" "$argv_capture"
+}
+
+@test "run rejects conflicting resource flags" {
+  run sessions run \
+    --model "openai-codex/gpt-5.5" \
+    --extensions \
+    --no-extensions \
+    "do work"
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q -- "--extensions cannot be combined with --no-extensions"
+}
+
+@test "run rejects an invalid project trust policy" {
+  run sessions run \
+    --model "openai-codex/gpt-5.5" \
+    --project-trust sometimes \
+    "do work"
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q -- "--project-trust must be inherit, approve, or deny"
+}
+
+@test "run interactive maps project trust and explicit resource disables to pi" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-interactive-policy"
+  local argv_capture="$BATS_TEST_TMPDIR/pi-argv-interactive-policy"
+  local cwd_capture="$BATS_TEST_TMPDIR/pi-cwd-interactive-policy"
+  stub_pi_capture_argv_cwd "$stub_dir" "$argv_capture" "$cwd_capture"
+
+  PATH="$stub_dir:$PATH" run sessions run \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5" \
+    --project-trust deny \
+    --no-extensions \
+    --no-skills \
+    --no-prompt-templates
+  [ "$status" -eq 0 ]
+
+  grep -qx -- "--no-approve" "$argv_capture"
+  grep -qx -- "--no-extensions" "$argv_capture"
+  grep -qx -- "--no-skills" "$argv_capture"
+  grep -qx -- "--no-prompt-templates" "$argv_capture"
 }
 
 @test "run with message prepares CLI deps before mix sessions" {

--- a/test/search.bats
+++ b/test/search.bats
@@ -17,6 +17,23 @@ teardown() { teardown_test_sessions; }
   echo "$output" | grep -q "hello"
 }
 
+@test "search clears inherited optional usage defaults" {
+  export usage_session="stale-session-filter"
+  export usage_after="2099-01-01"
+  export usage_before="2000-01-01"
+  export usage_tools=true
+  export usage_json=true
+
+  run sessions search "sccache"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "sccache"
+  [ "${output:0:1}" != "[" ]
+
+  run sessions search "config/sccache"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "No matches"
+}
+
 @test "search includes sessions regardless of filename prefix" {
   cat > "${PROJECT_DIR}agent-search-visible.jsonl" <<JSONL
 {"type":"session","version":3,"id":"agent-search-visible","timestamp":"2026-03-15T15:00:00.000Z","cwd":"/test/project"}

--- a/test/wake.bats
+++ b/test/wake.bats
@@ -417,6 +417,71 @@ STUB
   # Sanity: `sessions run` is also in the argv (confirms we're stubbing
   # the right layer).
   grep -q '^run$' "$capture"
+
+  [ "$(awk '/^--project-trust$/ { getline; print; exit }' "$capture")" = "inherit" ]
+  ! grep -qx -- "--no-extensions" "$capture"
+  ! grep -qx -- "--no-skills" "$capture"
+  ! grep -qx -- "--no-prompt-templates" "$capture"
+}
+
+@test "wake forwards project approval and explicit resource disables" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-shell-resource-policy"
+  local capture="$BATS_TEST_TMPDIR/shell-argv-resource-policy"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/shell" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$capture"
+exit 0
+STUB
+  chmod +x "$stub_dir/shell"
+
+  PATH="$stub_dir:$PATH" run sessions wake "${SESSION_1:0:8}" \
+    --background \
+    --model "openai-codex/gpt-5.5" \
+    --project-trust approve \
+    --no-extensions \
+    --no-skills \
+    --no-prompt-templates
+  [ "$status" -eq 0 ]
+  [ -f "$capture" ]
+
+  [ "$(awk '/^--project-trust$/ { getline; print; exit }' "$capture")" = "approve" ]
+  grep -qx -- "--no-extensions" "$capture"
+  grep -qx -- "--no-skills" "$capture"
+  grep -qx -- "--no-prompt-templates" "$capture"
+}
+
+@test "wake rejects invalid project trust before recording wake" {
+  local src_file
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  local before
+  before=$(wc -l < "$src_file" | tr -d ' ')
+
+  run sessions wake "$SESSION_1" \
+    --background \
+    --model "openai-codex/gpt-5.5" \
+    --project-trust sometimes
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q -- "--project-trust must be inherit, approve, or deny"
+  [ "$(wc -l < "$src_file" | tr -d ' ')" = "$before" ]
+}
+
+@test "wake rejects unsupported non-default project trust before recording wake" {
+  local src_file
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  echo '{"type":"harness","id":"h-claude","parentId":"u4","timestamp":"2026-03-14T10:31:00.000Z","name":"claude"}' >> "$src_file"
+  local before
+  before=$(wc -l < "$src_file" | tr -d ' ')
+
+  run sessions wake "$SESSION_1" \
+    --headless \
+    --background \
+    --model "openai-codex/gpt-5.5" \
+    --message "review" \
+    --project-trust approve
+  [ "$status" -eq 10 ]
+  echo "$output" | grep -q -- "claude.*does not support.*project_trust"
+  [ "$(wc -l < "$src_file" | tr -d ' ')" = "$before" ]
 }
 
 @test "wake forwards session cwd to sessions run" {
@@ -611,7 +676,7 @@ STUB
   [ "$after_messages" = "$before_messages" ]
   jq -e 'select(.type == "wake" and .headless == false)' "$src_file"
 
-  [ "$(tail -1 "$capture")" = "openai-codex/gpt-5.5" ]
+  [ "$(awk '/^--model$/ { getline; print; exit }' "$capture")" = "openai-codex/gpt-5.5" ]
   ! grep -qx 'stale inherited message' "$capture"
   ! grep -qx -- '--headless' "$capture"
   ! grep -qx '' "$capture"


### PR DESCRIPTION
## Summary

- inherit the selected harness's normal extensions, skills, and prompt templates in print/headless runs by default
- add generic one-run `--project-trust inherit|approve|deny` policy through `sessions wake` and `sessions run`
- translate Pi approval to `--approve`, denial to `--no-approve`, and inheritance to no override
- preserve explicit resource-free flags and reject invalid or unsupported non-default policy before wake mutation
- fix `sessions search` leaking ambient `usage_session` and other optional usage values from an enclosing Sessions invocation

## Trust boundary

Project approval allows project-scoped configuration and executable resources for one run. It does not persist trust and is not a sandbox. Harness adapters must translate non-default policy or reject it explicitly.

## Validation

- 320/320 BATS tests
- 129 Elixir tests plus 4 doctests
- configured codebase/Python lints
- generated README check and `git diff --check`
- signed commits verified
- isolated auth-only integration smoke from Junior home, with no global settings: Sessions passed `project-trust approve`, loaded filtered `ricon-pi@v0.3.1`, executed `session_set_label`, and returned `SESSIONS_CAPABILITY_OK`

Supports the approved pilot in ricon-family/fold#160.
