### PR TITLE
chore: update Pi to v0.81.0-kkl.1

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -50,4 +50,4 @@ policy explicitly or fail as unsupported.
 
 - Elixir 1.19+
 - Jason (JSON parsing)
-- pi (owned by this package via mise: `github:KnickKnackLabs/pi@v0.80.10-kkl.1`)
+- pi (owned by this package via mise: `github:KnickKnackLabs/pi@v0.81.0-kkl.1`)

--- a/mise.toml
+++ b/mise.toml
@@ -17,7 +17,7 @@ bats = "1.13.0"
 "shiv:codebase" = "0.3"                    # Codebase linting + migrations
 "shiv:readme" = "0.1"                      # README generation/checks
 "shiv:shell" = "0.1.0"                     # Persistent terminal sessions (used by wake)
-"github:KnickKnackLabs/pi" = "v0.80.10-kkl.1" # Agent harness pinned by sessions
+"github:KnickKnackLabs/pi" = "v0.81.0-kkl.1" # Agent harness pinned by sessions
 erlang = "28.4.1"
 elixir = "1.19.5-otp-27"
 


### PR DESCRIPTION
## Summary

- pin Sessions' owned Pi runtime to signed release `v0.81.0-kkl.1`
- keep the CLI dependency documentation on the same exact version

This is a dependency-only update. It does not change Sessions behavior.

## Validation

- resolved `mise which pi` to the `0.81.0-kkl.1` installation and verified `pi --version`
- 109 focused run/wake/harness/lint BATS tests
- full BATS suite: 335/335
- Elixir suite: 132 tests plus 4 doctests
- `readme build --check`
- `git diff --check`

A Sessions `v0.4.15` release remains a separate action after merge approval.
