### PR TITLE
fix: resolve relative child cwd from caller

### DIFF
--- a/.mise/tasks/run
+++ b/.mise/tasks/run
@@ -25,7 +25,8 @@ SYSTEM_PROMPT_FILE="${usage_system_prompt_file:-}"
 TIMEOUT="${usage_timeout:-}"
 MODEL="${usage_model:-}"
 SESSION="${usage_session:-}"
-CWD="${usage_cwd:-${SESSIONS_CALLER_PWD:-${CALLER_PWD:-.}}}"
+CALLER_CWD="${SESSIONS_CALLER_PWD:-${CALLER_PWD:-.}}"
+CWD="${usage_cwd:-$CALLER_CWD}"
 HEADLESS="${usage_headless:-false}"
 INTERACTIVE="${usage_interactive:-false}"
 PROJECT_TRUST="${usage_project_trust:-inherit}"
@@ -235,6 +236,17 @@ if [[ "$MODEL" != */* ]]; then
 fi
 
 sessions_validate_project_trust "$PROJECT_TRUST" || exit 1
+
+# Mise tasks run from Sessions' package root. Resolve relative child paths from
+# the invoking caller before either launch path changes directories again.
+case "$CWD" in
+  /*) ;;
+  *) CWD="$CALLER_CWD/$CWD" ;;
+esac
+CWD=$(cd "$CWD" 2>/dev/null && pwd -P) || {
+  echo "Error: --cwd directory not found: ${usage_cwd:-$CALLER_CWD}" >&2
+  exit 1
+}
 
 # Resolve the selected harness and its Sessions-owned executable before any
 # launch environment is sanitized. Unsupported skeleton adapters may return no

--- a/test/run.bats
+++ b/test/run.bats
@@ -55,6 +55,31 @@ teardown() {
   ! grep -qx '' "$argv_capture"
 }
 
+@test "run resolves relative requested cwd from the caller in interactive and print paths" {
+  local stub_dir="$BATS_TEST_TMPDIR/stub-pi-relative-cwd"
+  local cwd_capture="$BATS_TEST_TMPDIR/pi-relative-cwd"
+  local argv_capture="$BATS_TEST_TMPDIR/pi-relative-argv"
+  local caller="$BATS_TEST_TMPDIR/caller"
+  local expected="$caller/target"
+
+  mkdir -p "$expected"
+  stub_pi_capture_argv_cwd "$stub_dir" "$argv_capture" "$cwd_capture"
+
+  SESSIONS_CALLER_PWD="$caller" PATH="$stub_dir:$PATH" run sessions run \
+    --cwd target \
+    --model "openai-codex/gpt-5.5"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$cwd_capture")" = "$(cd "$expected" && pwd -P)" ]
+
+  rm "$cwd_capture"
+  SESSIONS_CALLER_PWD="$caller" PATH="$stub_dir:$PATH" run sessions run \
+    --cwd target \
+    --model "openai-codex/gpt-5.5" \
+    "probe"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$cwd_capture")" = "$(cd "$expected" && pwd -P)" ]
+}
+
 @test "run interactive resolves Sessions pi with mise and launches it directly" {
   local stub_dir="$BATS_TEST_TMPDIR/stub-mise-pi"
   local argv_capture="$BATS_TEST_TMPDIR/pi-argv-owned"


### PR DESCRIPTION
## Finding fixed

PR #120 preserves an absolute requested CWD, but an explicit relative `--cwd` is still interpreted from Sessions' mise package root. Interactive launch fails at `cd`; print/headless resolves it after changing into `cli/`. Neither path reaches the caller-requested project.

This resolves the child CWD once from `SESSIONS_CALLER_PWD` / `CALLER_PWD`, normalizes it to a physical absolute path, and then passes the same value through the Bash and Elixir launch paths and process audit.

## Validation

- `mise run test`: 322/322 BATS tests pass
- targeted `mise run test run` after final ordering cleanup: 24/24 pass
- `readme build --check`
- Bash syntax and `git diff --check`

The new regression invokes both the interactive child and the final print-mode Pi child with a relative CWD from a caller outside the Sessions tree.
