### PR TITLE
chore: consume Pi v0.83.0-kkl.3

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -50,4 +50,4 @@ policy explicitly or fail as unsupported.
 
 - Elixir 1.19+
 - Jason (JSON parsing)
-- pi (owned by this package via mise: `github:KnickKnackLabs/pi@v0.83.0-kkl.2`)
+- pi (owned by this package via mise: `github:KnickKnackLabs/pi@v0.83.0-kkl.3`)

--- a/mise.toml
+++ b/mise.toml
@@ -17,7 +17,7 @@ bats = "1.13.0"
 "shiv:codebase" = "0.3"                    # Codebase linting + migrations
 "shiv:readme" = "0.1"                      # README generation/checks
 "shiv:shell" = "0.1.0"                     # Persistent terminal sessions (used by wake)
-"github:KnickKnackLabs/pi" = "v0.83.0-kkl.2" # Agent harness pinned by sessions
+"github:KnickKnackLabs/pi" = "v0.83.0-kkl.3" # Agent harness pinned by sessions
 erlang = "28.4.1"
 elixir = "1.19.5-otp-27"
 


### PR DESCRIPTION
## Summary

- pin the Sessions-owned Pi runtime to `v0.83.0-kkl.3`
- keep the CLI dependency documentation exact

Pi release: https://github.com/KnickKnackLabs/pi/releases/tag/v0.83.0-kkl.3

## Validation

- `git diff --check`
- `mise exec -- pi --version` → `0.83.0-kkl.3`

This PR is AI-generated.
