### PR TITLE
chore: update Pi to v0.83.0-kkl.1

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -50,4 +50,4 @@ policy explicitly or fail as unsupported.
 
 - Elixir 1.19+
 - Jason (JSON parsing)
-- pi (owned by this package via mise: `github:KnickKnackLabs/pi@v0.81.0-kkl.2`)
+- pi (owned by this package via mise: `github:KnickKnackLabs/pi@v0.83.0-kkl.1`)

--- a/mise.toml
+++ b/mise.toml
@@ -17,7 +17,7 @@ bats = "1.13.0"
 "shiv:codebase" = "0.3"                    # Codebase linting + migrations
 "shiv:readme" = "0.1"                      # README generation/checks
 "shiv:shell" = "0.1.0"                     # Persistent terminal sessions (used by wake)
-"github:KnickKnackLabs/pi" = "v0.81.0-kkl.2" # Agent harness pinned by sessions
+"github:KnickKnackLabs/pi" = "v0.83.0-kkl.1" # Agent harness pinned by sessions
 erlang = "28.4.1"
 elixir = "1.19.5-otp-27"
 


### PR DESCRIPTION
## Summary

- pin Sessions' owned Pi harness to exact `v0.83.0-kkl.1`
- keep the CLI dependency documentation aligned with the executable declaration

## Validation

- `mise install`
- `mise exec -- pi --version` → `0.83.0-kkl.1`
- `mise run test ps run lint` → 33 focused checks passed
- `readme build --check`
- `codebase lint:mise-settings .`
- `codebase lint:github-actions .`
- `git diff --check`

Broad cross-platform validation is delegated to hosted PR CI per the runtime release-chain workflow.
