### PR TITLE
chore: follow KKL Pi patch stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed th
 
 The spawning stack uses [shell](https://github.com/KnickKnackLabs/shell) for persistent zmx sessions. `sessions wake` calls `sessions run` as its hidden low-level executor. For profile-specific sessions, use `new` + `wake`: bake profile or task instructions into the session with `--system-prompt-file` at creation, then wake it with task messages. If no explicit or baked prompt exists, the harness starts without an appended prompt and can rely on its native cwd context discovery.
 
-Before launch, Sessions resolves the selected harness executable from its own declared toolchain. The child then starts in the requested `--cwd` with Sessions' mise task context and direct tool-install paths removed. This keeps the harness version pinned without replacing the target project or agent home's own tool and resource context.
+Before launch, Sessions resolves the selected harness executable from its own declared toolchain. The child then starts in the requested `--cwd` with Sessions' mise task context and direct tool-install paths removed. Sessions selects the latest compatible KKL Pi patch from the `v0.83.0-kkl` release stream when its toolchain is installed or refreshed, without replacing the target project or agent home's own tool and resource context. A fixed Sessions release can therefore resolve a newer Pi patch after refresh.
 
 `sessions run` remains available as an advanced/compatibility command. It accepts an explicit `--system-prompt-file`, uses any prompt baked into the session, and otherwise starts without appending a system prompt. Caller-provided context belongs to the caller, not to `sessions`.
 

--- a/README.tsx
+++ b/README.tsx
@@ -235,7 +235,7 @@ sessions wake review/pr-50 --model openai-codex/gpt-5.5 --message "You missed th
       <Paragraph>
         {"Before launch, Sessions resolves the selected harness executable from its own declared toolchain. The child then starts in the requested "}
         <Code>--cwd</Code>
-        {" with Sessions' mise task context and direct tool-install paths removed. This keeps the harness version pinned without replacing the target project or agent home's own tool and resource context."}
+        {" with Sessions' mise task context and direct tool-install paths removed. Sessions selects the latest compatible KKL Pi patch from the `v0.83.0-kkl` release stream when its toolchain is installed or refreshed, without replacing the target project or agent home's own tool and resource context. A fixed Sessions release can therefore resolve a newer Pi patch after refresh."}
       </Paragraph>
 
       <Paragraph>

--- a/cli/README.md
+++ b/cli/README.md
@@ -50,4 +50,4 @@ policy explicitly or fail as unsupported.
 
 - Elixir 1.19+
 - Jason (JSON parsing)
-- pi (owned by this package via mise: `github:KnickKnackLabs/pi@v0.83.0-kkl.3`)
+- pi (owned by this package via mise: `github:KnickKnackLabs/pi@v0.83.0-kkl`; install or refresh selects the latest compatible KKL patch)

--- a/mise.toml
+++ b/mise.toml
@@ -17,7 +17,7 @@ bats = "1.13.0"
 "shiv:codebase" = "0.3"                    # Codebase linting + migrations
 "shiv:readme" = "0.1"                      # README generation/checks
 "shiv:shell" = "0.1.0"                     # Persistent terminal sessions (used by wake)
-"github:KnickKnackLabs/pi" = "v0.83.0-kkl.3" # Agent harness pinned by sessions
+"github:KnickKnackLabs/pi" = "v0.83.0-kkl" # Latest compatible KKL patch on install/refresh
 erlang = "28.4.1"
 elixir = "1.19.5-otp-27"
 


### PR DESCRIPTION
## Summary

- follow the `v0.83.0-kkl` Pi fork release stream instead of pinning one KKL patch
- document that fresh or refreshed Sessions toolchains may resolve a newer compatible Pi patch
- preserve Sessions-owned harness resolution and the target project's own tool context

This is the one-time bridge to Pi `v0.83.0-kkl.4`. Future releases in the same KKL patch stream will not require a Sessions source change, at the intentional cost that a fixed Sessions release can resolve a newer Pi patch after refresh.

## Validation

- isolated `mise install --minimum-release-age 0 'github:KnickKnackLabs/pi@v0.83.0-kkl'` resolved `0.83.0-kkl.4`
- isolated Pi `--version` and `--help` passed
- focused `mise run test ps run lint`: 33/33 passed
- full `mise run test`: 335/335 passed
- `readme build --check`
- `git diff --check`

This PR is AI-generated.
