### PR TITLE
Reject unsupported run project trust before launch

### DIFF
--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -234,6 +234,19 @@ fi
 
 sessions_validate_project_trust "$PROJECT_TRUST" || exit 1
 
+# Inherit requires no adapter behavior. Fail before recording process metadata
+# when the selected harness cannot honor an explicitly non-default trust policy.
+if [ "$PROJECT_TRUST" != "inherit" ]; then
+  if [ -n "$SESSION" ]; then
+    RUN_HARNESS_NAME=$(harness_resolve --session "$SESSION") || exit 1
+  else
+    RUN_HARNESS_NAME=$(harness_resolve) || exit 1
+  fi
+  # shellcheck source=/dev/null
+  source "$MISE_CONFIG_ROOT/lib/harness/$RUN_HARNESS_NAME.sh"
+  harness_call "$RUN_HARNESS_NAME" project_trust_flag "$PROJECT_TRUST" >/dev/null
+fi
+
 # Prompt resolution order:
 #   1. Explicit --system-prompt-file
 #   2. Latest system_prompt entry baked into --session by `sessions new`

--- a/test/run.bats
+++ b/test/run.bats
@@ -243,6 +243,25 @@ STUB
   echo "$output" | grep -q -- "--project-trust must be inherit, approve, or deny"
 }
 
+@test "run rejects unsupported non-default project trust before recording process metadata" {
+  local src_file
+  src_file=$(find "$PROJECT_DIR" -name "*${SESSION_1}.jsonl")
+  echo '{"type":"harness","id":"h-claude","parentId":"u4","timestamp":"2026-03-14T10:31:00.000Z","name":"claude"}' >> "$src_file"
+  local before
+  before=$(wc -l < "$src_file" | tr -d ' ')
+
+  run sessions run \
+    --session "$src_file" \
+    --cwd "$BATS_TEST_TMPDIR" \
+    --model "openai-codex/gpt-5.5" \
+    --project-trust approve \
+    "do work"
+
+  [ "$status" -eq 10 ]
+  echo "$output" | grep -q -- "claude.*does not support.*project_trust"
+  [ "$(wc -l < "$src_file" | tr -d ' ')" = "$before" ]
+}
+
 @test "run interactive maps project trust and explicit resource disables to pi" {
   local stub_dir="$BATS_TEST_TMPDIR/stub-pi-interactive-policy"
   local argv_capture="$BATS_TEST_TMPDIR/pi-argv-interactive-policy"


### PR DESCRIPTION
Fix-it for #118.

`wake` already preflights non-default `--project-trust` against the resolved harness before appending a wake entry, but low-level `sessions run` did not. That meant a direct run against a claude-declared session could accept `--project-trust approve`, append process metadata, and hand the policy to the pi CLI path instead of rejecting the unsupported harness policy.

This adds the same preflight to `run` before prompt/process work, plus a regression test that verifies no process metadata is appended on unsupported policy.

Tested:

```bash
bats test/run.bats
```
